### PR TITLE
Add asset parsing stages to crawler pipeline

### DIFF
--- a/backend/core/crawler_advanced.py
+++ b/backend/core/crawler_advanced.py
@@ -1,11 +1,14 @@
 import asyncio
 import logging
 import re
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from bs4 import BeautifulSoup
 
+from backend.core.config import get_settings
+from backend.core.parsers import detect_asset_type, parse_asset
+from backend.services.storage_service import BrandAssetManager
 from backend.tools.scraper import FirecrawlScraperTool, JinaReaderTool
 
 
@@ -20,20 +23,28 @@ class AdvancedCrawler:
         self.firecrawl = FirecrawlScraperTool()
         self.jina = JinaReaderTool()
         self.headers = {"User-Agent": "RaptorFlowResearch/3.0 (Industrial grade)"}
+        settings = get_settings()
+        self._asset_manager = BrandAssetManager(bucket_name=settings.GCS_INGEST_BUCKET)
+        self._default_tenant_id = settings.DEFAULT_TENANT_ID
 
-    async def scrape_semantic(self, url: str) -> Optional[Dict[str, str]]:
+    async def scrape_semantic(self, url: str) -> Optional[Dict[str, Any]]:
         """SOTA Extraction using tiered tools."""
         async with self.semaphore:
+            asset_result = await self._scrape_asset(url)
+            if asset_result:
+                return asset_result
+
             # Tier 1: Firecrawl (Best for structured/JS-heavy sites)
             try:
                 data = await self.firecrawl._execute(url)
                 if data and (data.get("markdown") or data.get("content")):
-                    return {
-                        "url": url,
-                        "title": data.get("metadata", {}).get("title", ""),
-                        "content": data.get("markdown") or data.get("content"),
-                        "source": "firecrawl",
-                    }
+                    return self._normalize_result(
+                        url=url,
+                        title=data.get("metadata", {}).get("title", ""),
+                        content=data.get("markdown") or data.get("content"),
+                        source="firecrawl",
+                        metadata={"asset_type": "html"},
+                    )
             except Exception as e:
                 logging.warning(f"Firecrawl failed for {url}, trying Jina: {e}")
 
@@ -41,12 +52,13 @@ class AdvancedCrawler:
             try:
                 data = await self.jina._execute(url)
                 if data and data.get("content"):
