### PR TITLE
Migrate PhonePe integration to Standard Checkout v2 (pg-sdk-node)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,10 +34,13 @@ TAVILY_API_KEY=your-tavily-key
 PERPLEXITY_API_KEY=your-perplexity-key
 BRAVE_SEARCH_API_KEY=your-brave-key
 
-# Payment (PhonePe)
-PHONEPE_MERCHANT_ID=your-merchant-id
-PHONEPE_SALT_KEY=your-salt-key
-PHONEPE_SALT_INDEX=1
+# Payment (PhonePe Standard Checkout v2)
+PHONEPE_CLIENT_ID=your-client-id
+PHONEPE_CLIENT_SECRET=your-client-secret
+PHONEPE_CLIENT_VERSION=1
+PHONEPE_ENV=SANDBOX
+PHONEPE_WEBHOOK_USERNAME=your-webhook-username
+PHONEPE_WEBHOOK_PASSWORD=your-webhook-password
 
 # Security
 SECRET_KEY=your-secret-key

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,6 +20,41 @@ This is the Python-based creative engine for RaptorFlow, built with FastAPI and 
    - `INFERENCE_PROVIDER`: "google" (default).
    - `RF_INTERNAL_KEY`: Secret key for API auth.
 
+### PhonePe Standard Checkout v2
+Set the following environment variables for PhonePe checkout:
+- `PHONEPE_CLIENT_ID`: Client ID from PhonePe dashboard.
+- `PHONEPE_CLIENT_SECRET`: Client secret from PhonePe dashboard.
+- `PHONEPE_CLIENT_VERSION`: Client version (e.g., `1`).
+- `PHONEPE_ENV`: `SANDBOX` for UAT or `PRODUCTION` for live payments.
+- `PHONEPE_WEBHOOK_USERNAME`: Webhook username configured in the PhonePe portal.
+- `PHONEPE_WEBHOOK_PASSWORD`: Webhook password configured in the PhonePe portal.
+
+**SANDBOX vs PRODUCTION**
+- Use `PHONEPE_ENV=SANDBOX` for testing against the sandbox environment.
+- Use `PHONEPE_ENV=PRODUCTION` when going live; ensure webhook credentials and redirect URLs are updated.
+
+### How to test locally (PhonePe)
+1. Run the backend:
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+2. Start an ngrok tunnel for the webhook endpoint:
+   ```bash
+   ngrok http 8000
+   ```
+3. Configure the PhonePe webhook URL to:
+   ```
+   https://<ngrok-subdomain>.ngrok.io/v1/payments/webhook
+   ```
+4. Initiate a payment:
+   ```bash
+   curl -X POST "http://localhost:8000/v1/payments/initiate?user_id=test&amount=10.5&transaction_id=order-123&redirect_url=http://localhost:3000/success"
+   ```
+5. Check order status after redirect (optional):
+   ```bash
+   curl "http://localhost:8000/v1/payments/status/order-123"
+   ```
+
 ## Deployment
 Deploy to Google Cloud Run:
 ```bash

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -62,10 +62,13 @@ class Config(BaseSettings):
     PERPLEXITY_API_KEY: Optional[str] = None
     BRAVE_SEARCH_API_KEY: Optional[str] = None
 
-    # Payment Configuration
-    PHONEPE_MERCHANT_ID: Optional[str] = None
-    PHONEPE_SALT_KEY: Optional[str] = None
-    PHONEPE_SALT_INDEX: int = 1
+    # Payment Configuration (PhonePe Standard Checkout v2)
+    PHONEPE_CLIENT_ID: Optional[str] = None
+    PHONEPE_CLIENT_SECRET: Optional[str] = None
+    PHONEPE_CLIENT_VERSION: Optional[int] = None
+    PHONEPE_ENV: Optional[str] = None
+    PHONEPE_WEBHOOK_USERNAME: Optional[str] = None
+    PHONEPE_WEBHOOK_PASSWORD: Optional[str] = None
 
     # Security
     SECRET_KEY: str = "industrial-secret-placeholder"

--- a/backend/phonepe/phonepeBridge.js
+++ b/backend/phonepe/phonepeBridge.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const { StandardCheckoutPayRequest } = require('pg-sdk-node');
+const { getClient } = require('./phonepeClient');
+
+const readInput = () => {
+  const raw = fs.readFileSync(0, 'utf8');
+  if (!raw) {
+    return {};
+  }
+  return JSON.parse(raw);
+};
+
+const writeOutput = (data) => {
+  process.stdout.write(JSON.stringify(data));
+};
+
+const fail = (error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(message);
+  process.exit(1);
+};
+
+const handlePay = async (payload) => {
+  const request = StandardCheckoutPayRequest.builder()
+    .merchantOrderId(payload.merchantOrderId)
+    .amount(payload.amount)
+    .redirectUrl(payload.redirectUrl)
+    .build();
+
+  const response = await getClient().pay(request);
+
+  return {
+    redirectUrl: response.redirectUrl,
+    orderId: response.orderId,
+    state: response.state,
+    expireAt: response.expireAt,
+  };
+};
+
+const handleStatus = async (payload) => {
+  return getClient().getOrderStatus(payload.merchantOrderId);
+};
+
+const handleValidate = async (payload) => {
+  return getClient().validateCallback(
+    payload.username,
+    payload.password,
+    payload.authorization,
+    payload.responseBody
+  );
+};
+
+const main = async () => {
+  const action = process.argv[2];
+  const payload = readInput();
+
+  if (!action) {
+    throw new Error('PhonePe bridge error: missing action.');
+  }
+
+  switch (action) {
+    case 'pay':
+      return handlePay(payload);
+    case 'status':
+      return handleStatus(payload);
+    case 'validate':
+      return handleValidate(payload);
+    default:
+      throw new Error(`PhonePe bridge error: unknown action ${action}.`);
+  }
+};
+
+main()
+  .then(writeOutput)
+  .catch(fail);

--- a/backend/phonepe/phonepeClient.js
+++ b/backend/phonepe/phonepeClient.js
@@ -1,0 +1,60 @@
+const { Env, StandardCheckoutClient } = require('pg-sdk-node');
+
+const REQUIRED_ENV_VARS = [
+  'PHONEPE_CLIENT_ID',
+  'PHONEPE_CLIENT_SECRET',
+  'PHONEPE_CLIENT_VERSION',
+  'PHONEPE_ENV',
+];
+
+const getRequiredEnv = (name) => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`PhonePe config error: missing ${name}.`);
+  }
+  return value;
+};
+
+const resolveEnv = () => {
+  const envValue = getRequiredEnv('PHONEPE_ENV').toUpperCase();
+  if (!(envValue in Env)) {
+    throw new Error(
+      `PhonePe config error: PHONEPE_ENV must be SANDBOX or PRODUCTION (got ${envValue}).`
+    );
+  }
+  return Env[envValue];
+};
+
+const validateEnv = () => {
+  REQUIRED_ENV_VARS.forEach((name) => getRequiredEnv(name));
+  const clientVersion = Number(getRequiredEnv('PHONEPE_CLIENT_VERSION'));
+  if (!Number.isFinite(clientVersion)) {
+    throw new Error('PhonePe config error: PHONEPE_CLIENT_VERSION must be a number.');
+  }
+  resolveEnv();
+  return clientVersion;
+};
+
+let client;
+
+const getClient = () => {
+  if (!client) {
+    const clientId = getRequiredEnv('PHONEPE_CLIENT_ID');
+    const clientSecret = getRequiredEnv('PHONEPE_CLIENT_SECRET');
+    const clientVersion = validateEnv();
+    const env = resolveEnv();
+
+    client = StandardCheckoutClient.getInstance(
+      clientId,
+      clientSecret,
+      clientVersion,
+      env
+    );
+  }
+
+  return client;
+};
+
+module.exports = {
+  getClient,
+};

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -1,64 +1,201 @@
-import base64
-import hashlib
 import json
-from typing import Any, Dict
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional, Protocol
+from uuid import uuid4
 
 from backend.core.config import get_settings
+
+BRIDGE_PATH = Path(__file__).resolve().parents[1] / "phonepe" / "phonepeBridge.js"
+FINAL_ORDER_STATES = {"COMPLETED", "SUCCESS"}
+
+
+class PhonePeCallbackError(RuntimeError):
+    """Raised when PhonePe callback validation fails."""
+
+
+class PhonePeGateway(Protocol):
+    def pay(
+        self, merchant_order_id: str, amount_paise: int, redirect_url: str
+    ) -> Dict[str, Any]:
+        ...
+
+    def get_order_status(self, merchant_order_id: str) -> Dict[str, Any]:
+        ...
+
+    def validate_callback(
+        self,
+        username: str,
+        password: str,
+        authorization: str,
+        response_body: str,
+    ) -> Dict[str, Any]:
+        ...
+
+
+class PhonePeNodeClient:
+    """Bridge that calls the PhonePe Node SDK via a Node.js helper script."""
+
+    def __init__(self, bridge_path: Path = BRIDGE_PATH) -> None:
+        self.bridge_path = bridge_path
+
+    def _run(self, action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        result = subprocess.run(
+            ["node", str(self.bridge_path), action],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if result.returncode != 0:
+            error_message = (result.stderr or result.stdout).strip()
+            raise RuntimeError(f"PhonePe SDK error: {error_message}")
+
+        if not result.stdout:
+            return {}
+
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("PhonePe SDK returned invalid JSON") from exc
+
+    def pay(
+        self, merchant_order_id: str, amount_paise: int, redirect_url: str
+    ) -> Dict[str, Any]:
+        return self._run(
+            "pay",
+            {
+                "merchantOrderId": merchant_order_id,
+                "amount": amount_paise,
+                "redirectUrl": redirect_url,
+            },
+        )
+
+    def get_order_status(self, merchant_order_id: str) -> Dict[str, Any]:
+        return self._run("status", {"merchantOrderId": merchant_order_id})
+
+    def validate_callback(
+        self,
+        username: str,
+        password: str,
+        authorization: str,
+        response_body: str,
+    ) -> Dict[str, Any]:
+        return self._run(
+            "validate",
+            {
+                "username": username,
+                "password": password,
+                "authorization": authorization,
+                "responseBody": response_body,
+            },
+        )
 
 
 class PaymentService:
     """
-    SOTA PhonePe Payment Gateway Integration.
+    PhonePe Standard Checkout v2 integration.
     Handles transaction initiation, status verification, and webhook validation.
     """
 
-    def __init__(self):
+    def __init__(self, gateway: Optional[PhonePeGateway] = None):
         self.settings = get_settings()
-        self.merchant_id = self.settings.PHONEPE_MERCHANT_ID
-        self.salt_key = self.settings.PHONEPE_SALT_KEY
-        self.salt_index = self.settings.PHONEPE_SALT_INDEX
-        self.base_url = "https://api.phonepe.com/apis/hermes"  # Change for UAT/Prod
+        self.gateway = gateway or PhonePeNodeClient()
+        self.order_states: Dict[str, str] = {}
+        self.processed_orders: set[str] = set()
+        self._validated = False
 
-    def _generate_checksum(self, payload_base64: str, endpoint: str) -> str:
-        """Generates X-VERIFY checksum for PhonePe requests."""
-        main_string = payload_base64 + endpoint + self.salt_key
-        sha256 = hashlib.sha256(main_string.encode("utf-8")).hexdigest()
-        return f"{sha256}###{self.salt_index}"
+    def _validate_phonepe_settings(self) -> None:
+        required_fields = [
+            "PHONEPE_CLIENT_ID",
+            "PHONEPE_CLIENT_SECRET",
+            "PHONEPE_CLIENT_VERSION",
+            "PHONEPE_ENV",
+            "PHONEPE_WEBHOOK_USERNAME",
+            "PHONEPE_WEBHOOK_PASSWORD",
+        ]
+
+        missing = [
+            field
+            for field in required_fields
+            if not getattr(self.settings, field, None)
+        ]
+        if missing:
+            raise ValueError(
+                "Missing PhonePe configuration: " + ", ".join(sorted(missing))
+            )
+
+        env_value = str(self.settings.PHONEPE_ENV).upper()
+        if env_value not in {"SANDBOX", "PRODUCTION"}:
+            raise ValueError(
+                "PHONEPE_ENV must be set to SANDBOX or PRODUCTION (case-insensitive)."
+            )
 
     def initiate_payment(
         self, user_id: str, amount: float, transaction_id: str, redirect_url: str
     ) -> Dict[str, Any]:
         """Initiates a payment request with PhonePe."""
-        payload = {
-            "merchantId": self.merchant_id,
-            "merchantTransactionId": transaction_id,
-            "merchantUserId": user_id,
-            "amount": int(amount * 100),  # amount in paise
-            "redirectUrl": redirect_url,
-            "redirectMode": "POST",
-            "callbackUrl": f"{self.settings.NEXT_PUBLIC_API_URL}/v1/payments/webhook",
-            "paymentInstrument": {"type": "PAY_PAGE"},
-        }
+        self._ensure_phonepe_ready()
+        merchant_order_id = transaction_id or str(uuid4())
+        amount_paise = int(round(amount * 100))
 
-        payload_json = json.dumps(payload)
-        payload_base64 = base64.b64encode(payload_json.encode("utf-8")).decode("utf-8")
+        response = self.gateway.pay(merchant_order_id, amount_paise, redirect_url)
 
-        checksum = self._generate_checksum(payload_base64, "/pg/v1/pay")
-
-        # For now, return the payload and headers for the frontend to use
         return {
-            "url": f"{self.base_url}/pg/v1/pay",
-            "payload": payload_base64,
-            "checksum": checksum,
+            "url": response.get("redirectUrl"),
+            "merchantOrderId": merchant_order_id,
         }
 
-    def verify_webhook(self, x_verify: str, response_payload: str) -> bool:
-        """Validates the authenticity of the PhonePe webhook callback."""
-        # Main string = base64 response + salt key
-        main_string = response_payload + self.salt_key
-        sha256 = hashlib.sha256(main_string.encode("utf-8")).hexdigest()
-        calculated_checksum = f"{sha256}###{self.salt_index}"
-        return calculated_checksum == x_verify
+    def get_order_status(self, merchant_order_id: str) -> Dict[str, Any]:
+        """Fetch the order status from PhonePe."""
+        self._ensure_phonepe_ready()
+        return self.gateway.get_order_status(merchant_order_id)
+
+    def _record_order_state(self, merchant_order_id: str, state: Optional[str]) -> bool:
+        if not state:
+            return False
+
+        if self.order_states.get(merchant_order_id) == state:
+            return False
+
+        self.order_states[merchant_order_id] = state
+
+        if state in FINAL_ORDER_STATES:
+            self.processed_orders.add(merchant_order_id)
+
+        return True
+
+    def handle_webhook(self, authorization: str, response_body: str) -> Dict[str, str]:
+        """Validates webhook callback and updates order state idempotently."""
+        self._ensure_phonepe_ready()
+        try:
+            callback = self.gateway.validate_callback(
+                self.settings.PHONEPE_WEBHOOK_USERNAME,
+                self.settings.PHONEPE_WEBHOOK_PASSWORD,
+                authorization,
+                response_body,
+            )
+        except RuntimeError as exc:
+            raise PhonePeCallbackError(str(exc)) from exc
+
+        payload = callback.get("payload") or {}
+        merchant_order_id = payload.get("merchantOrderId")
+        if not merchant_order_id:
+            raise ValueError("Missing merchantOrderId in callback payload.")
+
+        if merchant_order_id in self.processed_orders:
+            return {"status": "already_processed"}
+
+        order_status = self.get_order_status(merchant_order_id)
+        self._record_order_state(merchant_order_id, order_status.get("state"))
+
+        return {"status": "received"}
+
+    def _ensure_phonepe_ready(self) -> None:
+        if not self._validated:
+            self._validate_phonepe_settings()
+            self._validated = True
 
 
 payment_service = PaymentService()

--- a/backend/tests/test_payments_api.py
+++ b/backend/tests/test_payments_api.py
@@ -1,41 +1,59 @@
+import os
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
 
-from backend.main import app
+from backend.services.payment_service import PhonePeCallbackError
+
+os.environ.setdefault("PHONEPE_CLIENT_ID", "client-id")
+os.environ.setdefault("PHONEPE_CLIENT_SECRET", "client-secret")
+os.environ.setdefault("PHONEPE_CLIENT_VERSION", "1")
+os.environ.setdefault("PHONEPE_ENV", "SANDBOX")
+os.environ.setdefault("PHONEPE_WEBHOOK_USERNAME", "webhook-user")
+os.environ.setdefault("PHONEPE_WEBHOOK_PASSWORD", "webhook-pass")
+
+from backend.main import app  # noqa: E402
 
 client = TestClient(app)
 
 
 def test_initiate_payment_api():
     """Test the payment initiation endpoint."""
-    response = client.post(
-        "/v1/payments/initiate",
-        params={
-            "user_id": "user1",
-            "amount": 10.5,
-            "transaction_id": "tx789",
-            "redirect_url": "http://localhost:3000/success",
-        },
-    )
+    with patch("backend.api.v1.payments.payment_service") as service:
+        service.initiate_payment.return_value = {
+            "url": "https://phonepe.com/checkout",
+            "merchantOrderId": "tx789",
+        }
+        response = client.post(
+            "/v1/payments/initiate",
+            params={
+                "user_id": "user1",
+                "amount": 10.5,
+                "transaction_id": "tx789",
+                "redirect_url": "http://localhost:3000/success",
+            },
+        )
     assert response.status_code == 200
     data = response.json()
-    assert "url" in data
-    assert "payload" in data
-    assert "checksum" in data
+    assert data["url"] == "https://phonepe.com/checkout"
+    assert data["merchantOrderId"] == "tx789"
 
 
 def test_webhook_api_missing_header():
-    """Test webhook fails without X-VERIFY header."""
+    """Test webhook fails without Authorization header."""
     response = client.post("/v1/payments/webhook", json={"response": "..."})
     assert response.status_code == 400
-    assert response.json()["detail"] == "Missing X-VERIFY header"
+    assert response.json()["detail"] == "Missing Authorization header"
 
 
-def test_webhook_api_invalid_checksum():
-    """Test webhook fails with invalid checksum."""
-    response = client.post(
-        "/v1/payments/webhook",
-        headers={"X-VERIFY": "invalid"},
-        json={"response": "..."},
-    )
+def test_webhook_api_invalid_callback():
+    """Test webhook fails with invalid callback authentication."""
+    with patch("backend.api.v1.payments.payment_service") as service:
+        service.handle_webhook.side_effect = PhonePeCallbackError("Invalid callback")
+        response = client.post(
+            "/v1/payments/webhook",
+            headers={"Authorization": "invalid"},
+            json={"response": "..."},
+        )
     assert response.status_code == 401
-    assert response.json()["detail"] == "Invalid checksum"
+    assert response.json()["detail"] == "Invalid callback"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,400 @@
+{
+  "name": "raptorflow",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "raptorflow",
+      "dependencies": {
+        "pg-sdk-node": "^2.0.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
+      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/class-transformer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==",
+      "license": "MIT"
+    },
+    "node_modules/class-transformer-validator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/class-transformer-validator/-/class-transformer-validator-0.9.1.tgz",
+      "integrity": "sha512-83/KFCyd6UiiwH6PlQS5y17O5TTx58CawvNI+XdrMs0Ig9QI5kiuzRqGcC/WrEpd1F7i4KIxCwdn6m4B6fl0jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "class-transformer": ">=0.2.3",
+        "class-validator": ">=0.12.0"
+      }
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
+      "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.33",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.33.tgz",
+      "integrity": "sha512-r9kw4OA6oDO4dPXkOrXTkArQAafIKAU71hChInV4FxZ69dxCfbwQGDPzqR5/vea94wU705/3AZroEbSoeVWrQw==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/pg-sdk-node": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pg-sdk-node/-/pg-sdk-node-2.0.2.tgz",
+      "integrity": "sha512-kAMI1zzfO0ojUWytPInTOc+MWHeuHI56tfMLzPDE3R0puYbvzPgwrCFG72AAU76L7jYAttU1XNukuduEo/J6SA==",
+      "license": "ISC",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "axios": "^1.2.1",
+        "axios-retry": "^3.2.0",
+        "class-transformer": "^0.4.0",
+        "class-transformer-validator": "^0.9.1",
+        "class-validator": "^0.14.1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "start": "npm --prefix raptorflow-app run start",
     "lint": "npm --prefix raptorflow-app run lint",
     "test": "npm --prefix raptorflow-app run test"
+  },
+  "dependencies": {
+    "pg-sdk-node": "^2.0.2"
   }
 }

--- a/raptorflow-app/src/tests/system-audit.test.ts
+++ b/raptorflow-app/src/tests/system-audit.test.ts
@@ -57,7 +57,7 @@ describe('System Audit: Frontend-to-Backend Connectivity', () => {
     it('initiates PhonePe payment via the new payments endpoint', async () => {
         (global.fetch as unknown as Mock).mockResolvedValueOnce({
             ok: true,
-            json: async () => ({ url: 'https://phonepe.com/pay', payload: '...', checksum: '...' }),
+            json: async () => ({ url: 'https://phonepe.com/pay' }),
         });
 
         const result = await initiatePayment('user-123', 100, 'tx-001', 'http://localhost:3000');


### PR DESCRIPTION
### Motivation
- Remove legacy PhonePe checksum/X-VERIFY flow and migrate to the Standard Checkout v2 (OAuth style) using the official PhonePe Node SDK for improved security and maintainability.
- Support the required operations: create payment (checkout URL), order status lookup, and webhook handling with SDK-based callback validation.
- Keep existing API surface (`/v1/payments/initiate` and webhook route) while replacing internal checksum code and environment variables.
- Provide clear local testing instructions and update environment examples and docs for SANDBOX/PRODUCTION usage.

### Description
- Replaced checksum logic and salt env vars with a new PhonePe client bridge using the official Node SDK (`pg-sdk-node`) via `backend/phonepe/phonepeClient.js` and `backend/phonepe/phonepeBridge.js`.
- Rewrote `PaymentService` (`backend/services/payment_service.py`) to call the Node bridge for `pay`, `getOrderStatus`, and `validateCallback`, added idempotent webhook processing, and added a `/v1/payments/status/{merchant_order_id}` endpoint.
- Updated configuration to require `PHONEPE_CLIENT_ID`, `PHONEPE_CLIENT_SECRET`, `PHONEPE_CLIENT_VERSION`, `PHONEPE_ENV`, `PHONEPE_WEBHOOK_USERNAME`, and `PHONEPE_WEBHOOK_PASSWORD` in `backend/core/config.py`, `.env.example`, and `backend/README.md` with SANDBOX/PRODUCTION guidance and local testing steps (ngrok example).
- Added and updated unit tests and frontend test expectations to reflect the new response shape and SDK usage: `backend/tests/test_phonepe_integration.py`, `backend/tests/test_payments_api.py`, and `raptorflow-app/src/tests/system-audit.test.ts`.

### Testing
- Added unit tests `backend/tests/test_phonepe_integration.py` that mock the gateway to verify `pay()` is called with the correct `merchantOrderId`, `amount` and `redirectUrl` and to validate idempotent webhook handling. (Tests added but not executed in this rollout.)
- Updated API tests in `backend/tests/test_payments_api.py` to assert the new JSON shape and webhook error paths using mocks. (Tests added but not executed in this rollout.)
- Adjusted frontend system audit test `raptorflow-app/src/tests/system-audit.test.ts` to expect the checkout `url` only. (Test changed locally; not executed here.)
- No automated test suite was run in this environment as part of the change; CI should run the full test matrix after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c9b397f0c83329e3541bd98f8e7c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added payment status endpoint to check PhonePe transaction status
  * Enhanced webhook security with improved authentication

* **Documentation**
  * Added setup and local testing guide for PhonePe integration
  * Added deployment instructions for production environments

* **Chores**
  * Updated payment gateway configuration structure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->