### PR TITLE
Update Gemini model references to 2.5 Flash / Flash-Lite in docs and plans

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ This is the Python-based creative engine for RaptorFlow, built with FastAPI and 
 ## Tech Stack
 - **Framework:** FastAPI
 - **Orchestration:** LangGraph
-- **Inference:** Vertex AI (Gemini)
+- **Inference:** Vertex AI (Gemini 2.5 Flash/Flash-Lite)
 - **Database:** Supabase (PostgreSQL + pgvector)
 
 ## Setup

--- a/conductor/tracks/cognitive_intelligence_engine_20251223/plan.md
+++ b/conductor/tracks/cognitive_intelligence_engine_20251223/plan.md
@@ -39,7 +39,7 @@
 ## Phase 4: Base Agent Intelligence & Personas (Phases 31-40)
 - [x] Phase 31: Develop the Base Agent Class with integrated Tool calling. [6a59bb0]
 - [x] Phase 32: Design SOTA Prompt Templates for Strategy and Research. [6a59bb0]
-- [x] Phase 33: Implement Vertex AI Primary Inference with Model Fallback (Gemini 1.5 Pro -> Flash). [6a59bb0]
+- [x] Phase 33: Implement Vertex AI Primary Inference with Model Fallback (Gemini 2.5 Flash -> Flash-Lite). [6a59bb0]
 - [x] Phase 34: Define the "Strategist" Persona and Instruction Set. [6a59bb0]
 - [x] Phase 35: Define the "Researcher" Persona and Instruction Set. [6a59bb0]
 - [x] Phase 36: Define the "Creative Director" Persona and Instruction Set. [6a59bb0]

--- a/conductor/tracks/cognitive_intelligence_engine_20251223/spec.md
+++ b/conductor/tracks/cognitive_intelligence_engine_20251223/spec.md
@@ -6,7 +6,7 @@ The Cognitive Intelligence Engine is the industrial-grade "brain" of RaptorFlow.
 ## 2. Core Architectural Pillars (Learnings Integrated)
 
 ### 2.1 MLOps & Scalability (Osipov Principles)
-- **Vertex AI Inference:** Primary serverless inference via Google Vertex AI (Gemini 1.5 Pro/Flash).
+- **Vertex AI Inference:** Primary serverless inference via Google Vertex AI (Gemini 2.5 Flash/Flash-Lite).
 - **Data Pipelines:** Integrated validation and ingestion (Firecrawl/Jina) for high-fidelity research.
 - **Distributed Context:** Handling massive brand contexts through intelligent sharding and vector retrieval.
 - **Monitoring & CI/CD:** Automated testing for agent logic, telemetry for token usage, and latency tracking.

--- a/conductor/tracks/massive_build_20251223/plan.md
+++ b/conductor/tracks/massive_build_20251223/plan.md
@@ -182,7 +182,7 @@
 - [ ] Phase 0179: Write Unit Test: `test_prompt_rendering`
 - [ ] Phase 0180: Implement `backend/core/models.py`: Model Router
 - [ ] Phase 0181: Implement `ModelRouter.get_model(tier='high'|'low')`
-- [ ] Phase 0182: Implement Model Fallback: Gemini 1.5 Pro -> Flash
+- [ ] Phase 0182: Implement Model Fallback: Gemini 2.5 Flash -> Flash-Lite
 - [ ] Phase 0183: Implement Rate Limit Handling for LLM calls
 - [ ] Phase 0184: Implement Token Usage Tracker (Global Request Context)
 - [ ] Phase 0185: Write Unit Test: `test_model_fallback`

--- a/conductor/tracks/muse_skills_20251222/plan.md
+++ b/conductor/tracks/muse_skills_20251222/plan.md
@@ -11,7 +11,7 @@
     - [x] Enable `pgvector` extension and create vector index.
     - [x] Set up LangGraph checkpointing tables (if not handled automatically by helper).
 - [x] **Task 1.3: Vertex AI Client Configuration**
-    - [x] Create `src/lib/vertexai.ts` to initialize Gemini 2.0/1.5 models.
+    - [x] Create `src/lib/vertexai.ts` to initialize Gemini 2.5 Flash/Flash-Lite models.
     - [x] Set up environment variables for GCP Project, Location, and Credentials.
 - [x] **Task: Conductor - User Manual Verification 'Phase 1: Core Infrastructure & Dependencies' (Protocol in workflow.md)** [checkpoint: 0e43b54]
 

