### PR TITLE
Add tenant scoping to Blackbox telemetry and outcomes

### DIFF
--- a/backend/api/v1/blackbox_learning.py
+++ b/backend/api/v1/blackbox_learning.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from backend.core.auth import get_tenant_id
 from backend.core.vault import Vault
 from backend.services.blackbox_service import BlackboxService
 
@@ -47,10 +48,12 @@ def get_evidence_package(
 
 @router.post("/cycle/{move_id}")
 async def trigger_learning_cycle(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Triggers the multi-agentic learning cycle for a specific move."""
-    result = await service.trigger_learning_cycle(str(move_id))
+    result = await service.trigger_learning_cycle(str(move_id), tenant_id)
     return result
 
 

--- a/backend/api/v1/blackbox_roi.py
+++ b/backend/api/v1/blackbox_roi.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 
+from backend.core.auth import get_tenant_id
 from backend.core.vault import Vault
 from backend.services.blackbox_service import AttributionModel, BlackboxService
 
@@ -20,15 +21,19 @@ def get_campaign_roi(
     campaign_id: UUID,
     model: AttributionModel = AttributionModel.LINEAR,
     service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Calculates ROI for a specific campaign using the chosen model."""
-    return service.compute_roi(campaign_id=campaign_id, model=model)
+    return service.compute_roi(campaign_id=campaign_id, tenant_id=tenant_id, model=model)
 
 
 @router.get("/matrix", response_model=List[Dict[str, Any]])
-def get_roi_matrix(service: BlackboxService = Depends(get_blackbox_service)):
+def get_roi_matrix(
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
+):
     """Retrieves ROI and momentum scores for all active campaigns."""
-    return service.get_roi_matrix_data()
+    return service.get_roi_matrix_data(tenant_id)
 
 
 @router.get("/momentum")
@@ -40,18 +45,22 @@ def get_momentum_score(service: BlackboxService = Depends(get_blackbox_service))
 
 @router.get("/outcomes/campaign/{campaign_id}")
 def get_outcomes_by_campaign(
-    campaign_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    campaign_id: UUID,
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Retrieves all business outcomes for a specific campaign."""
-    return service.get_outcomes_by_campaign(campaign_id)
+    return service.get_outcomes_by_campaign(campaign_id, tenant_id)
 
 
 @router.get("/outcomes/move/{move_id}")
 def get_outcomes_by_move(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Retrieves all business outcomes for a specific move."""
-    return service.get_outcomes_by_move(move_id)
+    return service.get_outcomes_by_move(move_id, tenant_id)
 
 
 @router.get("/evidence/{learning_id}")

--- a/backend/api/v1/blackbox_specialist.py
+++ b/backend/api/v1/blackbox_specialist.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from backend.core.auth import get_tenant_id
 from backend.core.vault import Vault
 from backend.services.blackbox_service import BlackboxService
 
@@ -21,6 +22,7 @@ async def run_specialist_agent(
     move_id: UUID,
     state_override: Dict[str, Any] = None,
     service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """
     SOTA Endpoint: Directly triggers a specific specialist agent.
@@ -53,8 +55,8 @@ async def run_specialist_agent(
     agent = agent_cls()
 
     # Gather context (standard state)
-    traces = service.get_telemetry_by_move(str(move_id))
-    outcomes = service.get_outcomes_by_move(move_id)
+    traces = service.get_telemetry_by_move(str(move_id), tenant_id)
+    outcomes = service.get_outcomes_by_move(move_id, tenant_id)
 
     initial_state = {
         "move_id": str(move_id),

--- a/backend/api/v1/blackbox_telemetry.py
+++ b/backend/api/v1/blackbox_telemetry.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 
+from backend.core.auth import get_tenant_id
 from backend.core.vault import Vault
 from backend.models.blackbox import BlackboxTelemetry
 from backend.services.blackbox_service import BlackboxService
@@ -20,32 +21,40 @@ def get_blackbox_service():
 def log_telemetry(
     telemetry: BlackboxTelemetry,
     service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Logs a new agent execution trace."""
+    telemetry = telemetry.model_copy(update={"tenant_id": tenant_id})
     service.log_telemetry(telemetry)
     return {"status": "logged"}
 
 
 @router.get("/audit/{agent_id}", response_model=List[Dict])
 def get_agent_audit_log(
-    agent_id: str, service: BlackboxService = Depends(get_blackbox_service)
+    agent_id: str,
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Retrieves recent traces for a specific agent."""
-    return service.get_agent_audit_log(agent_id)
+    return service.get_agent_audit_log(agent_id, tenant_id)
 
 
 @router.get("/cost/{move_id}")
 def calculate_move_cost(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Calculates total token usage for a move."""
-    total_tokens = service.calculate_move_cost(move_id)
+    total_tokens = service.calculate_move_cost(move_id, tenant_id)
     return {"move_id": move_id, "total_tokens": total_tokens}
 
 
 @router.get("/move/{move_id}", response_model=List[Dict])
 def get_telemetry_by_move(
-    move_id: UUID, service: BlackboxService = Depends(get_blackbox_service)
+    move_id: UUID,
+    service: BlackboxService = Depends(get_blackbox_service),
+    tenant_id: UUID = Depends(get_tenant_id),
 ):
     """Retrieves all telemetry traces for a specific move."""
-    return service.get_telemetry_by_move(str(move_id))
+    return service.get_telemetry_by_move(str(move_id), tenant_id)

--- a/backend/graphs/blackbox_analysis.py
+++ b/backend/graphs/blackbox_analysis.py
@@ -1,5 +1,6 @@
 import operator
 from typing import Annotated, Dict, List, TypedDict
+from uuid import UUID
 
 
 class AnalysisState(TypedDict):
@@ -9,6 +10,7 @@ class AnalysisState(TypedDict):
     """
 
     move_id: str
+    tenant_id: str
 
     # Annotated with operator.add to allow multiple nodes to append findings/data
     telemetry_data: Annotated[List[Dict], operator.add]
@@ -34,7 +36,9 @@ def ingest_telemetry_node(state: AnalysisState) -> Dict:
     Node: Ingests all telemetry associated with the move_id.
     """
     service = get_blackbox_service()
-    traces = service.get_telemetry_by_move(state["move_id"])
+    traces = service.get_telemetry_by_move(
+        state["move_id"], UUID(state["tenant_id"])
+    )
     return {"telemetry_data": traces, "status": ["ingested"]}
 
 

--- a/backend/models/blackbox.py
+++ b/backend/models/blackbox.py
@@ -9,6 +9,7 @@ class BlackboxTelemetry(BaseModel):
     """Pydantic model for Blackbox Telemetry (Execution Traces)."""
 
     id: UUID = Field(default_factory=uuid4)
+    tenant_id: UUID
     move_id: UUID
     agent_id: str
     trace: Dict[str, Any] = Field(default_factory=dict)
@@ -23,6 +24,7 @@ class BlackboxOutcome(BaseModel):
     """Pydantic model for Blackbox Outcomes (Conversion/Engagement)."""
 
     id: UUID = Field(default_factory=uuid4)
+    tenant_id: UUID
     campaign_id: Optional[UUID] = None
     move_id: Optional[UUID] = None
     source: str

--- a/backend/services/outcome_ingestion_service.py
+++ b/backend/services/outcome_ingestion_service.py
@@ -20,6 +20,7 @@ class OutcomeIngestionService:
         Parses external payload into a BlackboxOutcome and persists it.
         Example Payload: {"source": "linkedin_ads", "conversion_value": 150.0, "confidence": 0.9}
         """
+        tenant_id = payload.get("tenant_id")
         source = payload.get("source", "unknown")
         # Support various field names from different providers
         value = float(payload.get("conversion_value", payload.get("value", 0.0)))
@@ -30,6 +31,7 @@ class OutcomeIngestionService:
         move_id = payload.get("move_id")
 
         outcome = BlackboxOutcome(
+            tenant_id=tenant_id,
             source=source,
             value=value,
             confidence=confidence,

--- a/backend/tests/test_blackbox_api.py
+++ b/backend/tests/test_blackbox_api.py
@@ -14,7 +14,9 @@ def test_log_telemetry_endpoint():
     mock_service = MagicMock()
     app.dependency_overrides[get_blackbox_service] = lambda: mock_service
 
+    tenant_id = uuid4()
     payload = {
+        "tenant_id": str(tenant_id),
         "move_id": str(uuid4()),
         "agent_id": "api-test-agent",
         "trace": {"api": "test"},
@@ -22,7 +24,11 @@ def test_log_telemetry_endpoint():
         "latency": 0.2,
     }
 
-    response = client.post("/v1/blackbox/telemetry", json=payload)
+    response = client.post(
+        "/v1/blackbox/telemetry",
+        json=payload,
+        headers={"X-Tenant-ID": str(tenant_id)},
+    )
     assert response.status_code == 201
     mock_service.log_telemetry.assert_called_once()
 
@@ -34,10 +40,14 @@ def test_get_agent_audit_log_endpoint():
     mock_service.get_agent_audit_log.return_value = [{"id": "test"}]
     app.dependency_overrides[get_blackbox_service] = lambda: mock_service
 
-    response = client.get("/v1/blackbox/telemetry/audit/test-agent")
+    tenant_id = uuid4()
+    response = client.get(
+        "/v1/blackbox/telemetry/audit/test-agent",
+        headers={"X-Tenant-ID": str(tenant_id)},
+    )
     assert response.status_code == 200
     assert len(response.json()) == 1
-    mock_service.get_agent_audit_log.assert_called_with("test-agent")
+    mock_service.get_agent_audit_log.assert_called_with("test-agent", tenant_id)
 
     app.dependency_overrides.clear()
 
@@ -48,9 +58,13 @@ def test_calculate_move_cost_endpoint():
     app.dependency_overrides[get_blackbox_service] = lambda: mock_service
 
     move_id = uuid4()
-    response = client.get(f"/v1/blackbox/telemetry/cost/{move_id}")
+    tenant_id = uuid4()
+    response = client.get(
+        f"/v1/blackbox/telemetry/cost/{move_id}",
+        headers={"X-Tenant-ID": str(tenant_id)},
+    )
     assert response.status_code == 200
     assert response.json()["total_tokens"] == 500
-    mock_service.calculate_move_cost.assert_called_with(move_id)
+    mock_service.calculate_move_cost.assert_called_with(move_id, tenant_id)
 
     app.dependency_overrides.clear()

--- a/backend/tests/test_blackbox_learning_api.py
+++ b/backend/tests/test_blackbox_learning_api.py
@@ -54,7 +54,11 @@ async def test_trigger_learning_cycle(mock_service):
     )
 
     move_id = str(uuid4())
-    response = client.post(f"/v1/blackbox/learning/cycle/{move_id}")
+    tenant_id = uuid4()
+    response = client.post(
+        f"/v1/blackbox/learning/cycle/{move_id}",
+        headers={"X-Tenant-ID": str(tenant_id)},
+    )
     assert response.status_code == 200
     assert response.json() == {"status": "cycle_complete"}
-    mock_service.trigger_learning_cycle.assert_called_once_with(move_id)
+    mock_service.trigger_learning_cycle.assert_called_once_with(move_id, tenant_id)

--- a/backend/tests/test_blackbox_models.py
+++ b/backend/tests/test_blackbox_models.py
@@ -8,6 +8,7 @@ from backend.models.blackbox import BlackboxLearning, BlackboxOutcome, BlackboxT
 
 def test_blackbox_telemetry_schema():
     data = {
+        "tenant_id": uuid4(),
         "move_id": uuid4(),
         "agent_id": "test-agent-v1",
         "trace": {"steps": ["thought", "action"]},
@@ -25,6 +26,7 @@ def test_blackbox_outcome_schema():
         pytest.fail("BlackboxOutcome model not imported")
 
     data = {
+        "tenant_id": uuid4(),
         "source": "conversion_pixel",
         "value": 1500.0,
         "confidence": 0.95,

--- a/backend/tests/test_e2e_blackbox_flywheel.py
+++ b/backend/tests/test_e2e_blackbox_flywheel.py
@@ -28,9 +28,11 @@ class TestBlackboxE2E(unittest.TestCase):
         """
         move_id = uuid4()
         campaign_id = uuid4()
+        tenant_id = uuid4()
 
         # 1. Simulate Move Execution & Telemetry Logging
         telemetry = BlackboxTelemetry(
+            tenant_id=tenant_id,
             move_id=move_id,
             agent_id="research_agent",
             trace={"step": "market_scan", "found": ["link1", "link2"]},
@@ -44,6 +46,7 @@ class TestBlackboxE2E(unittest.TestCase):
 
         # 2. Simulate Outcome Attribution
         outcome = BlackboxOutcome(
+            tenant_id=tenant_id,
             campaign_id=campaign_id,
             move_id=move_id,
             source="linkedin",
@@ -74,7 +77,7 @@ class TestBlackboxE2E(unittest.TestCase):
         mock_inference.get_embeddings.return_value = mock_embed
 
         # Trigger Cycle
-        result = asyncio.run(self.service.trigger_learning_cycle(str(move_id)))
+        result = asyncio.run(self.service.trigger_learning_cycle(str(move_id), tenant_id))
 
         # 4. Verify Results
         self.assertEqual(result["findings_count"], 1)

--- a/backend/tests/test_learning_flywheel_output.py
+++ b/backend/tests/test_learning_flywheel_output.py
@@ -16,6 +16,7 @@ async def test_learning_flywheel_output():
 
     service = BlackboxService(mock_vault)
     move_id = str(uuid4())
+    tenant_id = uuid4()
 
     # 1. Mock the LangGraph run
     mock_final_state = {
@@ -34,7 +35,7 @@ async def test_learning_flywheel_output():
         service.upsert_learning_embedding = MagicMock()
 
         # 3. Trigger cycle
-        result = await service.trigger_learning_cycle(move_id)
+        result = await service.trigger_learning_cycle(move_id, tenant_id)
 
         # 4. Assertions
         assert result["status"] == "cycle_complete"

--- a/backend/tests/test_outcome_ingestion.py
+++ b/backend/tests/test_outcome_ingestion.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 from backend.models.blackbox import BlackboxOutcome
 from backend.services.outcome_ingestion_service import OutcomeIngestionService
@@ -16,7 +17,12 @@ def test_outcome_ingestion_service_webhook():
 
     service = OutcomeIngestionService(vault=mock_vault)
 
-    payload = {"source": "stripe", "conversion_value": 299.0, "confidence": 1.0}
+    payload = {
+        "tenant_id": str(uuid4()),
+        "source": "stripe",
+        "conversion_value": 299.0,
+        "confidence": 1.0,
+    }
 
     outcome = service.ingest_webhook_payload(payload)
 


### PR DESCRIPTION
### Motivation

- Enforce tenant isolation for telemetry and outcome data so queries and analytics operate only on a tenant's data.
- Persist `tenant_id` with telemetry/outcomes to enable multi-tenant ROI, analysis, and evidence packaging.

### Description

- Add `tenant_id: UUID` to the `BlackboxTelemetry` and `BlackboxOutcome` models in `backend/models/blackbox.py` and persist it when writing to Supabase/BigQuery.
- Scope service queries by accepting and applying `tenant_id` in `BlackboxService` methods such as `get_agent_audit_log`, `get_telemetry_by_move`, `calculate_move_cost`, `compute_roi`, `get_outcomes_by_campaign`, `get_outcomes_by_move`, `calculate_attribution_confidence`, `get_roi_matrix_data`, `trigger_learning_cycle`, and `generate_pivot_recommendation`, adding `.eq("tenant_id", str(tenant_id))` where appropriate.
- Update API layers to extract tenant context via the `get_tenant_id` dependency and pass `tenant_id` into service calls (files updated include `backend/api/v1/blackbox_telemetry.py`, `blackbox_roi.py`, `blackbox_learning.py`, and `blackbox_specialist.py`).
- Propagate tenant context through helper code by updating `trace_agent` to require/propagate `tenant_id`, `OutcomeIngestionService.ingest_webhook_payload` to read and persist `tenant_id`, and the analysis graph (`backend/graphs/blackbox_analysis.py`) to include `tenant_id` in ingestion state.

### Testing

- Unit and integration tests were updated to include `tenant_id` in model fixtures and request headers (notable files changed under `backend/tests/` include `test_blackbox_service.py`, `test_blackbox_api.py`, `test_blackbox_roi_api.py`, and `test_e2e_blackbox_flywheel.py`).
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca1cd4a488332a1b53cff2f13b0f6)