### PR TITLE
Replace `gemini-1.5-pro` defaults with `gemini-2.5-flash` and update tests

### DIFF
--- a/backend/core/governance.py
+++ b/backend/core/governance.py
@@ -48,7 +48,6 @@ class CostGovernor:
     """
 
     PRICING = {
-        "gemini-1.5-pro": {"input": 0.00000125, "output": 0.00000375},
         "gemini-1.5-flash": {"input": 0.000000075, "output": 0.0000003},
         "gemini-2.0-flash": {"input": 0.0000001, "output": 0.0000004},  # Estimated
         "gemini-2.5-flash-lite": {

--- a/backend/tests/test_governance.py
+++ b/backend/tests/test_governance.py
@@ -31,7 +31,7 @@ async def test_cost_governor_tracking():
     mock_cache.incrby = AsyncMock()
 
     governor = CostGovernor(cache=mock_cache)
-    await governor.log_cost("test-tenant", tokens=1000, model="gemini-1.5-pro")
+    await governor.log_cost("test-tenant", tokens=1000, model="gemini-2.5-flash")
 
     mock_cache.incrby.assert_called()
     # Check if key contains tenant and cost type

--- a/backend/tests/test_matrix_models.py
+++ b/backend/tests/test_matrix_models.py
@@ -11,7 +11,7 @@ def test_telemetry_event_valid():
         "timestamp": "2025-12-23T12:00:00Z",
         "event_type": "inference_start",
         "source": "agent_alpha",
-        "payload": {"model": "gemini-1.5-pro", "prompt_len": 150},
+        "payload": {"model": "gemini-2.5-flash", "prompt_len": 150},
         "metadata": {"session_id": "sess_456"},
     }
     event = TelemetryEvent(**data)

--- a/backend/tests/test_production_config.py
+++ b/backend/tests/test_production_config.py
@@ -37,7 +37,7 @@ def test_config_vertex_ai_success():
         "SUPABASE_URL": "https://test.supabase.co",
         "SUPABASE_SERVICE_ROLE_KEY": "test-key",
         "LLM_PROVIDER": "google",
-        "LLM_MODEL": "gemini-1.5-pro",
+        "LLM_MODEL": "gemini-2.5-flash",
         "UPSTASH_REDIS_REST_URL": "https://test.upstash.io",
         "UPSTASH_REDIS_REST_TOKEN": "test-token",
     }

--- a/backend/tests/test_serving.py
+++ b/backend/tests/test_serving.py
@@ -22,7 +22,7 @@ def model_server(mock_matrix):
 async def test_log_inference_metadata(model_server, mock_matrix):
     """Test that model server logs inference metadata."""
     metadata = {
-        "model": "gemini-1.5-pro",
+        "model": "gemini-2.5-flash",
         "tokens_in": 100,
         "tokens_out": 200,
         "latency_ms": 150.5,
@@ -34,4 +34,4 @@ async def test_log_inference_metadata(model_server, mock_matrix):
     event = args[0]
     assert event.event_type == TelemetryEventType.INFERENCE_END
     assert event.source == "agent_1"
-    assert event.payload["model"] == "gemini-1.5-pro"
+    assert event.payload["model"] == "gemini-2.5-flash"

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -26,7 +26,7 @@ def test_telemetry_captures_tokens():
         telemetry = Telemetry()
         telemetry.capture_token_usage(
             agent_name="Strategist",
-            model="gemini-1.5-pro",
+            model="gemini-2.5-flash",
             prompt_tokens=100,
             completion_tokens=50,
         )
@@ -34,4 +34,4 @@ def test_telemetry_captures_tokens():
         mock_log.assert_called_once()
         kwargs = mock_log.call_args[1]
         assert kwargs["extra"]["total_tokens"] == 150
-        assert kwargs["extra"]["model"] == "gemini-1.5-pro"
+        assert kwargs["extra"]["model"] == "gemini-2.5-flash"

--- a/raptorflow-app/src/lib/vertexai.ts
+++ b/raptorflow-app/src/lib/vertexai.ts
@@ -142,7 +142,8 @@ export function getGemini2Flash(): GeminiChatModel | null {
 export function getGemini15Pro(): GeminiChatModel | null {
   if (!_gemini15Pro) {
     const config = getInferenceConfig();
-    const modelName = config.models.ultra || config.models.high || "gemini-1.5-pro";
+    const modelName =
+      config.models.ultra || config.models.high || "gemini-2.5-flash";
     _gemini15Pro = createModel(modelName, 0.5, 8192, config);
   }
   return _gemini15Pro;


### PR DESCRIPTION
### Motivation
- Remove the unsupported `gemini-1.5-pro` model references and align defaults to supported Gemini versions such as `gemini-2.5-flash`.
- Keep frontend and backend model selection consistent so runtime routing and fallbacks use supported models.
- Prevent cost accounting from referencing an unsupported model in pricing data.

### Description
- Removed the `gemini-1.5-pro` pricing entry from `backend/core/governance.py`.
- Updated the frontend default model selector in `raptorflow-app/src/lib/vertexai.ts` to use `gemini-2.5-flash` instead of `gemini-1.5-pro`.
- Updated test fixtures and expectations that referenced `gemini-1.5-pro` to `gemini-2.5-flash` in `backend/tests/test_governance.py`, `backend/tests/test_telemetry.py`, `backend/tests/test_serving.py`, `backend/tests/test_matrix_models.py`, and `backend/tests/test_production_config.py`.
- Committed the changes to keep configuration, runtime selection, and tests consistent.

### Testing
- Updated unit test fixtures in the backend test files listed above so they no longer reference `gemini-1.5-pro`.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c06f635308332a7c03313b11e613b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default AI model configuration across the system
  * Removed outdated model pricing settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->