--- a/conductor/tracks/muse_skills_20251222/spec.md
+++ b/conductor/tracks/muse_skills_20251222/spec.md
@@ -45,9 +45,8 @@ Inspired by the Agent Skills Open Standard, a "Skill" is a structured package co
 ### 2.2 The Agent Orchestrator (LangGraph)
 -   **Framework:** LangGraph.js (Node.js/TS implementation).
 -   **Models:**
-    -   **Gemini 2.0 Flash (80%):** High-volume tasks (drafting, repurposing).
-    -   **Gemini 1.5 Pro (15%):** Reasoning, critiquing, complex synthesis.
-    -   **Gemini 1.5 Flash (5%):** Simple classification, chat routing.
+    -   **Gemini 2.5 Flash (85%):** High-volume tasks (drafting, repurposing) plus deeper reasoning and critique.
+    -   **Gemini 2.5 Flash-Lite (15%):** Simple classification, chat routing, and lightweight formatting.
     *(Note: "Gemini 3.5" and "3.0" mentioned in prompt are treated as future/placeholder names; we will use the best available Vertex AI equivalents).*
 
 ### 2.3 Memory & RAG (Supabase)
@@ -84,7 +83,7 @@ Inspired by the Agent Skills Open Standard, a "Skill" is a structured package co
 -   [ ] **Custom Skill Working:** I can create a "Haiku Writer" skill in the UI, and the agent successfully uses it.
 -   [ ] **Memory Persistence:** I can refresh the page, and the chat history/context is preserved (LangGraph checkpointing).
 -   [ ] **RAG Integration:** The agent can answer "What is my brand voice?" by citing the "Foundation" documents.
--   [ ] **Vertex AI Connected:** Logs show requests going to Gemini 2.0/1.5 on Vertex AI.
+-   [ ] **Vertex AI Connected:** Logs show requests going to Gemini 2.5 Flash/Flash-Lite on Vertex AI.
 
 ## 5. Technical Constraints
 -   **Stack:** Next.js (App Router), LangChain.js / LangGraph.js, Supabase, Vertex AI.

--- a/conductor/tracks/muse_sota_upgrade_20251222/spec.md
+++ b/conductor/tracks/muse_sota_upgrade_20251222/spec.md
@@ -36,7 +36,7 @@ This track focuses on upgrading the Muse backend from a prototype to a "State-of
 - **Cache:** Upstash Redis
 - **Monitoring:** LangSmith
 - **Payments:** PhonePe Gateway
-- **Models:** Gemini 1.5 Pro/Flash, OpenAI o1/GPT-4o
+- **Models:** Gemini 2.5 Flash/Flash-Lite, OpenAI o1/GPT-4o
 
 ## 4. Acceptance Criteria
 1. Backend can persist state across sessions (Checkpointing).

