### PR TITLE
Add dossier schema and gap-planning loop in deep research

### DIFF
--- a/backend/agents/shared/research_deep.py
+++ b/backend/agents/shared/research_deep.py
@@ -1,12 +1,17 @@
 import json
-from typing import List, Optional
+import logging
+from typing import Dict, List, Optional
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
 from backend.core.config import get_settings
+from backend.core.gap_planner import build_gap_queries, evaluate_dossier_gaps
 from backend.core.research_engine import ResearchEngine, SearchProvider
 from backend.inference import InferenceProvider
+from backend.models.dossier_schema import DEFAULT_DOSSIER_SCHEMA, build_dossier_model
+
+logger = logging.getLogger("raptorflow.research_deep")
 
 
 class ResearchPlan(BaseModel):
@@ -39,12 +44,45 @@ class ResearchDeepAgent:
         self.synthesizer = InferenceProvider.get_model(
             model_tier="ultra"
         ).with_structured_output(DeepInsight)
+        self.dossier_extractor = InferenceProvider.get_model(
+            model_tier="reasoning"
+        ).with_structured_output(build_dossier_model(DEFAULT_DOSSIER_SCHEMA))
         self.engine = ResearchEngine()
         settings = get_settings()
         self.search_api = SearchProvider(api_key=settings.SERPER_API_KEY or "")
 
+    @staticmethod
+    def _is_missing_value(value: object) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, str):
+            return not value.strip()
+        if isinstance(value, (list, tuple, set, dict)):
+            return len(value) == 0
+        return False
+
+    def _merge_dossier_data(
+        self, existing: Dict[str, object], updates: Dict[str, object]
+    ) -> Dict[str, object]:
+        merged = dict(existing)
+        for key, value in updates.items():
+            if self._is_missing_value(value):
+                continue
+            current = merged.get(key)
+            if self._is_missing_value(current):
+                merged[key] = value
+                continue
+            if isinstance(current, list) and isinstance(value, list):
+                merged[key] = sorted(set(current + value))
+        return merged
+
     async def execute(self, task: str, context: Optional[dict] = None) -> DeepInsight:
         context = context or {}
+        dossier_data: Dict[str, object] = dict(context.get("dossier_data", {}))
+        company_name = context.get("company_name") or task
+        max_depth = context.get("max_depth", 3)
+        research_logs: List[str] = []
+
         # Step 1: Query Planning
         plan = await self.planner.ainvoke(
             [
@@ -58,14 +96,79 @@ class ResearchDeepAgent:
             ]
         )
 
-        # Step 2: Search & Scrape (Async)
-        all_urls = []
-        for query in plan.queries:
-            links = await self.search_api.search(query)
-            all_urls.extend(links)
+        missing_fields, _, gap_notes = evaluate_dossier_gaps(dossier_data)
+        depth = 0
+        scraped_data: List[Dict[str, str]] = []
 
