### PR TITLE
Add budget governor and enforce budget gates across agents, tools, and orchestrator

### DIFF
--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from backend.inference import InferenceProvider
 from backend.models.cognitive import AgentMessage, CognitiveIntelligenceState
+from backend.services.budget_governor import BudgetGovernor
 
 logger = logging.getLogger("raptorflow.agents.base")
 
@@ -105,6 +106,26 @@ class BaseCognitiveAgent(ABC):
         Node execution logic with token tracking.
         """
         logger.info(f"Agent {self.name} ({self.role}) executing...")
+
+        if state.get("budget_caps") or state.get("budget_usage") or state.get(
+            "tool_usage"
+        ):
+            governor = BudgetGovernor()
+            decision = governor.evaluate(state, agent_id=self.name)
+            await governor.apply_decision(decision, agent_id=self.name)
+            if not decision.allowed:
+                logger.warning(
+                    f"Budget gate blocked agent {self.name}: {decision.reason}"
+                )
+                return {
+                    "messages": [
+                        AgentMessage(
+                            role=self.role,
+                            content=f"Budget gate blocked agent {self.name}: {decision.reason}",
+                        )
+                    ],
+                    "error": decision.reason,
+                }
 
         messages = self._format_messages(state.get("messages", []))
 

--- a/backend/models/cognitive.py
+++ b/backend/models/cognitive.py
@@ -7,6 +7,25 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class BudgetCaps(BaseModel):
+    """SOTA budget limits for agentic execution."""
+
+    token_cap: Optional[int] = None
+    tool_call_cap: Optional[int] = None
+    time_cap_seconds: Optional[int] = None
+    concurrency_cap: Optional[int] = None
+
+
+class BudgetUsage(BaseModel):
+    """Tracks budget consumption during a run."""
+
+    tokens_used: int = 0
+    tool_calls: int = 0
+    time_elapsed_seconds: float = 0.0
+    active_tool_calls: int = 0
+    started_at: Optional[datetime] = None
+
+
 class ModelTier(str, Enum):
     ULTRA = "ultra"
     SMART = "reasoning"
@@ -80,6 +99,9 @@ class CognitiveIntelligenceState(TypedDict):
     quality_score: float  # Aggregate quality 0-1
     cost_accumulator: float  # Estimated USD burn
     token_usage: Dict[str, int]  # Input/Output counts
+    tool_usage: Dict[str, int]
+    budget_caps: Optional[BudgetCaps]
+    budget_usage: Optional[BudgetUsage]
 
     # 6. Errors & Flow Control
     error: Optional[str]

--- a/backend/services/budget_governor.py
+++ b/backend/services/budget_governor.py
@@ -1,0 +1,167 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from backend.core.base_tool import RaptorRateLimiter
+from backend.services.matrix_service import MatrixService
+
+logger = logging.getLogger("raptorflow.services.budget_governor")
+
+
+@dataclass
+class BudgetDecision:
+    allowed: bool
+    action: str
+    reason: str
+    throttle_tpm: Optional[int] = None
+    throttle_delay_seconds: Optional[float] = None
+
+
+class BudgetGovernor:
+    """
+    SOTA Budget Governor.
+    Evaluates budget usage before agent/tool execution and enforces gates.
+    """
+
+    def __init__(
+        self,
+        warning_threshold: float = 0.8,
+        matrix_service: Optional[MatrixService] = None,
+    ):
+        self.warning_threshold = warning_threshold
+        self.matrix = matrix_service or MatrixService()
+
+    def _coerce_caps(self, caps: Any) -> Dict[str, Optional[int]]:
+        if caps is None:
+            return {}
+        if hasattr(caps, "model_dump"):
+            return caps.model_dump()
+        return dict(caps)
+
+    def _coerce_usage(self, usage: Any) -> Dict[str, Any]:
+        if usage is None:
+            return {}
+        if hasattr(usage, "model_dump"):
+            return usage.model_dump()
+        return dict(usage)
+
+    def _calculate_elapsed_seconds(self, usage: Dict[str, Any]) -> float:
+        started_at = usage.get("started_at")
+        if isinstance(started_at, str):
+            try:
+                started_at = datetime.fromisoformat(started_at)
+            except ValueError:
+                started_at = None
+        if isinstance(started_at, datetime):
+            return (datetime.now() - started_at).total_seconds()
+        return usage.get("time_elapsed_seconds", 0.0) or 0.0
+
+    def _usage_summary(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        token_usage = state.get("token_usage", {}) or {}
+        tool_usage = state.get("tool_usage", {}) or {}
+        usage = self._coerce_usage(state.get("budget_usage"))
+        tokens_used = usage.get("tokens_used", sum(token_usage.values()))
+        tool_calls = usage.get("tool_calls", sum(tool_usage.values()))
+        active_tool_calls = usage.get("active_tool_calls", 0)
+        elapsed_seconds = self._calculate_elapsed_seconds(usage)
+        return {
+            "tokens_used": tokens_used,
+            "tool_calls": tool_calls,
+            "active_tool_calls": active_tool_calls,
+            "time_elapsed_seconds": elapsed_seconds,
+        }
+
+    def evaluate(
+        self,
+        state: Dict[str, Any],
+        *,
+        agent_id: str,
+        tool_name: Optional[str] = None,
+        concurrency: Optional[int] = None,
+    ) -> BudgetDecision:
+        caps = self._coerce_caps(state.get("budget_caps"))
+        usage = self._usage_summary(state)
+        tokens_used = usage["tokens_used"]
+        tool_calls = usage["tool_calls"]
+        time_elapsed = usage["time_elapsed_seconds"]
+        active_tool_calls = concurrency or usage["active_tool_calls"]
+
+        token_cap = caps.get("token_cap")
+        tool_cap = caps.get("tool_call_cap")
+        time_cap = caps.get("time_cap_seconds")
+        concurrency_cap = caps.get("concurrency_cap")
+
+        if token_cap is not None and tokens_used >= token_cap:
+            return BudgetDecision(
+                allowed=False,
+                action="block",
+                reason=f"Token cap reached ({tokens_used}/{token_cap}).",
+            )
+
+        if tool_cap is not None and tool_calls >= tool_cap:
+            return BudgetDecision(
+                allowed=False,
+                action="block",
+                reason=f"Tool call cap reached ({tool_calls}/{tool_cap}).",
+            )
+
+        if time_cap is not None and time_elapsed >= time_cap:
+            return BudgetDecision(
+                allowed=False,
+                action="block",
+                reason=f"Time cap reached ({int(time_elapsed)}/{time_cap}s).",
+            )
+
+        if concurrency_cap is not None and active_tool_calls >= concurrency_cap:
+            return BudgetDecision(
+                allowed=False,
+                action="reroute",
+                reason=f"Concurrency cap reached ({active_tool_calls}/{concurrency_cap}).",
+            )
+
+        should_throttle = False
+        throttle_reason = None
+        if token_cap is not None and tokens_used >= token_cap * self.warning_threshold:
+            should_throttle = True
+            throttle_reason = "Token usage nearing cap."
+        if tool_cap is not None and tool_calls >= tool_cap * self.warning_threshold:
+            should_throttle = True
+            throttle_reason = throttle_reason or "Tool usage nearing cap."
+        if time_cap is not None and time_elapsed >= time_cap * self.warning_threshold:
+            should_throttle = True
+            throttle_reason = throttle_reason or "Time usage nearing cap."
+
+        if should_throttle:
+            return BudgetDecision(
+                allowed=True,
+                action="throttle",
+                reason=throttle_reason or "Budget nearing cap.",
+                throttle_tpm=500,
+                throttle_delay_seconds=1.0,
+            )
+
+        return BudgetDecision(allowed=True, action="allow", reason="Within budget.")
+
+    async def apply_decision(self, decision: BudgetDecision, *, agent_id: str) -> None:
+        if decision.action == "throttle":
+            RaptorRateLimiter.apply_budget_throttle(
+                decision.throttle_delay_seconds or 0.0,
+                decision.reason,
+            )
+            try:
+                await self.matrix.execute_skill(
+                    "inference_throttling",
+                    {
+                        "agent_id": agent_id,
+                        "tpm_limit": decision.throttle_tpm or 500,
+                    },
+                )
+            except Exception as exc:
+                logger.warning(f"Budget throttle skill failed: {exc}")
+        elif decision.action in {"block", "reroute"}:
+            RaptorRateLimiter.apply_budget_throttle(0.0, decision.reason, blocked=True)
+
+        if decision.action == "allow":
+            RaptorRateLimiter.clear_budget_throttle()
+


### PR DESCRIPTION
### Motivation

- Introduce runtime budget enforcement to limit token spend, tool calls, execution time, and concurrency for agentic workloads. 
- Provide a centralized decision point that can throttle, block, or reroute agent/tool calls when budgets are near or exceed configured caps. 
- Integrate budget decisions with existing throttling and matrix skills to enable programmatic enforcement and operational observability. 
- Short-circuit or re-route orchestrator nodes when a workspace/run breaches budget constraints to avoid runaway cost.

### Description

- Added `BudgetCaps` and `BudgetUsage` models and extended `CognitiveIntelligenceState` with `tool_usage`, `budget_caps`, and `budget_usage` in `backend/models/cognitive.py`.
- Implemented `BudgetGovernor` and `BudgetDecision` in `backend/services/budget_governor.py`, which evaluates state-based usage vs caps and returns actions (`allow`, `throttle`, `block`, `reroute`).
- Extended `RaptorRateLimiter` in `backend/core/base_tool.py` with budget throttle state and `wait_if_throttled` logic, and wired throttle checks into `BaseRaptorTool.run` so tool calls can be delayed or blocked.
- Integrated budget gating in agent/tool paths: added pre-call checks in `BaseCognitiveAgent.__call__` (`backend/agents/base.py`) and in the `SkillExecutor` flow in `backend/agents/moves.py` to consult the governor and update `tool_usage`/`budget_usage` counters.
- Added `_budget_gate` to the moves orchestrator (`backend/graphs/moves_campaigns_orchestrator.py`) and inserted gate checks in key nodes (`plan_campaign`, `campaign_auditor`, `generate_moves`, `refine_moves`, `execute_skills`, `kpi_setter`) so the graph can short-circuit to `budget_exceeded` and stop or throttle execution.
- Budget actions are applied via `RaptorRateLimiter` and by invoking the existing `inference_throttling` Matrix skill through `MatrixService` to persist throttling keys.

### Testing

- No automated tests were executed as part of this change.
- Recommend running the unit test suite, especially `backend/tests/test_agent_token_tracking.py`, `backend/tests/test_swarm_state.py`, and matrix/skill-related tests after integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cafe9a75483329cd1c2375a8f5aa0)