### PR TITLE
Add configurable search provider registry with URL normalization

### DIFF
--- a/backend/agents/shared/research_deep.py
+++ b/backend/agents/shared/research_deep.py
@@ -5,7 +5,8 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
 from backend.core.config import get_settings
-from backend.core.research_engine import ResearchEngine, SearchProvider
+from backend.core.research_engine import ResearchEngine
+from backend.core.search_provider import SearchProviderRegistry
 from backend.inference import InferenceProvider
 
 
@@ -41,7 +42,7 @@ class ResearchDeepAgent:
         ).with_structured_output(DeepInsight)
         self.engine = ResearchEngine()
         settings = get_settings()
-        self.search_api = SearchProvider(api_key=settings.SERPER_API_KEY or "")
+        self.search_api = SearchProviderRegistry(settings=settings)
 
     async def execute(self, task: str, context: Optional[dict] = None) -> DeepInsight:
         context = context or {}

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -75,6 +75,14 @@ class Config(BaseSettings):
     TAVILY_API_KEY: Optional[str] = None
     PERPLEXITY_API_KEY: Optional[str] = None
     BRAVE_SEARCH_API_KEY: Optional[str] = None
+    SEARCH_PROVIDER_ORDER: list[str] = ["native", "serper"]
+    SEARCH_PROVIDER_QUOTAS: dict[str, Optional[int]] = {
+        "native": None,
+        "serper": 500,
+    }
+    SEARCH_PROVIDER_SETTINGS: dict[str, dict[str, str]] = {
+        "serper": {"endpoint": "https://google.serper.dev/search"},
+    }
 
     # Payment Configuration (PhonePe Standard Checkout v2)
     PHONEPE_CLIENT_ID: Optional[str] = None

--- a/backend/core/research_engine.py
+++ b/backend/core/research_engine.py
@@ -6,8 +6,6 @@ from urllib.parse import urlparse
 import aiohttp
 from bs4 import BeautifulSoup
 
-from backend.core.search_native import NativeSearch
-
 logger = logging.getLogger("raptorflow.research_engine")
 
 
@@ -69,16 +67,3 @@ class ResearchEngine:
                     }
                 )
         return valid_results
-
-
-class SearchProvider:
-    """Abstraction for Native zero-cost Search."""
-
-    def __init__(self, api_key: str = ""):
-        # api_key is kept for backward compatibility but unused by NativeSearch
-        self._native = NativeSearch()
-
-    async def search(self, query: str, num_results: int = 5) -> List[str]:
-        """Performs native search and returns links."""
-        results = await self._native.query(query, limit=num_results)
-        return [res["url"] for res in results]

