### PR TITLE
Introduce Playwright headless renderer with heuristic-triggered JS rendering

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -76,6 +76,10 @@ class Config(BaseSettings):
     PERPLEXITY_API_KEY: Optional[str] = None
     BRAVE_SEARCH_API_KEY: Optional[str] = None
 
+    # Rendering
+    JS_RENDERING_ENABLED: bool = False
+    JS_RENDERING_TIMEOUT_S: int = 20
+
     # Payment Configuration (PhonePe Standard Checkout v2)
     PHONEPE_CLIENT_ID: Optional[str] = None
     PHONEPE_CLIENT_SECRET: Optional[str] = None

--- a/backend/core/renderers/__init__.py
+++ b/backend/core/renderers/__init__.py
@@ -1,0 +1,1 @@
+"""Rendering helpers for dynamic web pages."""

--- a/backend/core/renderers/playwright.py
+++ b/backend/core/renderers/playwright.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from bs4 import BeautifulSoup
+
+
+APP_SHELL_MARKERS: tuple[str, ...] = (
+    "id=\"root\"",
+    "id='root'",
+    "id=\"app\"",
+    "id='app'",
+    "id=\"__next\"",
+    "id='__next'",
+    "id=\"__nuxt\"",
+    "id='__nuxt'",
+    "data-reactroot",
+    "ng-app",
+)
+
+
+def _text_density(html: str) -> float:
+    if not html:
+        return 0.0
+    soup = BeautifulSoup(html, "html.parser")
+    for element in soup(["script", "style", "noscript"]):
+        element.decompose()
+    text = soup.get_text(separator=" ", strip=True)
+    html_length = max(len(html), 1)
+    return len(text) / html_length
+
+
+def _has_app_shell_marker(html: str, markers: Iterable[str] = APP_SHELL_MARKERS) -> bool:
+    if not html:
+        return False
+    lowered = html.lower()
+    return any(marker in lowered for marker in markers)
+
+
+def should_render(html: str, min_text_density: float = 0.02) -> bool:
+    if _has_app_shell_marker(html):
+        return True
+    if _text_density(html) < min_text_density:
+        return True
+    if not re.search(r"<body[^>]*>.*</body>", html, re.DOTALL | re.IGNORECASE):
+        return True
+    return False
+
+
+@dataclass
+class PlaywrightRenderer:
+    timeout_s: int = 20
+    user_agent: Optional[str] = None
+
+    async def render(self, url: str) -> str:
+        from playwright.async_api import async_playwright
+
+        async with async_playwright() as playwright:
+            browser = await playwright.chromium.launch(headless=True)
+            context = await browser.new_context(user_agent=self.user_agent)
+            page = await context.new_page()
+            await page.goto(url, wait_until="networkidle", timeout=self.timeout_s * 1000)
+            await page.wait_for_timeout(1000)
+            html = await page.content()
+            await context.close()
+            await browser.close()
+            return html


### PR DESCRIPTION
### Motivation
- Add a headless rendering step for pages where static HTML extraction is insufficient due to client-side rendering or app shells.
- Use a lightweight heuristic to detect when JS rendering is beneficial based on text density, app-shell markers, and body presence.
- Make JS rendering opt-in and configurable to avoid unnecessary resource usage in normal scraping flows.

### Description
- Add a new renderer module `backend/core/renderers/playwright.py` implementing `PlaywrightRenderer` and the `should_render` heuristic for app-shell markers and text density checks.
- Wire rendering into `ResearchEngine.fetch_page` so that when `JS_RENDERING_ENABLED` is true and `should_render` returns true, the page is fetched via Playwright before cleaning.
- Apply the same rendering fallback to `AdvancedCrawler._fallback_scrape` to improve extraction from JS-heavy sites.
- Add configuration flags `JS_RENDERING_ENABLED` and `JS_RENDERING_TIMEOUT_S` to `backend/core/config.py` to control rendering behavior and timeout.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cac0ba8b08332a270016b28dfd705)