--- a/conductor/tracks/muse_v2_spine_20251222/spec.md
+++ b/conductor/tracks/muse_v2_spine_20251222/spec.md
@@ -5,7 +5,7 @@ Implementation of the "Shared Agent Platform" using a dedicated Python service (
 
 ## 2. Infrastructure
 - **Brain:** Python 3.11+, FastAPI, LangGraph, LangChain.
-- **Inference:** Vertex AI (Gemini 1.5 Flash for routing, 1.5 Pro for research/quality).
+- **Inference:** Vertex AI (Gemini 2.5 Flash-Lite for routing, 2.5 Flash for research/quality).
 - **Memory:** LangGraph `PostgresSaver` connecting directly to Supabase.
 - **Search:** `pgvector` for RAG and asset retrieval.
 - **Visuals:** Konva-based canvas state (JSON) managed by MemeDirector.

--- a/conductor/tracks/supabase_industrial_20251224/plan.md
+++ b/conductor/tracks/supabase_industrial_20251224/plan.md
@@ -12,7 +12,7 @@
 - [ ] Task: Implement Architect Node (Validation & Contradiction Detection).
 - [ ] Task: Implement Prophet Node (Psychographic ICP Generation).
 - [ ] Task: Implement Strategist Node (90-Day Arc & Move Backlog).
-- [ ] Task: Implement Model Router with 40/60 Gemini 2.0/1.5 Flash split.
+- [ ] Task: Implement Model Router with 40/60 Gemini 2.5 Flash/Flash-Lite split.
 - [ ] Task: Integrate Onboarding Spine with Supabase persistence.
 - [ ] Task: Conductor - User Manual Verification 'Phase 2: AI Onboarding' (Protocol in workflow.md)
 

--- a/conductor/tracks/supabase_industrial_20251224/spec.md
+++ b/conductor/tracks/supabase_industrial_20251224/spec.md
@@ -16,7 +16,7 @@ This track delivers the commercial and multi-tenant backbone of RaptorFlow. It h
     - **Architect:** Foundation validation & contradiction detection.
     - **Prophet:** Psychographic ICP generation (2-3 profiles).
     - **Strategist:** 90-day campaign arc & move backlog drafting.
-- **Model Routing:** Enforce **Gemini 2.0 Flash (40%)** and **Gemini 1.5 Flash (60%)** split.
+- **Model Routing:** Enforce **Gemini 2.5 Flash (40%)** and **Gemini 2.5 Flash-Lite (60%)** split.
 - **Persistence:** AI outputs written to DB before exiting onboarding.
 
 ### 3. Multi-Provider Payment Gateway (Rupees)
@@ -42,7 +42,7 @@ This track delivers the commercial and multi-tenant backbone of RaptorFlow. It h
 
 ### 2. AI Onboarding & Model Fidelity
 - [ ] **End-to-End Success:** A new user completes onboarding, and AI-generated ICPs/Arcs are persisted and visible.
-- [ ] **Model Split:** Backend telemetry confirms the 40/60 distribution between Gemini 2.0 and 1.5 Flash.
+- [ ] **Model Split:** Backend telemetry confirms the 40/60 distribution between Gemini 2.5 Flash and 2.5 Flash-Lite.
 
 ### 3. Payments, Entitlements & Currency
 - [ ] **Currency Consistency:** The currency symbol **₹** and **INR/Rupees** is used in every billing UI, including checkout and invoices.

--- a/conductor/tracks/system_audit_20251224/spec.md
+++ b/conductor/tracks/system_audit_20251224/spec.md
@@ -26,7 +26,7 @@ This track focuses on a comprehensive audit and technical completion of the Rapt
 - **Intelligence-to-Task Mapping:**
     - **High Tier (Gemini 3 Flash Preview):** Complex Campaign creation, strategic positioning, and deep analysis.
     - **Mid Tier (Gemini 2.5/2.0 Flash):** Standard ICP generation, move execution, and Blackbox analysis.
-    - **Base Tier (Gemini 1.5 Flash):** Simple UI helpers, Muse grammar checks, and routine formatting.
+    - **Base Tier (Gemini 2.5 Flash-Lite):** Simple UI helpers, Muse grammar checks, and routine formatting.
 - **Security:** Inference must strictly use Vertex API keys sourced from ENV/Secret Manager. No hardcoding.
 - **Fallback Logic:** Implement a robust fallback system (Cascading or ENV-based) to ensure service continuity if a specific model or key fails.
 

--- a/raptorflow-app/backend.txt
+++ b/raptorflow-app/backend.txt
@@ -42,7 +42,7 @@
 - **Cache**: Redis (session state, hot data, rate limiting)
 - **Object Storage**: S3/GCS (uploaded files, PDFs, images)
 - **AI Framework**: LangGraph, LangChain
-- **LLM Provider**: Google Vertex AI (Gemini 1.5 Pro, Gemini 2.0 Flash)
+- **LLM Provider**: Google Vertex AI (Gemini 2.5 Flash, Gemini 2.5 Flash-Lite)
 - **Embeddings**: Vertex AI `text-embedding-004`
 - **OCR**: Google Cloud Vision API
 - **Auth**: Supabase Auth (JWT)


### PR DESCRIPTION
### Motivation
- Remove outdated references to `Gemini 1.5`/`1.5 Pro`/`1.5 Flash` and align documentation to the current Vertex AI tiers.
- Ensure plan/spec examples (model routing and fallback) match the runtime configuration that uses `Gemini 2.5 Flash`/`Flash-Lite`.
- Keep project documentation consistent so engineering and ops teams use the same model-tier terminology.

### Description
- Replaced `Gemini 1.5` references with `Gemini 2.5 Flash`/`Flash-Lite` across backend and conductor tracks, including `backend/README.md` and `raptorflow-app/backend.txt`.
- Updated multiple conductor track `spec.md` and `plan.md` files to reflect the new model tiers and adjusted routing/fallback examples (e.g., `muse_v2_spine_20251222`, `muse_sota_upgrade_20251222`, `cognitive_intelligence_engine_20251223`, `supabase_industrial_20251224`, `muse_skills_20251222`, `massive_build_20251223`, `system_audit_20251224`).
- Minor text edits to plan phases and acceptance criteria to reference `Gemini 2.5 Flash -> Flash-Lite` fallback and `2.5 Flash / 2.5 Flash-Lite` splits.

### Testing
- This is a documentation-only change and does not modify runtime code paths or configuration.
- No automated tests were run as part of this change because no code was altered.
- Manual verification consisted of searching the repo to ensure `1.5` references were removed or replaced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c06f46f8c83329ebdc30edb68dedb)