--- a/backend/core/search_provider.py
+++ b/backend/core/search_provider.py
@@ -1,0 +1,192 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
+
+import httpx
+
+from backend.core.config import get_settings
+from backend.core.search_native import NativeSearch
+
+logger = logging.getLogger("raptorflow.search_provider")
+
+TRACKING_QUERY_PARAMS = {
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "utm_id",
+    "gclid",
+    "fbclid",
+    "igshid",
+    "mc_cid",
+    "mc_eid",
+    "ref",
+    "ref_src",
+    "ref_url",
+    "spm",
+}
+
+
+def normalize_url(url: str) -> str:
+    if not url:
+        return url
+    trimmed = url.strip()
+    if "://" not in trimmed:
+        trimmed = f"https://{trimmed}"
+    parsed = urlsplit(trimmed)
+    scheme = parsed.scheme.lower() if parsed.scheme else "https"
+    netloc = parsed.netloc.lower()
+    if scheme == "http" and netloc.endswith(":80"):
+        netloc = netloc[:-3]
+    if scheme == "https" and netloc.endswith(":443"):
+        netloc = netloc[:-4]
+    query_items = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in TRACKING_QUERY_PARAMS
+    ]
+    query_items.sort()
+    query = "&".join(f"{k}={v}" for k, v in query_items) if query_items else ""
+    return urlunsplit((scheme, netloc, parsed.path or "/", query, ""))
+
+
+def dedupe_urls(urls: Iterable[str]) -> List[str]:
+    seen = set()
+    deduped = []
+    for url in urls:
+        normalized = normalize_url(url)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+@dataclass
+class ProviderResult:
+    urls: List[str]
+    provider: str
+
+
+class BaseSearchProvider:
+    name = "base"
+
+    def __init__(self, settings):
+        self.settings = settings
+
+    def is_available(self) -> bool:
+        return True
+
+    async def search(self, query: str, num_results: int = 5) -> ProviderResult:
+        raise NotImplementedError
+
+
+class NativeSearchProvider(BaseSearchProvider):
+    name = "native"
+
+    def __init__(self, settings):
+        super().__init__(settings)
+        self._native = NativeSearch()
+
+    async def search(self, query: str, num_results: int = 5) -> ProviderResult:
+        results = await self._native.query(query, limit=num_results)
+        urls = [res.get("url", "") for res in results]
+        return ProviderResult(urls=urls, provider=self.name)
+
+
+class SerperSearchProvider(BaseSearchProvider):
+    name = "serper"
+
+    def __init__(self, settings, endpoint: str):
+        super().__init__(settings)
+        self.endpoint = endpoint
+        self._client = httpx.AsyncClient(timeout=10.0)
+
+    def is_available(self) -> bool:
+        return bool(self.settings.SERPER_API_KEY)
+
+    async def search(self, query: str, num_results: int = 5) -> ProviderResult:
+        if not self.settings.SERPER_API_KEY:
+            return ProviderResult(urls=[], provider=self.name)
+        payload = {"q": query, "num": num_results}
+        headers = {
+            "X-API-KEY": self.settings.SERPER_API_KEY,
+            "Content-Type": "application/json",
+        }
+        response = await self._client.post(self.endpoint, json=payload, headers=headers)
+        if response.status_code != 200:
+            logger.warning("Serper search failed: %s", response.status_code)
+            return ProviderResult(urls=[], provider=self.name)
+        data = response.json()
+        urls = [item.get("link", "") for item in data.get("organic", [])]
+        return ProviderResult(urls=urls, provider=self.name)
+
+
+class SearchProviderRegistry:
+    def __init__(self, settings=None):
+        self.settings = settings or get_settings()
+        self._providers = self._build_providers()
+        self._cursor = 0
+        self._remaining_quotas = self._initialize_quotas()
+
+    def _build_providers(self) -> List[BaseSearchProvider]:
+        provider_settings = self.settings.SEARCH_PROVIDER_SETTINGS or {}
+        order = self.settings.SEARCH_PROVIDER_ORDER or ["native"]
+        providers: Dict[str, BaseSearchProvider] = {
+            "native": NativeSearchProvider(self.settings),
+            "serper": SerperSearchProvider(
+                self.settings,
+                provider_settings.get("serper", {}).get(
+                    "endpoint", "https://google.serper.dev/search"
+                ),
+            ),
+        }
+        return [providers[name] for name in order if name in providers]
+
+    def _initialize_quotas(self) -> Dict[str, Optional[int]]:
+        quotas: Dict[str, Optional[int]] = {}
+        for name, quota in (self.settings.SEARCH_PROVIDER_QUOTAS or {}).items():
+            quotas[name] = quota
+        return quotas
+
+    def _next_candidates(self) -> Iterable[Tuple[int, BaseSearchProvider]]:
+        if not self._providers:
+            return []
+        total = len(self._providers)
+        return (
+            ((self._cursor + offset) % total, self._providers[(self._cursor + offset) % total])
+            for offset in range(total)
+        )
+
+    def _has_quota(self, provider: BaseSearchProvider) -> bool:
+        quota = self._remaining_quotas.get(provider.name)
+        return quota is None or quota > 0
+
+    def _consume_quota(self, provider: BaseSearchProvider) -> None:
+        if provider.name not in self._remaining_quotas:
+            return
+        if self._remaining_quotas[provider.name] is None:
+            return
+        self._remaining_quotas[provider.name] = max(
+            0, (self._remaining_quotas[provider.name] or 0) - 1
+        )
+
+    async def search(self, query: str, num_results: int = 5) -> List[str]:
+        if not query:
+            return []
+        for index, provider in self._next_candidates():
+            if not provider.is_available() or not self._has_quota(provider):
+                continue
+            try:
+                result = await provider.search(query, num_results=num_results)
+            except Exception as exc:
+                logger.warning("Search provider %s failed: %s", provider.name, exc)
+                continue
+            urls = dedupe_urls(result.urls)
+            if urls:
+                self._consume_quota(provider)
+                self._cursor = (index + 1) % len(self._providers)
+                return urls
+        return []

--- a/backend/graphs/research_deep_advanced.py
+++ b/backend/graphs/research_deep_advanced.py
@@ -2,7 +2,7 @@ from langgraph.graph import END, START, StateGraph
 
 from backend.agents.shared.research_specialists import LibrarianAgent, SynthesisAgent
 from backend.core.config import get_settings
-from backend.core.research_engine import SearchProvider
+from backend.core.search_provider import SearchProviderRegistry
 from backend.models.research_schemas import ResearchDeepState
 
 # --- Nodes ---
@@ -22,7 +22,7 @@ async def planning_node(state: ResearchDeepState):
 async def discovery_node(state: ResearchDeepState):
     """Search API identifies top URLs."""
     settings = get_settings()
-    search = SearchProvider(api_key=settings.SERPER_API_KEY or "")
+    search = SearchProviderRegistry(settings=settings)
     all_urls = []
     for q in state.queries:
         links = await search.search(q, num_results=3)


### PR DESCRIPTION
### Motivation
- Replace the single hard-coded `SearchProvider` with a configurable registry to enable multiple search engines and failover.
- Provide per-provider quota tracking and round-robin/rotating selection to avoid exhausting third-party limits.
- Normalize and deduplicate returned URLs to remove tracking parameters and canonicalize schemes/hosts before crawling.
- Update research workflows to use the new registry so search orchestration can leverage multiple engines.

### Description
- Add `backend/core/search_provider.py` which implements `SearchProviderRegistry`, provider classes (`NativeSearchProvider`, `SerperSearchProvider`), URL `normalize_url` and `dedupe_urls`, and quota/rotation logic.
- Remove the old `SearchProvider` class from `backend/core/research_engine.py` and keep `ResearchEngine` focused on fetching and scraping.
- Update `backend/agents/shared/research_deep.py` and `backend/graphs/research_deep_advanced.py` to instantiate `SearchProviderRegistry` (via `SearchProviderRegistry(settings=settings)`) instead of the removed class.
- Add configuration entries to `backend/core/config.py` including `SEARCH_PROVIDER_ORDER`, `SEARCH_PROVIDER_QUOTAS`, and `SEARCH_PROVIDER_SETTINGS` (defaulting to `native` then `serper` with a Serper endpoint and quotas).

### Testing
- No automated tests were executed as part of this change.
- (No automated test failures reported because tests were not run.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cac07161083329a26844bcc8a3cb3)