### PR TITLE
Implement JWT verification and require authenticated user on v1 endpoints

### DIFF
--- a/backend/api/v1/assets.py
+++ b/backend/api/v1/assets.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
-from backend.core.auth import get_tenant_id
+from backend.core.auth import get_current_user, get_tenant_id
 from backend.core.config import get_settings
 from backend.services.storage_service import BrandAssetManager
 
@@ -18,6 +18,7 @@ async def get_brand_asset_manager():
 async def upload_logo(
     file: UploadFile = File(...),
     tenant_id: UUID = Depends(get_tenant_id),
+    _current_user: dict = Depends(get_current_user),
     manager: BrandAssetManager = Depends(get_brand_asset_manager),
 ):
     """

--- a/backend/api/v1/blackbox_learning.py
+++ b/backend/api/v1/blackbox_learning.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from backend.core.auth import get_current_user
 from backend.core.vault import Vault
 from backend.services.blackbox_service import BlackboxService
 
@@ -17,7 +18,9 @@ def get_blackbox_service():
 
 @router.get("/feed", response_model=List[Dict[str, Any]])
 def get_learning_feed(
-    limit: int = 10, service: BlackboxService = Depends(get_blackbox_service)
+    limit: int = 10,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves the latest strategic learnings."""
     return service.get_learning_feed(limit=limit)
