### PR TITLE
Update example Gemini model identifier in InferenceLogExplorer

### DIFF
--- a/raptorflow-app/src/components/matrix/InferenceLogExplorer.tsx
+++ b/raptorflow-app/src/components/matrix/InferenceLogExplorer.tsx
@@ -20,7 +20,7 @@ export function InferenceLogExplorer() {
       timestamp: new Date().toISOString(),
       event_type: "inference_end",
       source: "MoveGenerator",
-      metadata: { model: "gemini-1.5-ultra", latency_ms: 1240, tokens: 850 }
+      metadata: { model: "gemini-2.5-flash-lite", latency_ms: 1240, tokens: 850 }
     },
     {
       event_id: "ev_2",


### PR DESCRIPTION
### Motivation
- Replace a legacy/invalid Gemini model name in the frontend mock payload so example data matches the actual model routing defaults.
- Keep the example consistent with the project's inference configuration which defaults to `gemini-2.5-flash-lite`.

### Description
- Updated `raptorflow-app/src/components/matrix/InferenceLogExplorer.tsx` to replace `gemini-1.5-ultra` with `gemini-2.5-flash-lite` in the mock `events` payload.
- This change only affects the example/mock data displayed when `useMatrixOverview` does not return events and does not modify runtime logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c06f2692483329a651d364159a12a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the model configuration in the Inference Log Explorer to use an optimized version for the first event's processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->