### PR TITLE
Wire real data flow into research_deep_advanced graph and add data-flow test

### DIFF
--- a/backend/models/research_schemas.py
+++ b/backend/models/research_schemas.py
@@ -39,6 +39,8 @@ class ResearchDeepState(BaseModel):
     queries: List[str] = []
     hypotheses: List[ResearchHypothesis] = []
     documents: List[WebDocument] = []
+    discovered_urls: List[HttpUrl] = []
+    scraped_docs: List[WebDocument] = []
     claims: List[FactClaim] = []
 
     # Progress

--- a/backend/tests/test_research_deep_advanced_graph.py
+++ b/backend/tests/test_research_deep_advanced_graph.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.agents.shared.research_specialists import LibrarianAgent, SynthesisAgent
+from backend.core.crawler_advanced import AdvancedCrawler
+from backend.core.research_engine import SearchProvider
+from backend.graphs.research_deep_advanced import build_sota_research_spine
+from backend.models.research_schemas import ResearchDeepState
+
+
+@pytest.mark.asyncio
+async def test_research_deep_advanced_graph_data_flow():
+    urls = ["https://example.com/a", "https://example.com/b"]
+    crawler_results = [
+        {
+            "url": urls[0],
+            "title": "Example A",
+            "content": "Example claim. Supporting details follow.",
+            "source": "firecrawl",
+        }
+    ]
+
+    with (
+        patch.object(
+            LibrarianAgent, "plan_search", new=AsyncMock(return_value=["query"])
+        ),
+        patch.object(SearchProvider, "search", new=AsyncMock(return_value=urls)),
+        patch.object(
+            AdvancedCrawler, "batch_crawl", new=AsyncMock(return_value=crawler_results)
+        ),
+        patch.object(
+            SynthesisAgent, "generate_report", new=AsyncMock(return_value="Report")
+        ),
+    ):
+        graph = build_sota_research_spine()
+        state = ResearchDeepState(
+            workspace_id="workspace",
+            task_id="task",
+            objective="Objective",
+            max_depth=1,
+        )
+        result = await graph.ainvoke(state.dict())
+
+    assert result["discovered_urls"] == urls
+    assert result["depth"] == 1
+    assert result["status"] == "completed"
+    assert result["final_report_md"] == "Report"
+
+    scraped_docs = result["scraped_docs"]
+    assert len(scraped_docs) == 1
+    first_doc = scraped_docs[0]
+    first_doc_url = str(first_doc.url) if hasattr(first_doc, "url") else first_doc["url"]
+    assert first_doc_url == urls[0]
+
+    claims = result["claims"]
+    assert len(claims) == 1
+    claim_text = claims[0].claim if hasattr(claims[0], "claim") else claims[0]["claim"]
+    assert claim_text.startswith("Example claim.")


### PR DESCRIPTION
### Motivation
- Make the SOTA research graph actually propagate discovered URLs, scraped documents, and extracted claims through the pipeline instead of only mocking state transitions.
- Surface intermediate artifacts (`discovered_urls`, `scraped_docs`, `claims`) so downstream nodes can perform real synthesis and verification.
- Provide a unit test that validates end-to-end graph state transitions with mocked external dependencies.

### Description
- Extend `ResearchDeepState` to include `discovered_urls` and `scraped_docs` fields in `backend/models/research_schemas.py`.
- Update `discovery_node` in `backend/graphs/research_deep_advanced.py` to return `discovered_urls` derived from search results.
- Implement `scraping_node` to call the unified crawler (`AdvancedCrawler.batch_crawl`) and populate `scraped_docs` and `documents`, and implement `verification_node` to extract `FactClaim` objects from `scraped_docs` for synthesis.
- Add `backend/tests/test_research_deep_advanced_graph.py` which mocks `LibrarianAgent`, `SearchProvider`, `AdvancedCrawler`, and `SynthesisAgent` to assert discovered URLs, scraped docs, extracted claims, and final report emission.

### Testing
- Ran `pytest -q backend/tests/test_research_deep_advanced_graph.py` which initially failed with `ModuleNotFoundError: No module named 'backend'` before adjusting `PYTHONPATH`.
- Re-ran with `PYTHONPATH=. pytest -q backend/tests/test_research_deep_advanced_graph.py` which failed due to a missing runtime dependency `langchain_core` causing `ModuleNotFoundError: No module named 'langchain_core'` during collection.
- The test is present and exercises the full graph flow with mocked components, but CI/local environment needs `langchain_core` (or further test shimming) to run successfully.
- Changes were committed with the message `Implement research deep advanced data flow`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cac0a0b188332bbc82fe7c1e468d2)