### PR TITLE
Consolidate tools and skills into unified registry with capability metadata and RBAC

### DIFF
--- a/backend/agents/specialists/image_generator.py
+++ b/backend/agents/specialists/image_generator.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 from backend.agents.base import BaseCognitiveAgent
 from backend.core.prompts import CreativePrompts
 from backend.models.cognitive import CognitiveIntelligenceState
-from backend.tools.image_gen import DalleTool
 
 logger = logging.getLogger("raptorflow.agents.image_generator")
 
@@ -27,12 +26,16 @@ class ImageGenAgent(BaseCognitiveAgent):
     """
 
     def __init__(self):
+        from backend.tools.registry import UnifiedToolRegistry
+
+        registry = UnifiedToolRegistry.default()
+        profiles = registry.get_capability_profiles(["image_gen_dalle"])
         super().__init__(
             name="ImageGenerator",
             role="creator",
             system_prompt=CreativePrompts.VISUAL_ARCHITECT,
             model_tier="driver",
-            tools=[DalleTool()],
+            tools=registry.resolve_tools_from_profiles(profiles),
             output_schema=ImageOutput,
         )
 

--- a/backend/agents/specialists/researcher.py
+++ b/backend/agents/specialists/researcher.py
@@ -38,14 +38,16 @@ class ResearcherAgent(BaseCognitiveAgent):
 
     def __init__(self):
         from backend.core.prompts import ResearchPrompts
-        from backend.tools.search import TavilyMultiHopTool
+        from backend.tools.registry import UnifiedToolRegistry
 
+        registry = UnifiedToolRegistry.default()
+        profiles = registry.get_capability_profiles(["tavily_search"])
         super().__init__(
             name="Researcher",
             role="researcher",
             system_prompt=ResearchPrompts.TREND_EXTRACTOR,
             model_tier="reasoning",  # Researchers need high reasoning
-            tools=[TavilyMultiHopTool()],
+            tools=registry.resolve_tools_from_profiles(profiles),
             output_schema=ResearchOutput,
         )
 

--- a/backend/tools/image_gen.py
+++ b/backend/tools/image_gen.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict
 
-from backend.core.base_tool import RaptorRateLimiter
+from backend.core.base_tool import BaseRaptorTool, RaptorRateLimiter
 from backend.core.config import get_settings
 
 logger = logging.getLogger("raptorflow.tools.image_gen")
@@ -48,6 +48,29 @@ class ImageGenerator:
             "revised_prompt": revised_prompt,
             "model": "dall-e-3",
         }
+
+
+class DalleTool(BaseRaptorTool):
+    """
+    Adapter for DALL-E 3 generation with the BaseRaptorTool interface.
+    """
+
+    def __init__(self):
+        self._generator = ImageGenerator()
+
+    @property
+    def name(self) -> str:
+        return self._generator.name
+
+    @property
+    def description(self) -> str:
+        return self._generator.description
+
+    @RaptorRateLimiter.get_retry_decorator()
+    async def _execute(
+        self, prompt: str, size: str = "1024x1024", quality: str = "standard"
+    ) -> Dict[str, Any]:
+        return await self._generator._execute(prompt, size=size, quality=quality)
 
 
 class NanoBananaImageTool:

--- a/backend/tools/registry.py
+++ b/backend/tools/registry.py
@@ -1,0 +1,240 @@
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, List, Optional, Sequence, Union
+
+from backend.core.base_tool import BaseRaptorTool
+from backend.skills.matrix_skills import (
+    MatrixSkill,
+    SkillPrivilegeMatrix,
+    ToolExecutionWrapper,
+    UserRole,
+)
+
+logger = logging.getLogger("raptorflow.tools.registry")
+
+
+class ToolKind(str, Enum):
+    TOOL = "tool"
+    SKILL = "skill"
+
+
+@dataclass(frozen=True)
+class CapabilityDescriptor:
+    cost: str
+    latency_ms: int
+    reliability: float
+    permissions: Sequence[str]
+
+
+@dataclass(frozen=True)
+class CapabilityProfile:
+    name: str
+    description: str
+    kind: ToolKind
+    cost: str
+    latency_ms: int
+    reliability: float
+    permissions: Sequence[str]
+
+
+@dataclass
+class RegistryEntry:
+    name: str
+    description: str
+    kind: ToolKind
+    implementation: Union[BaseRaptorTool, MatrixSkill]
+    descriptor: CapabilityDescriptor
+
+
+class SkillToolAdapter:
+    """
+    Adapter that exposes Matrix skills with a BaseRaptorTool-like run interface.
+    """
+
+    def __init__(self, skill: MatrixSkill, description: str):
+        self._skill = skill
+        self._description = description
+        self._wrapper = ToolExecutionWrapper(skill)
+
+    @property
+    def name(self) -> str:
+        return self._skill.name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    async def run(self, **kwargs):
+        return await self._wrapper.execute(kwargs)
+
+
+class UnifiedToolRegistry:
+    """
+    Unified registry for BaseRaptorTool tools and Matrix skills with capability metadata.
+    """
+
+    _default_instance: Optional["UnifiedToolRegistry"] = None
+
+    def __init__(self, rbac: Optional[SkillPrivilegeMatrix] = None):
+        self._rbac = rbac or SkillPrivilegeMatrix()
+        self._entries: Dict[str, RegistryEntry] = {}
+
+    @classmethod
+    def default(cls) -> "UnifiedToolRegistry":
+        if cls._default_instance is None:
+            registry = cls()
+            registry._register_default_tools()
+            cls._default_instance = registry
+        return cls._default_instance
+
+    def _register_default_tools(self) -> None:
+        from backend.tools.image_gen import DalleTool
+        from backend.tools.search import (
+            PerplexitySearchTool,
+            RaptorSearchTool,
+            TavilyMultiHopTool,
+        )
+
+        self.register_tool(
+            RaptorSearchTool(),
+            CapabilityDescriptor(
+                cost="low",
+                latency_ms=800,
+                reliability=0.9,
+                permissions=self._all_role_permissions(),
+            ),
+        )
+        self.register_tool(
+            TavilyMultiHopTool(),
+            CapabilityDescriptor(
+                cost="medium",
+                latency_ms=1200,
+                reliability=0.88,
+                permissions=self._all_role_permissions(),
+            ),
+        )
+        self.register_tool(
+            PerplexitySearchTool(),
+            CapabilityDescriptor(
+                cost="medium",
+                latency_ms=1100,
+                reliability=0.87,
+                permissions=self._all_role_permissions(),
+            ),
+        )
+        self.register_tool(
+            DalleTool(),
+            CapabilityDescriptor(
+                cost="high",
+                latency_ms=2500,
+                reliability=0.92,
+                permissions=self._all_role_permissions(),
+            ),
+        )
+
+    def register_tool(self, tool: BaseRaptorTool, descriptor: CapabilityDescriptor) -> None:
+        logger.info("Registering tool %s", tool.name)
+        self._entries[tool.name] = RegistryEntry(
+            name=tool.name,
+            description=tool.description,
+            kind=ToolKind.TOOL,
+            implementation=tool,
+            descriptor=descriptor,
+        )
+
+    def register_skill(
+        self,
+        skill: MatrixSkill,
+        descriptor: Optional[CapabilityDescriptor] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        logger.info("Registering matrix skill %s", skill.name)
+        permissions = (
+            descriptor.permissions if descriptor else self._skill_permissions(skill.name)
+        )
+        descriptor = descriptor or CapabilityDescriptor(
+            cost="low",
+            latency_ms=500,
+            reliability=0.95,
+            permissions=permissions,
+        )
+        skill_description = description or (skill.__doc__ or "Matrix skill")
+        self._entries[skill.name] = RegistryEntry(
+            name=skill.name,
+            description=skill_description.strip(),
+            kind=ToolKind.SKILL,
+            implementation=skill,
+            descriptor=descriptor,
+        )
+
+    def get_capability_profile(
+        self, name: str, role: Optional[UserRole] = None
+    ) -> Optional[CapabilityProfile]:
+        entry = self._entries.get(name)
+        if not entry:
+            return None
+        if entry.kind == ToolKind.SKILL and role is not None:
+            self._enforce_rbac(role, entry.name)
+        return CapabilityProfile(
+            name=entry.name,
+            description=entry.description,
+            kind=entry.kind,
+            cost=entry.descriptor.cost,
+            latency_ms=entry.descriptor.latency_ms,
+            reliability=entry.descriptor.reliability,
+            permissions=entry.descriptor.permissions,
+        )
+
+    def get_capability_profiles(
+        self, names: Iterable[str], role: Optional[UserRole] = None
+    ) -> List[CapabilityProfile]:
+        profiles = []
+        for name in names:
+            profile = self.get_capability_profile(name, role=role)
+            if profile:
+                profiles.append(profile)
+        return profiles
+
+    def list_capability_profiles(
+        self, role: Optional[UserRole] = None
+    ) -> List[CapabilityProfile]:
+        profiles = []
+        for name in self._entries:
+            profile = self.get_capability_profile(name, role=role)
+            if profile:
+                profiles.append(profile)
+        return profiles
+
+    def resolve_tools_from_profiles(
+        self, profiles: Sequence[CapabilityProfile], role: Optional[UserRole] = None
+    ) -> List[Union[BaseRaptorTool, SkillToolAdapter]]:
+        tools: List[Union[BaseRaptorTool, SkillToolAdapter]] = []
+        for profile in profiles:
+            entry = self._entries.get(profile.name)
+            if not entry:
+                continue
+            if entry.kind == ToolKind.SKILL and role is not None:
+                self._enforce_rbac(role, entry.name)
+            if entry.kind == ToolKind.SKILL:
+                tools.append(SkillToolAdapter(entry.implementation, entry.description))
+            else:
+                tools.append(entry.implementation)
+        return tools
+
+    def _enforce_rbac(self, role: UserRole, skill_name: str) -> None:
+        if not self._rbac.has_permission(role, skill_name):
+            raise PermissionError(
+                f"Role '{role.value}' does not have access to skill '{skill_name}'."
+            )
+
+    def _skill_permissions(self, skill_name: str) -> List[str]:
+        return [
+            role.value
+            for role in UserRole
+            if self._rbac.has_permission(role, skill_name)
+        ]
+
+    @staticmethod
+    def _all_role_permissions() -> List[str]:
+        return [role.value for role in UserRole]


### PR DESCRIPTION
### Motivation
- Consolidate separate tool and skill implementations into a single discovery surface so agents can request capabilities instead of hard-coded tool instances.
- Expose standardized capability metadata (cost, latency, reliability, permissions) to enable capability-aware tool selection and orchestration.
- Replace per-agent hard-coded tool lists with a profile-based resolution so runtime composition is simpler and consistent.
- Enforce RBAC from the existing `SkillPrivilegeMatrix` at the registry layer to centralize permission checks for Matrix skills.

### Description
- Add a new unified registry at `backend/tools/registry.py` implementing `UnifiedToolRegistry`, `CapabilityDescriptor`/`CapabilityProfile`, `RegistryEntry`, and `SkillToolAdapter` to normalize `BaseRaptorTool` and `MatrixSkill` interfaces.
- Wire RBAC enforcement into the registry by consulting `SkillPrivilegeMatrix` and raising `PermissionError` when a role lacks access to a skill via `UnifiedToolRegistry._enforce_rbac`.
- Register default tools (search variants and DALL·E adapter) in the registry and add a `DalleTool` adapter in `backend/tools/image_gen.py` that implements the `BaseRaptorTool` interface.
- Update specialist agents (`backend/agents/specialists/researcher.py` and `backend/agents/specialists/image_generator.py`) to obtain capability profiles via `UnifiedToolRegistry.default().get_capability_profiles(...)` and convert them to runnable tools with `resolve_tools_from_profiles`.

### Testing
- No automated tests were executed as part of this change.
- Local static inspection and import checks were used during development (no failures reported).
- Existing unit tests in the repository were not modified or executed by this PR.
- Manual validation consisted of ensuring agents now resolve tools through `UnifiedToolRegistry` without altering agent behavior logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cafe797708332ae7e2035ddef8d35)