-        unique_urls = list(set(all_urls))[:10]  # Limit to top 10 for economy
-        scraped_data = await self.engine.batch_fetch(unique_urls)
+        while depth < max_depth:
+            if missing_fields:
+                gap_queries = build_gap_queries(
+                    company_name, missing_fields, gap_notes
+                )
+                combined_queries = list(dict.fromkeys(plan.queries + gap_queries))
+                research_logs.append(
+                    f"Depth {depth}: {len(missing_fields)} gaps detected "
+                    f"({', '.join(missing_fields)})."
+                )
+                logger.info(research_logs[-1])
+            else:
+                research_logs.append(
+                    f"Depth {depth}: No dossier gaps detected. Halting research loop."
+                )
+                logger.info(research_logs[-1])
+                break
+
+            # Step 2: Search & Scrape (Async)
+            all_urls = []
+            for query in combined_queries:
+                links = await self.search_api.search(query)
+                all_urls.extend(links)
+
+            unique_urls = list(dict.fromkeys(all_urls))[:10]  # Limit to top 10
+            scraped_data = await self.engine.batch_fetch(unique_urls)
+
+            # Step 3: Extract dossier fields from web data
+            data_packet = "\n\n".join(
+                [
+                    f"SOURCE: {d['url']}\nCONTENT: {d['content'][:3000]}"
+                    for d in scraped_data
+                ]
+            )
+
+            extraction = await self.dossier_extractor.ainvoke(
+                [
+                    SystemMessage(
+                        content=(
+                            "Extract dossier fields from the web data. "
+                            "Return only fields with high confidence."
+                        )
+                    ),
+                    HumanMessage(
+                        content=(
+                            f"TASK: {task}\nCOMPANY: {company_name}\n\nWEB DATA:{data_packet}"
+                        )
+                    ),
+                ]
+            )
+
+            dossier_data = self._merge_dossier_data(
+                dossier_data, extraction.model_dump()
+            )
+            missing_fields, _, gap_notes = evaluate_dossier_gaps(dossier_data)
+            research_logs.append(
+                f"Depth {depth}: Remaining gaps "
+                f"({len(missing_fields)}): {', '.join(missing_fields) or 'none'}."
+            )
+            logger.info(research_logs[-1])
+
+            if not missing_fields:
+                research_logs.append(
+                    f"Depth {depth}: All dossier gaps resolved."
+                )
+                logger.info(research_logs[-1])
+                break
+
+            depth += 1
 
         # Step 3: Synthesis with RAG-style context
         system_msg = SystemMessage(

--- a/backend/core/gap_planner.py
+++ b/backend/core/gap_planner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Tuple
+
+from backend.models.dossier_schema import DEFAULT_DOSSIER_SCHEMA, DossierSchema
+
+
+def _is_missing_value(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _iter_schema_fields(schema: DossierSchema):
+    for field in schema.fields:
+        if field.required:
+            yield field
+
+
+def evaluate_dossier_gaps(
+    data: Dict[str, object],
+    schema: DossierSchema = DEFAULT_DOSSIER_SCHEMA,
+) -> Tuple[List[str], List[str], Dict[str, str]]:
+    """
+    Compare dossier data to schema and return missing fields and search queries.
+    Returns (missing_fields, suggested_queries, gap_notes)
+    """
+    missing_fields: List[str] = []
+    suggested_queries: List[str] = []
+    gap_notes: Dict[str, str] = {}
+
+    for field in _iter_schema_fields(schema):
+        value = data.get(field.name)
+        if _is_missing_value(value):
+            missing_fields.append(field.name)
+            gap_notes[field.name] = field.description
+            if field.query_hints:
+                suggested_queries.extend(field.query_hints)
+
+    return missing_fields, sorted(set(suggested_queries)), gap_notes
+
+
+def build_gap_queries(
+    company_name: str,
+    missing_fields: Iterable[str],
+    gap_notes: Dict[str, str],
+    schema: DossierSchema = DEFAULT_DOSSIER_SCHEMA,
+) -> List[str]:
+    field_map = {field.name: field for field in schema.fields}
+    queries: List[str] = []
+    for field_name in missing_fields:
+        field = field_map.get(field_name)
+        if not field:
+            continue
+        if field.query_hints:
+            queries.extend([f"{company_name} {hint}" for hint in field.query_hints])
+        else:
+            description = gap_notes.get(field_name) or field.description
+            queries.append(f"{company_name} {description}")
+
+    return sorted(set(queries))

--- a/backend/models/dossier_schema.py
+++ b/backend/models/dossier_schema.py
@@ -1,0 +1,114 @@
+from typing import List, Optional, Type
+
+from pydantic import BaseModel, Field, create_model
+
+
+class DossierField(BaseModel):
+    name: str
+    description: str
+    required: bool = True
+    query_hints: List[str] = Field(default_factory=list)
+    field_type: Type = str
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class DossierSchema(BaseModel):
+    fields: List[DossierField]
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+DEFAULT_DOSSIER_SCHEMA = DossierSchema(
+    fields=[
+        DossierField(
+            name="company_overview",
+            description="Concise company overview and mission.",
+            query_hints=["company overview", "mission statement", "about us"],
+        ),
+        DossierField(
+            name="products_services",
+            description="Primary products or services offered.",
+            query_hints=["product suite", "services", "platform features"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="pricing_packaging",
+            description="Pricing tiers, packaging, and monetization model.",
+            query_hints=["pricing", "plans", "subscription tiers"],
+        ),
+        DossierField(
+            name="target_segments",
+            description="Core customer segments and ICP focus.",
+            query_hints=["target customers", "ideal customer profile", "segments"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="positioning_messaging",
+            description="Positioning, value proposition, and messaging themes.",
+            query_hints=["positioning", "value proposition", "messaging"],
+        ),
+        DossierField(
+            name="differentiators",
+            description="Key differentiators or competitive advantages.",
+            query_hints=["differentiators", "competitive advantage", "unique features"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="vulnerabilities",
+            description="Weaknesses, risks, or gaps to exploit.",
+            query_hints=["weaknesses", "limitations", "customer complaints"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="go_to_market",
+            description="Go-to-market strategy and distribution channels.",
+            query_hints=["go-to-market", "sales channels", "marketing strategy"],
+        ),
+        DossierField(
+            name="recent_news",
+            description="Recent announcements, launches, or notable news.",
+            query_hints=["recent news", "press release", "announcement"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="customer_proof",
+            description="Customer proof points, case studies, or testimonials.",
+            query_hints=["case study", "testimonial", "customer story"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="leadership",
+            description="Key leadership team members and roles.",
+            query_hints=["leadership team", "executives", "founders"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="funding_financials",
+            description="Funding history, financial signals, or revenue estimates.",
+            query_hints=["funding", "investors", "revenue"],
+        ),
+        DossierField(
+            name="tech_stack",
+            description="Core technology stack and integrations.",
+            query_hints=["tech stack", "integrations", "developer docs"],
+            field_type=List[str],
+        ),
+        DossierField(
+            name="partnerships",
+            description="Strategic partnerships and ecosystem alliances.",
+            query_hints=["partnerships", "alliances", "integrations partners"],
+            field_type=List[str],
+        ),
+    ]
+)
+
+
+def build_dossier_model(schema: DossierSchema):
+    field_definitions = {}
+    for field in schema.fields:
+        field_definitions[field.name] = (
+            Optional[field.field_type],
+            Field(default=None, description=field.description),
+        )
+    return create_model("DossierData", **field_definitions)


### PR DESCRIPTION
### Motivation
- Introduce a formal dossier schema to define required research fields and guidance for extraction. 
- Detect and prioritize missing dossier fields so the research agent can iteratively close information gaps. 
- Produce targeted search queries for missing topics to improve recall during web search/scrape cycles. 
- Surface gap resolution status in logs for transparency and debugging of the research process.

### Description
- Added `backend/models/dossier_schema.py` which defines `DossierField`, `DossierSchema`, a `DEFAULT_DOSSIER_SCHEMA`, and `build_dossier_model` for structured dossier outputs. 
- Implemented `backend/core/gap_planner.py` with `evaluate_dossier_gaps` and `build_gap_queries` to detect missing fields and generate company-scoped search queries. 
- Updated `backend/agents/shared/research_deep.py` to: use the dossier schema extractor (`dossier_extractor`) via `build_dossier_model`, loop search → scrape → extract until gaps close or `max_depth` is reached, merge incremental extractions with `_merge_dossier_data`, and log gap status via `research_logs` and `logger.info`. 
- Limited scraped URLs and extraction payload sizes for economy and safety, and de-duplicated combined queries and URLs.

### Testing
- No automated tests were run as part of this change. 
- Basic repository operations (`git add` / `git commit`) were executed to record the change. 
- Runtime behavior should be validated via integration tests or manual runs of the deep research flow that exercise search, scraping, and LLM extraction. 
- Recommend adding unit tests for `evaluate_dossier_gaps`, `build_gap_queries`, and the dossier merge logic in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cac0c9e508332a46e01557022cb47)