### PR TITLE
Require explicit X-Tenant-ID header by default

### DIFF
--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -14,11 +14,13 @@ async def get_tenant_id(x_tenant_id: Optional[str] = Header(None)) -> UUID:
     from Supabase/Auth0 and extract the tenant_id from claims.
     """
     if not x_tenant_id:
-        # For development/demo, allow fallback or fail
-        # In a real build, this MUST raise 401
         settings = get_settings()
-        fallback = settings.DEFAULT_TENANT_ID
-        return UUID(fallback)
+        if settings.ALLOW_DEFAULT_TENANT_ID_FALLBACK:
+            return UUID(settings.DEFAULT_TENANT_ID)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing X-Tenant-ID header.",
+        )
 
     try:
         return UUID(x_tenant_id)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -74,6 +74,7 @@ class Config(BaseSettings):
     SECRET_KEY: str = "industrial-secret-placeholder"
     RF_INTERNAL_KEY: Optional[str] = None
     DEFAULT_TENANT_ID: str = "00000000-0000-0000-0000-000000000000"
+    ALLOW_DEFAULT_TENANT_ID_FALLBACK: bool = False
     AUTONOMY_LEVEL: str = "medium"
     NEXT_PUBLIC_API_URL: str = "http://localhost:8000"
 


### PR DESCRIPTION
### Motivation
- Prevent silent usage of a placeholder tenant by rejecting requests that lack an explicit `X-Tenant-ID` header to improve security and correctness.
- Preserve a controlled development path by allowing an opt-in fallback flag for local/demo use.

### Description
- Add `ALLOW_DEFAULT_TENANT_ID_FALLBACK: bool = False` to `backend/core/config.py` `Config` so fallback is opt-in.
- Update `backend/core/auth.py` `get_tenant_id` to raise `401 Unauthorized` when `X-Tenant-ID` is missing unless `ALLOW_DEFAULT_TENANT_ID_FALLBACK` is true.
- Maintain existing behavior of returning `400 Bad Request` for invalid UUID formats in `get_tenant_id`.
- Callers that relied on the implicit default tenant must now provide `X-Tenant-ID` or enable the new config flag.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca1c9bab0833284e2de331051296c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added a new configuration flag to control tenant ID header fallback behavior in API authentication. By default, requests missing the required tenant ID header now return authentication errors instead of using fallback values, improving system security. Fallback behavior can be re-enabled through configuration if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->