-                    return {
-                        "url": url,
-                        "title": data.get("title", ""),
-                        "content": data.get("content"),
-                        "source": "jina",
-                    }
+                    return self._normalize_result(
+                        url=url,
+                        title=data.get("title", ""),
+                        content=data.get("content"),
+                        source="jina",
+                        metadata={"asset_type": "html"},
+                    )
             except Exception as e:
                 logging.warning(
                     f"Jina failed for {url}, falling back to BeautifulSoup: {e}"
@@ -55,7 +67,7 @@ class AdvancedCrawler:
             # Tier 3: Local BeautifulSoup Fallback (Reliable but messy)
             return await self._fallback_scrape(url)
 
-    async def _fallback_scrape(self, url: str) -> Optional[Dict[str, str]]:
+    async def _fallback_scrape(self, url: str) -> Optional[Dict[str, Any]]:
         """Classic extraction as a last resort."""
         try:
             async with aiohttp.ClientSession(headers=self.headers) as session:
@@ -73,18 +85,111 @@ class AdvancedCrawler:
 
                     text = re.sub(r"\n+", "\n", soup.get_text(separator=" ")).strip()
 
-                    return {
-                        "url": url,
-                        "title": title,
-                        "content": text[:10000],
-                        "source": "fallback_bs4",
-                    }
+                    return self._normalize_result(
+                        url=url,
+                        title=title,
+                        content=text[:10000],
+                        source="fallback_bs4",
+                        metadata={"asset_type": "html"},
+                    )
         except Exception as e:
             logging.error(f"Fallback scrape failed for {url}: {e}")
             return None
 
-    async def batch_crawl(self, urls: List[str]) -> List[Dict[str, str]]:
+    async def batch_crawl(self, urls: List[str]) -> List[Dict[str, Any]]:
         """Parallel industrial research."""
         tasks = [self.scrape_semantic(url) for url in urls]
         results = await asyncio.gather(*tasks)
         return [r for r in results if r]
+
+    async def _scrape_asset(self, url: str) -> Optional[Dict[str, Any]]:
+        asset_type = detect_asset_type(url)
+        headers = {"User-Agent": self.headers["User-Agent"]}
+        content_type = None
+
+        async with aiohttp.ClientSession(headers=headers) as session:
+            try:
+                async with session.head(url, timeout=10, allow_redirects=True) as resp:
+                    content_type = resp.headers.get("Content-Type")
+                    asset_type = asset_type or detect_asset_type(url, content_type)
+            except Exception:
+                content_type = None
+
+            if not asset_type:
+                return None
+
+            try:
+                async with session.get(url, timeout=20) as resp:
+                    if resp.status != 200:
+                        return None
+                    content_type = resp.headers.get("Content-Type", content_type)
+                    asset_type = asset_type or detect_asset_type(url, content_type)
+                    if not asset_type:
+                        return None
+                    asset_bytes = await resp.read()
+            except Exception as e:
+                logging.warning(f"Failed to fetch asset {url}: {e}")
+                return None
+
+        try:
+            parsed = parse_asset(asset_type, asset_bytes)
+        except Exception as e:
+            logging.warning(f"Failed to parse asset {url}: {e}")
+            return None
+        storage_url = await self._store_raw_asset(
+            url=url,
+            asset_bytes=asset_bytes,
+            asset_type=asset_type,
+            content_type=content_type or "application/octet-stream",
+        )
+        metadata = {
+            "asset_type": asset_type,
+            "storage_url": storage_url,
+            **parsed.metadata,
+        }
+        title = parsed.title or metadata.get("document_title", "") or ""
+        return self._normalize_result(
+            url=url,
+            title=title,
+            content=parsed.text,
+            source=f"asset_{asset_type}",
+            metadata=metadata,
+        )
+
+    async def _store_raw_asset(
+        self,
+        url: str,
+        asset_bytes: bytes,
+        asset_type: str,
+        content_type: str,
+    ) -> Optional[str]:
+        filename = url.split("/")[-1] or f"asset.{asset_type}"
+        if "." not in filename:
+            filename = f"{filename}.{asset_type}"
+        try:
+            return await asyncio.to_thread(
+                self._asset_manager.upload_raw_asset,
+                file_content=asset_bytes,
+                filename=filename,
+                content_type=content_type,
+                tenant_id=self._default_tenant_id,
+            )
+        except Exception as e:
+            logging.warning(f"Failed to store raw asset {url}: {e}")
+            return None
+
+    def _normalize_result(
+        self,
+        url: str,
+        title: str,
+        content: str,
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return {
+            "url": url,
+            "title": title,
+            "content": content,
+            "source": source,
+            "metadata": metadata or {},
+        }

--- a/backend/core/parsers/__init__.py
+++ b/backend/core/parsers/__init__.py
@@ -1,0 +1,50 @@
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from backend.core.parsers.docx import parse_docx
+from backend.core.parsers.pdf import parse_pdf
+from backend.core.parsers.pptx import parse_pptx
+from backend.core.parsers.types import ParsedAsset
+
+ASSET_SUFFIXES = {
+    ".pdf": "pdf",
+    ".pptx": "pptx",
+    ".ppt": "pptx",
+    ".docx": "docx",
+    ".doc": "docx",
+}
+
+ASSET_CONTENT_TYPES = {
+    "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+    "application/vnd.ms-powerpoint": "pptx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/msword": "docx",
+}
+
+PARSERS = {
+    "pdf": parse_pdf,
+    "pptx": parse_pptx,
+    "docx": parse_docx,
+}
+
+
+def detect_asset_type(url: str, content_type: Optional[str] = None) -> Optional[str]:
+    parsed = urlparse(url)
+    path = parsed.path.lower()
+    for suffix, asset_type in ASSET_SUFFIXES.items():
+        if path.endswith(suffix):
+            return asset_type
+
+    if content_type:
+        normalized = content_type.split(";")[0].strip().lower()
+        return ASSET_CONTENT_TYPES.get(normalized)
+
+    return None
+
+
+def parse_asset(asset_type: str, content: bytes) -> ParsedAsset:
+    parser = PARSERS.get(asset_type)
+    if not parser:
+        raise ValueError(f"Unsupported asset type: {asset_type}")
+    return parser(content)

--- a/backend/core/parsers/docx.py
+++ b/backend/core/parsers/docx.py
@@ -1,0 +1,41 @@
+import io
+from typing import Dict, List
+
+from docx import Document
+
+from backend.core.parsers.types import ParsedAsset
+
+
+def parse_docx(content: bytes) -> ParsedAsset:
+    document = Document(io.BytesIO(content))
+    section_entries: List[Dict[str, Any]] = []
+    text_parts: List[str] = []
+    section_index = 0
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if not text:
+            continue
+
+        style_name = paragraph.style.name if paragraph.style else ""
+        is_heading = style_name.lower().startswith("heading")
+        if is_heading:
+            section_index += 1
+            section_entries.append(
+                {
+                    "page_number": section_index,
+                    "title": text,
+                    "style": style_name,
+                }
+            )
+            text_parts.append(f"[Section {section_index}]\n{text}")
+        else:
+            text_parts.append(text)
+
+    combined_text = "\n\n".join(text_parts).strip()
+    asset_metadata = {
+        "page_count": max(section_index, 1) if text_parts else 0,
+        "pages": section_entries,
+    }
+    title = section_entries[0]["title"] if section_entries else ""
+    return ParsedAsset(text=combined_text, title=title, metadata=asset_metadata)

--- a/backend/core/parsers/pdf.py
+++ b/backend/core/parsers/pdf.py
@@ -1,0 +1,42 @@
+import io
+from typing import Any, Dict, List
+
+import fitz
+import pdfplumber
+
+from backend.core.parsers.types import ParsedAsset
+
+
+def _extract_title(metadata: Dict[str, Any]) -> str:
+    title = metadata.get("title")
+    if isinstance(title, str):
+        return title.strip()
+    return ""
+
+
+def parse_pdf(content: bytes) -> ParsedAsset:
+    page_entries: List[Dict[str, Any]] = []
+    text_parts: List[str] = []
+
+    with pdfplumber.open(io.BytesIO(content)) as pdf:
+        for index, page in enumerate(pdf.pages, start=1):
+            page_text = page.extract_text() or ""
+            page_text = page_text.strip()
+            if page_text:
+                text_parts.append(f"[Page {index}]\n{page_text}")
+            page_title = page_text.splitlines()[0].strip() if page_text else ""
+            page_entries.append(
+                {"page_number": index, "title": page_title, "char_count": len(page_text)}
+            )
+
+    with fitz.open(stream=content, filetype="pdf") as doc:
+        metadata = doc.metadata or {}
+        title = _extract_title(metadata)
+
+    combined_text = "\n\n".join(text_parts).strip()
+    asset_metadata = {
+        "page_count": len(page_entries),
+        "pages": page_entries,
+        "document_title": title,
+    }
+    return ParsedAsset(text=combined_text, title=title, metadata=asset_metadata)

--- a/backend/core/parsers/pptx.py
+++ b/backend/core/parsers/pptx.py
@@ -1,0 +1,45 @@
+import io
+from typing import Dict, List
+
+from pptx import Presentation
+
+from backend.core.parsers.types import ParsedAsset
+
+
+def _slide_title(slide) -> str:
+    if slide.shapes.title and slide.shapes.title.text:
+        return slide.shapes.title.text.strip()
+    return ""
+
+
+def parse_pptx(content: bytes) -> ParsedAsset:
+    presentation = Presentation(io.BytesIO(content))
+    slide_entries: List[Dict[str, Any]] = []
+    text_parts: List[str] = []
+
+    for index, slide in enumerate(presentation.slides, start=1):
+        slide_texts = []
+        for shape in slide.shapes:
+            if not hasattr(shape, "text"):
+                continue
+            text = shape.text.strip()
+            if text:
+                slide_texts.append(text)
+        slide_text = "\n".join(slide_texts).strip()
+        if slide_text:
+            text_parts.append(f"[Slide {index}]\n{slide_text}")
+        title = _slide_title(slide)
+        slide_entries.append(
+            {
+                "page_number": index,
+                "title": title,
+                "char_count": len(slide_text),
+            }
+        )
+
+    combined_text = "\n\n".join(text_parts).strip()
+    asset_metadata = {
+        "page_count": len(slide_entries),
+        "pages": slide_entries,
+    }
+    return ParsedAsset(text=combined_text, title="", metadata=asset_metadata)

--- a/backend/core/parsers/types.py
+++ b/backend/core/parsers/types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class ParsedAsset:
+    text: str
+    title: str
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -221,3 +221,24 @@ class BrandAssetManager:
         except Exception as e:
             logger.error(f"Failed to upload logo: {e}")
             raise e
+
+    def upload_raw_asset(
+        self, file_content: bytes, filename: str, content_type: str, tenant_id: str
+    ) -> str:
+        """
+        Uploads a raw asset (PDF, PPTX, DOCX) to GCS and returns the public URL.
+        """
+        try:
+            bucket = self.client.get_bucket(self.bucket_name)
+            blob = bucket.blob(f"{tenant_id}/assets/raw/{filename}")
+
+            blob.upload_from_string(file_content, content_type=content_type)
+            blob.make_public()
+
+            logger.info(
+                f"Successfully uploaded raw asset: {filename} to {self.bucket_name}"
+            )
+            return blob.public_url
+        except Exception as e:
+            logger.error(f"Failed to upload raw asset: {e}")
+            raise e


### PR DESCRIPTION
### Motivation
- Enable the crawler to detect and extract text from binary assets (PDF, PPTX, DOCX) encountered during research crawls.
- Detect assets by `Content-Type` and URL suffixes so the pipeline can route binary files to dedicated parsers.
- Normalize extracted text and rich metadata (page/slide numbers, titles, char counts) into the same result schema for downstream RAG/ingest consumers.

### Description
- Added parser modules and types under `backend/core/parsers`: `pdf.py`, `pptx.py`, `docx.py`, and `types.py` implementing `ParsedAsset` and per-format `parse_*` functions.
- Added a dispatcher in `backend/core/parsers/__init__.py` with `detect_asset_type(url, content_type)` and `parse_asset(asset_type, content)`.
- Extended `backend/core/crawler_advanced.py` to detect assets, do HEAD/GET to confirm `Content-Type`, parse assets via `parse_asset`, normalize responses with `_normalize_result`, and store raw files with `_store_raw_asset`.
- Added `upload_raw_asset` to `backend/services/storage_service.py` (BrandAssetManager) and integrated it into the crawler using the existing `GCS_INGEST_BUCKET` and `DEFAULT_TENANT_ID` settings.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cac07f418833291c0da18412b65ec)