@@ -27,6 +30,7 @@ def get_learning_feed(
 def validate_insight(
     learning_id: UUID,
     status_update: Dict[str, str],
+    _current_user: dict = Depends(get_current_user),
     service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Updates the validation status of a strategic insight (HITL)."""
@@ -39,7 +43,9 @@ def validate_insight(
 
 @router.get("/evidence/{learning_id}", response_model=List[Dict[str, Any]])
 def get_evidence_package(
-    learning_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    learning_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves all telemetry traces associated with a specific learning."""
     return service.get_evidence_package(learning_id)
@@ -47,7 +53,9 @@ def get_evidence_package(
 
 @router.post("/cycle/{move_id}")
 async def trigger_learning_cycle(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Triggers the multi-agentic learning cycle for a specific move."""
     result = await service.trigger_learning_cycle(str(move_id))
@@ -56,7 +64,9 @@ async def trigger_learning_cycle(
 
 @router.get("/move/{move_id}", response_model=List[Dict[str, Any]])
 def get_learnings_by_move(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves all strategic learnings associated with a specific move."""
     return service.get_learnings_by_move(move_id)

--- a/backend/api/v1/blackbox_memory.py
+++ b/backend/api/v1/blackbox_memory.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
 
+from backend.core.auth import get_current_user
 from backend.core.vault import Vault
 from backend.services.blackbox_service import BlackboxService
 
@@ -30,7 +31,9 @@ class EvidenceLink(BaseModel):
 
 @router.post("/upsert", status_code=status.HTTP_201_CREATED)
 def upsert_learning(
-    learning: LearningCreate, service: BlackboxService = Depends(get_blackbox_service)
+    learning: LearningCreate,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Generates embedding and persists a new strategic learning."""
     service.upsert_learning_embedding(
@@ -43,7 +46,10 @@ def upsert_learning(
 
 @router.get("/search", response_model=List[Dict])
 def search_memory(
-    query: str, limit: int = 5, service: BlackboxService = Depends(get_blackbox_service)
+    query: str,
+    limit: int = 5,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Searches strategic memory for relevant insights."""
     return service.search_strategic_memory(query=query, limit=limit)
@@ -51,7 +57,9 @@ def search_memory(
 
 @router.post("/link-evidence")
 def link_evidence(
-    link: EvidenceLink, service: BlackboxService = Depends(get_blackbox_service)
+    link: EvidenceLink,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Links existing traces to a learning."""
     service.link_learning_to_evidence(
@@ -64,6 +72,7 @@ def link_evidence(
 def get_planner_context(
     move_type: str,
     limit: int = 5,
+    _current_user: dict = Depends(get_current_user),
     service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves formatted context for the planner agent."""
@@ -75,6 +84,7 @@ def get_planner_context(
 def prune_memory(
     learning_type: str,
     before: datetime,
+    _current_user: dict = Depends(get_current_user),
     service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Removes outdated learnings."""

--- a/backend/api/v1/blackbox_roi.py
+++ b/backend/api/v1/blackbox_roi.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 
+from backend.core.auth import get_current_user
 from backend.core.vault import Vault
 from backend.services.blackbox_service import AttributionModel, BlackboxService
 
@@ -19,6 +20,7 @@ def get_blackbox_service():
 def get_campaign_roi(
     campaign_id: UUID,
     model: AttributionModel = AttributionModel.LINEAR,
+    _current_user: dict = Depends(get_current_user),
     service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Calculates ROI for a specific campaign using the chosen model."""
@@ -26,13 +28,19 @@ def get_campaign_roi(
 
 
 @router.get("/matrix", response_model=List[Dict[str, Any]])
-def get_roi_matrix(service: BlackboxService = Depends(get_blackbox_service)):
+def get_roi_matrix(
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
+):
     """Retrieves ROI and momentum scores for all active campaigns."""
     return service.get_roi_matrix_data()
 
 
 @router.get("/momentum")
-def get_momentum_score(service: BlackboxService = Depends(get_blackbox_service)):
+def get_momentum_score(
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
+):
     """Retrieves the overall system momentum score."""
     score = service.calculate_momentum_score()
     return {"momentum_score": score}
@@ -40,7 +48,9 @@ def get_momentum_score(service: BlackboxService = Depends(get_blackbox_service))
 
 @router.get("/outcomes/campaign/{campaign_id}")
 def get_outcomes_by_campaign(
-    campaign_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    campaign_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves all business outcomes for a specific campaign."""
     return service.get_outcomes_by_campaign(campaign_id)
@@ -48,7 +58,9 @@ def get_outcomes_by_campaign(
 
 @router.get("/outcomes/move/{move_id}")
 def get_outcomes_by_move(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves all business outcomes for a specific move."""
     return service.get_outcomes_by_move(move_id)
@@ -56,7 +68,9 @@ def get_outcomes_by_move(
 
 @router.get("/evidence/{learning_id}")
 def get_evidence_package(
-    learning_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    learning_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves the evidence package (telemetry) for a learning."""
     return service.get_evidence_package(learning_id)

--- a/backend/api/v1/blackbox_specialist.py
+++ b/backend/api/v1/blackbox_specialist.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from backend.core.auth import get_current_user
 from backend.core.vault import Vault
 from backend.services.blackbox_service import BlackboxService
 
@@ -20,6 +21,7 @@ async def run_specialist_agent(
     agent_id: str,
     move_id: UUID,
     state_override: Dict[str, Any] = None,
+    _current_user: dict = Depends(get_current_user),
     service: BlackboxService = Depends(get_blackbox_service),
 ):
     """

--- a/backend/api/v1/blackbox_telemetry.py
+++ b/backend/api/v1/blackbox_telemetry.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 
+from backend.core.auth import get_current_user
 from backend.core.vault import Vault
 from backend.models.blackbox import BlackboxTelemetry
 from backend.services.blackbox_service import BlackboxService
@@ -19,6 +20,7 @@ def get_blackbox_service():
 @router.post("", status_code=status.HTTP_201_CREATED)
 def log_telemetry(
     telemetry: BlackboxTelemetry,
+    _current_user: dict = Depends(get_current_user),
     service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Logs a new agent execution trace."""
@@ -28,7 +30,9 @@ def log_telemetry(
 
 @router.get("/audit/{agent_id}", response_model=List[Dict])
 def get_agent_audit_log(
-    agent_id: str, service: BlackboxService = Depends(get_blackbox_service)
+    agent_id: str,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves recent traces for a specific agent."""
     return service.get_agent_audit_log(agent_id)
@@ -36,7 +40,9 @@ def get_agent_audit_log(
 
 @router.get("/cost/{move_id}")
 def calculate_move_cost(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Calculates total token usage for a move."""
     total_tokens = service.calculate_move_cost(move_id)
@@ -45,7 +51,9 @@ def calculate_move_cost(
 
 @router.get("/move/{move_id}", response_model=List[Dict])
 def get_telemetry_by_move(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: BlackboxService = Depends(get_blackbox_service),
 ):
     """Retrieves all telemetry traces for a specific move."""
     return service.get_telemetry_by_move(str(move_id))

--- a/backend/api/v1/campaigns.py
+++ b/backend/api/v1/campaigns.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
+from backend.core.auth import get_current_user
 from backend.models.campaigns import GanttChart
 from backend.services.campaign_service import CampaignService, get_campaign_service
 
@@ -10,7 +11,9 @@ router = APIRouter(prefix="/v1/campaigns", tags=["campaigns"])
 
 @router.get("/{campaign_id}/gantt", response_model=GanttChart)
 async def get_campaign_gantt(
-    campaign_id: str, service: CampaignService = Depends(get_campaign_service)
+    campaign_id: str,
+    _current_user: dict = Depends(get_current_user),
+    service: CampaignService = Depends(get_campaign_service),
 ):
     """SOTA Endpoint: Retrieves Gantt chart data for a campaign."""
     gantt = await service.get_gantt_chart(campaign_id)
@@ -23,6 +26,7 @@ async def get_campaign_gantt(
 async def generate_campaign_arc(
     campaign_id: str,
     background_tasks: BackgroundTasks,
+    _current_user: dict = Depends(get_current_user),
     service: CampaignService = Depends(get_campaign_service),
 ):
     """SOTA Endpoint: Triggers agentic inference for a 90-day strategic arc in the background."""
@@ -43,7 +47,9 @@ async def generate_campaign_arc(
 
 @router.get("/generate-arc/{campaign_id}/status")
 async def get_campaign_arc_status(
-    campaign_id: str, service: CampaignService = Depends(get_campaign_service)
+    campaign_id: str,
+    _current_user: dict = Depends(get_current_user),
+    service: CampaignService = Depends(get_campaign_service),
 ):
     """SOTA Endpoint: Retrieves status of the agentic inference for a campaign."""
     result = await service.get_arc_generation_status(campaign_id)
@@ -58,6 +64,7 @@ async def get_campaign_arc_status(
 async def apply_campaign_pivot(
     campaign_id: str,
     pivot_data: Dict[str, Any],
+    _current_user: dict = Depends(get_current_user),
     service: CampaignService = Depends(get_campaign_service),
 ):
     """SOTA Endpoint: Applies a strategic pivot to a campaign's 90-day arc."""

--- a/backend/api/v1/foundation.py
+++ b/backend/api/v1/foundation.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from backend.core.auth import get_tenant_id
+from backend.core.auth import get_current_user, get_tenant_id
 from backend.core.vault import Vault
 from backend.models.foundation import BrandKit, FoundationState, Positioning
 from backend.services.foundation_service import FoundationService
@@ -18,6 +18,7 @@ async def get_foundation_service():
 async def save_foundation_state(
     state: FoundationState,
     tenant_id: UUID = Depends(get_tenant_id),
+    _current_user: dict = Depends(get_current_user),
     service: FoundationService = Depends(get_foundation_service),
 ):
     """Saves the comprehensive onboarding state JSON."""
@@ -29,6 +30,7 @@ async def save_foundation_state(
 @router.get("/state", response_model=FoundationState)
 async def get_foundation_state(
     tenant_id: UUID = Depends(get_tenant_id),
+    _current_user: dict = Depends(get_current_user),
     service: FoundationService = Depends(get_foundation_service),
 ):
     """Retrieves the comprehensive onboarding state JSON."""
@@ -40,7 +42,9 @@ async def get_foundation_state(
 
 @router.post("/brand-kit", response_model=BrandKit, status_code=status.HTTP_201_CREATED)
 async def create_brand_kit(
-    brand_kit: BrandKit, service: FoundationService = Depends(get_foundation_service)
+    brand_kit: BrandKit,
+    _current_user: dict = Depends(get_current_user),
+    service: FoundationService = Depends(get_foundation_service),
 ):
     """Creates a new brand kit."""
     return await service.create_brand_kit(brand_kit)
@@ -48,7 +52,9 @@ async def create_brand_kit(
 
 @router.get("/brand-kit/{id}", response_model=BrandKit)
 async def get_brand_kit(
-    id: UUID, service: FoundationService = Depends(get_foundation_service)
+    id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: FoundationService = Depends(get_foundation_service),
 ):
     """Retrieves a brand kit by ID."""
     bk = await service.get_brand_kit(id)
@@ -62,6 +68,7 @@ async def get_brand_kit(
 )
 async def create_positioning(
     positioning: Positioning,
+    _current_user: dict = Depends(get_current_user),
     service: FoundationService = Depends(get_foundation_service),
 ):
     """Creates a new positioning entry."""
@@ -70,7 +77,9 @@ async def create_positioning(
 
 @router.get("/positioning/active/{brand_kit_id}", response_model=Positioning)
 async def get_active_positioning(
-    brand_kit_id: UUID, service: FoundationService = Depends(get_foundation_service)
+    brand_kit_id: UUID,
+    _current_user: dict = Depends(get_current_user),
+    service: FoundationService = Depends(get_foundation_service),
 ):
     """Retrieves the active positioning for a brand kit."""
     pos = await service.get_active_positioning(brand_kit_id)

--- a/backend/api/v1/matrix.py
+++ b/backend/api/v1/matrix.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from backend.core.auth import get_current_user
 from backend.services.cost_governor import CostGovernor
 from backend.services.drift_detection import DriftDetectionService
 from backend.services.matrix_service import MatrixService
@@ -17,7 +18,9 @@ def get_matrix_service():
 
 @router.get("/overview")
 async def get_overview(
-    workspace_id: str, service: MatrixService = Depends(get_matrix_service)
+    workspace_id: str,
+    _current_user: dict = Depends(get_current_user),
+    service: MatrixService = Depends(get_matrix_service),
 ):
     """Retrieves the aggregated health dashboard for the entire ecosystem."""
     return await service.get_aggregated_overview(workspace_id)
@@ -25,7 +28,9 @@ async def get_overview(
 
 @router.post("/kill-switch")
 async def engage_kill_switch(
-    reason: str = "Manual Trigger", service: MatrixService = Depends(get_matrix_service)
+    reason: str = "Manual Trigger",
+    _current_user: dict = Depends(get_current_user),
+    service: MatrixService = Depends(get_matrix_service),
 ):
     """
     SOTA Global Kill-Switch.
@@ -48,6 +53,7 @@ async def engage_kill_switch(
 async def execute_matrix_skill(
     skill_name: str,
     params: Dict[str, Any],
+    _current_user: dict = Depends(get_current_user),
     service: MatrixService = Depends(get_matrix_service),
 ):
     """
@@ -62,7 +68,7 @@ async def execute_matrix_skill(
 
 
 @router.get("/mlops/drift")
-async def get_drift_report():
+async def get_drift_report(_current_user: dict = Depends(get_current_user)):
     """
     Retrieves the latest statistical data drift report.
     """
@@ -72,7 +78,9 @@ async def get_drift_report():
 
 
 @router.get("/governance/burn")
-async def get_financial_burn(workspace_id: str):
+async def get_financial_burn(
+    workspace_id: str, _current_user: dict = Depends(get_current_user)
+):
     """
     Retrieves real-time financial burn data (Token costs).
     """

--- a/backend/api/v1/moves.py
+++ b/backend/api/v1/moves.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
+from backend.core.auth import get_current_user
 from backend.services.move_service import MoveService, get_move_service
 
 router = APIRouter(prefix="/v1/moves", tags=["moves"])
@@ -11,6 +12,7 @@ router = APIRouter(prefix="/v1/moves", tags=["moves"])
 async def generate_weekly_moves(
     campaign_id: str,
     background_tasks: BackgroundTasks,
+    _current_user: dict = Depends(get_current_user),
     service: MoveService = Depends(get_move_service),
 ):
     """SOTA Endpoint: Triggers agentic move generation for a campaign."""
@@ -29,7 +31,9 @@ async def generate_weekly_moves(
 
 @router.get("/generate-weekly/{campaign_id}/status")
 async def get_moves_status(
-    campaign_id: str, service: MoveService = Depends(get_move_service)
+    campaign_id: str,
+    _current_user: dict = Depends(get_current_user),
+    service: MoveService = Depends(get_move_service),
 ):
     """SOTA Endpoint: Retrieves status of move generation."""
     result = await service.get_moves_generation_status(campaign_id)
@@ -42,6 +46,7 @@ async def get_moves_status(
 async def update_move_status(
     move_id: str,
     status_update: Dict[str, Any],
+    _current_user: dict = Depends(get_current_user),
     service: MoveService = Depends(get_move_service),
 ):
     """SOTA Endpoint: Updates the status and result of a specific move."""

--- a/backend/api/v1/muse.py
+++ b/backend/api/v1/muse.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.core.auth import get_tenant_id
+from backend.core.auth import get_current_user, get_tenant_id
 from backend.graphs.muse_create import build_muse_spine
 from backend.models.cognitive import CognitiveStatus
 
@@ -26,7 +26,9 @@ class MuseResponse(BaseModel):
 
 @router.post("/create", response_model=MuseResponse)
 async def create_muse_asset(
-    request: MuseCreateRequest, tenant_id: UUID = Depends(get_tenant_id)
+    request: MuseCreateRequest,
+    tenant_id: UUID = Depends(get_tenant_id),
+    _current_user: dict = Depends(get_current_user),
 ):
     """
     SOTA Endpoint: Triggers the full Muse Cognitive Spine.

--- a/backend/api/v1/payments.py
+++ b/backend/api/v1/payments.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from backend.core.auth import get_current_user
 from backend.services.payment_service import PhonePeCallbackError, payment_service
 
 router = APIRouter(prefix="/v1/payments", tags=["Payments"])
@@ -7,7 +8,11 @@ router = APIRouter(prefix="/v1/payments", tags=["Payments"])
 
 @router.post("/initiate")
 async def initiate_payment(
-    user_id: str, amount: float, transaction_id: str, redirect_url: str
+    user_id: str,
+    amount: float,
+    transaction_id: str,
+    redirect_url: str,
+    _current_user: dict = Depends(get_current_user),
 ):
     """Initiates a PhonePe payment session."""
     return payment_service.initiate_payment(
@@ -16,7 +21,9 @@ async def initiate_payment(
 
 
 @router.get("/status/{merchant_order_id}")
-async def get_payment_status(merchant_order_id: str):
+async def get_payment_status(
+    merchant_order_id: str, _current_user: dict = Depends(get_current_user)
+):
     """Fetch the latest order status from PhonePe."""
     return payment_service.get_order_status(merchant_order_id)
 

--- a/backend/api/v1/radar.py
+++ b/backend/api/v1/radar.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from backend.core.auth import get_tenant_id
+from backend.core.auth import get_current_user, get_tenant_id
 from backend.core.vault import Vault
 from backend.services.radar_service import RadarService
 
@@ -19,6 +19,7 @@ async def get_radar_service():
 async def scan_recon(
     icp_id: str,
     tenant_id: UUID = Depends(get_tenant_id),
+    _current_user: dict = Depends(get_current_user),
     service: RadarService = Depends(get_radar_service),
 ):
     """Performs a competitive signals scan."""
@@ -32,6 +33,7 @@ async def scan_recon(
 async def scan_dossier(
     icp_id: str,
     tenant_id: UUID = Depends(get_tenant_id),
+    _current_user: dict = Depends(get_current_user),
     service: RadarService = Depends(get_radar_service),
 ):
     """Generates deep competitor dossiers."""

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,7 +1,9 @@
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
+import httpx
 from fastapi import Header, HTTPException, status
+from jose import JWTError, ExpiredSignatureError, jwk, jwt
 
 from backend.core.config import get_settings
 
@@ -28,15 +30,122 @@ async def get_tenant_id(x_tenant_id: Optional[str] = Header(None)) -> UUID:
         )
 
 
-async def get_current_user(authorization: Optional[str] = Header(None)):
-    """
-    Verifies the JWT and returns the user object.
-    Placeholder for Supabase Auth integration.
-    """
+async def _fetch_jwks(jwks_url: str) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await client.get(jwks_url)
+        response.raise_for_status()
+        return response.json()
+
+
+def _get_bearer_token(authorization: Optional[str]) -> str:
     if not authorization:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing Authorization header.",
         )
-    # TODO: Verify JWT with Supabase secret
-    return {"id": "user_id", "role": "founder"}
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization header must be a Bearer token.",
+        )
+    return parts[1]
+
+
+async def _decode_with_jwks(
+    token: str,
+    jwks_url: str,
+    issuer: Optional[str],
+    audience: Optional[str],
+    algorithms: list[str],
+) -> dict[str, Any]:
+    jwks = await _fetch_jwks(jwks_url)
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid")
+    if not kid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="JWT header missing kid.",
+        )
+    key_data = next(
+        (key for key in jwks.get("keys", []) if key.get("kid") == kid), None
+    )
+    if not key_data:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="JWT signing key not found.",
+        )
+    public_key = jwk.construct(key_data)
+    return jwt.decode(
+        token,
+        public_key,
+        algorithms=algorithms,
+        issuer=issuer,
+        audience=audience,
+    )
+
+
+async def get_current_user(authorization: Optional[str] = Header(None)) -> dict[str, Any]:
+    """
+    Verifies the JWT and returns the user object.
+    Supports Supabase/Auth0 via JWKS or shared secret.
+    """
+    token = _get_bearer_token(authorization)
+    settings = get_settings()
+
+    issuer = settings.AUTH_ISSUER or (
+        f"{settings.SUPABASE_URL.rstrip('/')}/auth/v1"
+        if settings.SUPABASE_URL
+        else None
+    )
+    audience = settings.AUTH_AUDIENCE or "authenticated"
+    algorithms = [
+        alg.strip()
+        for alg in settings.AUTH_JWT_ALGORITHMS.split(",")
+        if alg.strip()
+    ]
+
+    try:
+        if settings.AUTH_JWT_SECRET or settings.SUPABASE_JWT_SECRET:
+            secret = settings.AUTH_JWT_SECRET or settings.SUPABASE_JWT_SECRET
+            payload = jwt.decode(
+                token,
+                secret,
+                algorithms=algorithms,
+                issuer=issuer,
+                audience=audience,
+            )
+        else:
+            jwks_url = settings.AUTH_JWKS_URL or (
+                f"{settings.SUPABASE_URL.rstrip('/')}/auth/v1/.well-known/jwks.json"
+                if settings.SUPABASE_URL
+                else None
+            )
+            if not jwks_url:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="JWT verification is not configured.",
+                )
+            payload = await _decode_with_jwks(
+                token=token,
+                jwks_url=jwks_url,
+                issuer=issuer,
+                audience=audience,
+                algorithms=algorithms,
+            )
+    except ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired."
+        )
+    except (JWTError, httpx.HTTPError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid token: {exc}",
+        )
+
+    return {
+        "id": payload.get("sub"),
+        "email": payload.get("email"),
+        "role": payload.get("role"),
+        "claims": payload,
+    }

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -30,6 +30,7 @@ class Config(BaseSettings):
     # Supabase Configuration
     SUPABASE_URL: str = "https://placeholder.supabase.co"
     SUPABASE_SERVICE_ROLE_KEY: str = "placeholder-key"
+    SUPABASE_JWT_SECRET: Optional[str] = None
     DATABASE_URL: Optional[str] = None
 
     # Upstash Configuration
@@ -76,6 +77,11 @@ class Config(BaseSettings):
     DEFAULT_TENANT_ID: str = "00000000-0000-0000-0000-000000000000"
     AUTONOMY_LEVEL: str = "medium"
     NEXT_PUBLIC_API_URL: str = "http://localhost:8000"
+    AUTH_JWKS_URL: Optional[str] = None
+    AUTH_ISSUER: Optional[str] = None
+    AUTH_AUDIENCE: Optional[str] = None
+    AUTH_JWT_SECRET: Optional[str] = None
+    AUTH_JWT_ALGORITHMS: str = "RS256,HS256"
 
     # Monitoring
     LANGCHAIN_TRACING_V2: str = "false"
@@ -139,6 +145,7 @@ def get_settings() -> Config:
     sensitive_keys = [
         "SUPABASE_URL",
         "SUPABASE_SERVICE_ROLE_KEY",
+        "SUPABASE_JWT_SECRET",
         "DATABASE_URL",
         "UPSTASH_REDIS_REST_URL",
         "UPSTASH_REDIS_REST_TOKEN",
@@ -157,6 +164,11 @@ def get_settings() -> Config:
         "BRAVE_SEARCH_API_KEY",
         "SECRET_KEY",
         "RF_INTERNAL_KEY",
+        "AUTH_JWKS_URL",
+        "AUTH_ISSUER",
+        "AUTH_AUDIENCE",
+        "AUTH_JWT_SECRET",
+        "AUTH_JWT_ALGORITHMS",
         "LANGCHAIN_API_KEY",
     ]
 


### PR DESCRIPTION
### Motivation

- Replace the placeholder auth stub with real JWT verification to secure API endpoints.
- Validate token signature, issuer, audience, and expiry and return a real user object or raise `401` on failure.
- Support both JWKS-based verification (Auth0/Supabase) and shared-secret HMAC verification for flexibility.
- Ensure endpoints that require identity enforce authentication via `Depends(get_current_user)`.

### Description

- Implemented JWKS fetching and JWT decoding/validation in `backend/core/auth.py`, including helpers `_fetch_jwks`, `_decode_with_jwks`, and `_get_bearer_token`, and return a user dict with `id`, `email`, `role`, and `claims`.
- Added configuration settings in `backend/core/config.py` (`AUTH_JWKS_URL`, `AUTH_ISSUER`, `AUTH_AUDIENCE`, `AUTH_JWT_SECRET`, `AUTH_JWT_ALGORITHMS`, and `SUPABASE_JWT_SECRET`) and wired them into settings loading.
- Replaced the placeholder behavior by using `get_current_user` across protected v1 endpoints (e.g. `assets`, `foundation`, `muse`, `radar`, `matrix`, `moves`, `campaigns`, `blackbox_*`, `payments`, etc.) via `Depends(get_current_user)`.
- Added explicit error handling for expired tokens and upstream HTTP/JWT errors that map to `401 Unauthorized` responses.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca1cb310883328f8aef0a70ce843e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Enhancements**
  * Strengthened authentication across API endpoints to ensure all user interactions are properly validated.
  * Enhanced JWT token verification with improved validation mechanisms and issuer/audience checks for more robust security.
  * Extended authentication requirements across learning, memory, ROI, campaign, and specialist features to protect user data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->