### PR TITLE
Gate `/health` behind internal key and expose minimal public response

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -61,6 +61,17 @@ Deploy to Google Cloud Run:
 gcloud run deploy raptorflow-spine --source .
 ```
 
+## Health checks (Ops)
+The public `/health` endpoint returns a minimal response:
+```json
+{"status": "ok"}
+```
+
+For deep component checks, include the internal key:
+```bash
+curl -H "X-RF-Internal-Key: $RF_INTERNAL_KEY" http://localhost:8000/health
+```
+
 ## Blackbox Architecture
 The Blackbox is the "Cognitive Spine" of RaptorFlow, handling industrial-scale telemetry and automated learning.
 

--- a/backend/scripts/smoke_test_prod.py
+++ b/backend/scripts/smoke_test_prod.py
@@ -1,9 +1,10 @@
 import argparse
+import os
 
 import requests
 
 
-def smoke_test(base_url: str, token: str):
+def smoke_test(base_url: str, token: str, internal_key: str | None = None):
     """
     SOTA Production Smoke Test.
     Auth -> Matrix -> Agent Trace.
@@ -27,7 +28,10 @@ def smoke_test(base_url: str, token: str):
 
     # 2. Verify Deep Health
     print("Step 2: Checking System Health...")
-    res = requests.get(f"{base_url}/health", headers=headers, timeout=10)
+    health_headers = dict(headers)
+    if internal_key:
+        health_headers["X-RF-Internal-Key"] = internal_key
+    res = requests.get(f"{base_url}/health", headers=health_headers, timeout=10)
     if res.status_code == 200:
         print("✓ Deep Health Check Passed.")
     else:
@@ -48,7 +52,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Production Smoke Test")
     parser.add_argument("--url", help="Base URL of Production API", required=True)
     parser.add_argument("--token", help="Auth Token", required=True)
+    parser.add_argument(
+        "--internal-key",
+        help="Internal key for deep health checks (overrides RF_INTERNAL_KEY env).",
+    )
 
     # args = parser.parse_args()
-    # smoke_test(args.url, args.token)
+    # smoke_test(
+    #     args.url,
+    #     args.token,
+    #     args.internal_key or os.getenv("RF_INTERNAL_KEY"),
+    # )
     print("SOTA Smoke Test Initialized. Ready for Production Gates.")

--- a/backend/tests/test_health_deep.py
+++ b/backend/tests/test_health_deep.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
@@ -32,7 +33,10 @@ def test_health_check_deep_success():
         mock_redis.ping.return_value = True
         mock_cache_getter.return_value = mock_redis
 
-        response = client.get("/health")
+        with patch.dict(os.environ, {"RF_INTERNAL_KEY": "test-key"}):
+            response = client.get(
+                "/health", headers={"X-RF-Internal-Key": "test-key"}
+            )
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
@@ -58,7 +62,10 @@ def test_health_check_deep_failure():
         mock_redis.ping.return_value = True
         mock_cache_getter.return_value = mock_redis
 
-        response = client.get("/health")
+        with patch.dict(os.environ, {"RF_INTERNAL_KEY": "test-key"}):
+            response = client.get(
+                "/health", headers={"X-RF-Internal-Key": "test-key"}
+            )
         assert response.status_code == 503
         data = response.json()
         assert data["status"] == "degraded"

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -9,7 +9,7 @@ def test_health_check():
     """Test the system health check endpoint."""
     response = client.get("/health")
     assert response.status_code == 200
-    assert response.json()["status"] == "healthy"
+    assert response.json()["status"] == "ok"
 
 
 def test_correlation_id_middleware():

--- a/raptorflow-app/backend.txt
+++ b/raptorflow-app/backend.txt
@@ -786,7 +786,7 @@ $$;
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/health` | Health check |
+| GET | `/health` | Health check (public: `{ "status": "ok" }`, internal: add `X-RF-Internal-Key`) |
 | GET | `/api/v1/auth/me` | Get current user |
 
 ---


### PR DESCRIPTION
### Motivation
- Reduce information leakage from the public `/health` endpoint by returning only a minimal public status.
- Allow ops to run deep component checks (DB/Redis) when authenticated with an internal API key (`RF_INTERNAL_KEY`).
- Make smoke tests and docs reflect the new internal-only health behavior.

### Description
- Update `backend/main.py` to accept `X-RF-Internal-Key` or a Bearer token and short-circuit to a public `{"status": "ok"}` response unless the provided key matches `RF_INTERNAL_KEY` from `get_settings()`.
- Keep the existing deep checks (database and cache ping) and only run them when the internal key is present and valid.
- Update `backend/tests/test_main.py` and `backend/tests/test_health_deep.py` to expect the public `"ok"` response and to exercise deep checks with the `X-RF-Internal-Key` header, and update `backend/scripts/smoke_test_prod.py` to accept an `--internal-key` flag.
- Document the change in `backend/README.md` and the API listing in `raptorflow-app/backend.txt` with usage examples for ops (curl with `X-RF-Internal-Key`).

### Testing
- Updated unit tests: `backend/tests/test_main.py` now expects `{"status": "ok"}` for the public check and `backend/tests/test_health_deep.py` was modified to call `/health` with `X-RF-Internal-Key` to validate deep checks.
- Adjusted `backend/scripts/smoke_test_prod.py` to send `X-RF-Internal-Key` when provided.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca1cfaadc8332bcde93911b6b4876)