### PR TITLE
Add Swarm Learning Memory layer and broadcast reflections to shared ledger

### DIFF
--- a/backend/agents/memory_updater.py
+++ b/backend/agents/memory_updater.py
@@ -4,6 +4,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
 from backend.inference import InferenceProvider
+from backend.memory.swarm_learning import SwarmLearningMemory
 
 
 class StylePreference(BaseModel):
@@ -21,7 +22,12 @@ class MemoryUpdaterAgent:
         ).with_structured_output(StylePreference)
 
     async def learn_from_edit(
-        self, draft: str, final: str
+        self,
+        draft: str,
+        final: str,
+        workspace_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        swarm_scope: Optional[str] = None,
     ) -> Optional[StylePreference]:
         # SOTA Technique: Delta Analysis
         # Compare AI draft vs User's final version to extract style rules.
@@ -37,4 +43,20 @@ class MemoryUpdaterAgent:
         )
 
         comparison = f"DRAFT: {draft}\nFINAL: {final}"
-        return await self.llm.ainvoke([system_msg, HumanMessage(content=comparison)])
+        preference = await self.llm.ainvoke(
+            [system_msg, HumanMessage(content=comparison)]
+        )
+
+        if preference and workspace_id:
+            swarm_memory = SwarmLearningMemory()
+            await swarm_memory.record_learning(
+                workspace_id=workspace_id,
+                content=f"{preference.key}: {preference.value}",
+                source="user_feedback",
+                confidence=preference.confidence,
+                agent_id=agent_id,
+                swarm_scope=swarm_scope,
+                metadata={"preference_key": preference.key},
+            )
+
+        return preference

--- a/backend/memory/swarm_learning.py
+++ b/backend/memory/swarm_learning.py
@@ -1,0 +1,185 @@
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+from backend.db import save_memory, vector_search
+from backend.inference import InferenceProvider
+from backend.memory.episodic_l2 import L2EpisodicMemory
+from backend.memory.short_term import L1ShortTermMemory
+
+logger = logging.getLogger("raptorflow.memory.swarm_learning")
+
+
+class SwarmLearningMemory:
+    """
+    Swarm Learning Memory layer.
+    Sits above MemoryManager and standardizes how agents write/read shared learnings.
+    Aggregates L1/L2/L3 tiers alongside a shared learning ledger.
+    """
+
+    L2_CONFIDENCE_THRESHOLD = 0.7
+    L3_CONFIDENCE_THRESHOLD = 0.85
+
+    L2_SOURCES = {"high_confidence_outcome", "user_feedback", "verified_research"}
+    L3_SOURCES = {"verified_research"}
+
+    def __init__(self, table: str = "muse_assets"):
+        self.l1 = L1ShortTermMemory()
+        self.l2 = L2EpisodicMemory(table=table)
+        self.table = table
+        self.ledger_ttl = 3600 * 24 * 7
+        self.max_ledger_entries = 200
+
+    def _normalize_scope(self, swarm_scope: Optional[str]) -> str:
+        return swarm_scope or "workspace"
+
+    def _ledger_key(self, workspace_id: str, swarm_scope: Optional[str]) -> str:
+        scope = self._normalize_scope(swarm_scope)
+        return f"swarm_learning:{scope}:{workspace_id}:ledger"
+
+    def _promotion_policy(
+        self, source: str, confidence: float, metadata: Dict[str, Any]
+    ) -> Tuple[bool, bool]:
+        """Determines whether a learning should be promoted to L2 or L3."""
+        promote_l2 = (
+            source in self.L2_SOURCES and confidence >= self.L2_CONFIDENCE_THRESHOLD
+        ) or metadata.get("user_feedback", False)
+        promote_l3 = (
+            source in self.L3_SOURCES and confidence >= self.L3_CONFIDENCE_THRESHOLD
+        ) or metadata.get("verified", False)
+        return promote_l2, promote_l3
+
+    async def record_learning(
+        self,
+        workspace_id: str,
+        content: str,
+        source: str,
+        confidence: float,
+        agent_id: Optional[str] = None,
+        swarm_scope: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Writes a learning artifact to the shared ledger and promotes it as needed."""
+        if metadata is None:
+            metadata = {}
+
+        entry = {
+            "id": str(uuid4()),
+            "content": content,
+            "source": source,
+            "confidence": confidence,
+            "agent_id": agent_id,
+            "metadata": metadata,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "swarm_scope": self._normalize_scope(swarm_scope),
+        }
+
+        await self._append_ledger_entry(workspace_id, entry, swarm_scope)
+
+        promote_l2, promote_l3 = self._promotion_policy(source, confidence, metadata)
+
+        try:
+            embedder = InferenceProvider.get_embeddings()
+            if promote_l2:
+                embedding = await embedder.aembed_query(content)
+                await self.l2.store_episode(
+                    workspace_id=workspace_id,
+                    content=content,
+                    embedding=embedding,
+                    metadata={
+                        "subtype": "learning",
+                        "source": source,
+                        "confidence": confidence,
+                        "agent_id": agent_id,
+                        "ledger_id": entry["id"],
+                        "swarm_scope": entry["swarm_scope"],
+                    },
+                )
+
+            if promote_l3:
+                embedding = await embedder.aembed_query(content)
+                await save_memory(
+                    workspace_id=workspace_id,
+                    content=content,
+                    embedding=embedding,
+                    memory_type="semantic",
+                    metadata={
+                        "type": "learning",
+                        "source": source,
+                        "confidence": confidence,
+                        "agent_id": agent_id,
+                        "ledger_id": entry["id"],
+                        "swarm_scope": entry["swarm_scope"],
+                    },
+                )
+        except Exception as exc:
+            logger.error(f"Swarm learning promotion failed: {exc}")
+
+        return entry
+
+    async def _append_ledger_entry(
+        self, workspace_id: str, entry: Dict[str, Any], swarm_scope: Optional[str]
+    ) -> None:
+        key = self._ledger_key(workspace_id, swarm_scope)
+        ledger_entries = await self.l1.retrieve(key) or []
+        ledger_entries.append(entry)
+        ledger_entries = ledger_entries[-self.max_ledger_entries :]
+        await self.l1.store(key, ledger_entries, ttl=self.ledger_ttl)
+
+    async def retrieve_swarm_context(
+        self,
+        workspace_id: str,
+        query: str,
+        swarm_scope: Optional[str] = None,
+        limit: int = 3,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Returns cross-agent learnings from ledger, L2, and L3."""
+        scope = self._normalize_scope(swarm_scope)
+        results = {"ledger": [], "episodic": [], "semantic": []}
+
+        try:
+            ledger_entries = await self.l1.retrieve(
+                self._ledger_key(workspace_id, scope)
+            )
+            if ledger_entries:
+                results["ledger"] = self._filter_ledger(ledger_entries, query, limit)
+
+            embedder = InferenceProvider.get_embeddings()
+            query_embedding = await embedder.aembed_query(query)
+
+            results["episodic"] = await self.l2.recall_similar(
+                workspace_id,
+                query_embedding,
+                limit=limit,
+                filters={"subtype": "learning", "swarm_scope": scope},
+            )
+
+            raw_results = await vector_search(
+                workspace_id=workspace_id,
+                embedding=query_embedding,
+                table=self.table,
+                limit=limit,
+                filters={"type": "learning", "swarm_scope": scope},
+            )
+            results["semantic"] = [
+                {"id": r[0], "content": r[1], "metadata": r[2], "similarity": r[3]}
+                for r in raw_results
+            ]
+        except Exception as exc:
+            logger.error(f"Swarm learning retrieval failed: {exc}")
+
+        return results
+
+    def _filter_ledger(
+        self, entries: List[Dict[str, Any]], query: str, limit: int
+    ) -> List[Dict[str, Any]]:
+        query_lower = query.lower()
+        filtered = [
+            entry
+            for entry in entries
+            if query_lower in str(entry.get("content", "")).lower()
+        ]
+        if not filtered:
+            filtered = entries
+        return filtered[-limit:]

--- a/backend/tests/test_memory_reflection.py
+++ b/backend/tests/test_memory_reflection.py
@@ -32,8 +32,12 @@ async def test_memory_reflection_summarize_daily():
     )
     mock_llm.with_structured_output.return_value = mock_chain
 
-    with patch("backend.agents.memory_reflection.InferenceProvider") as mock_inference:
+    with patch("backend.agents.memory_reflection.InferenceProvider") as mock_inference, patch(
+        "backend.agents.memory_reflection.SwarmLearningMemory"
+    ) as mock_swarm_memory:
         mock_inference.get_model.return_value = mock_llm
+        mock_swarm_instance = mock_swarm_memory.return_value
+        mock_swarm_instance.record_learning = AsyncMock()
 
         agent = MemoryReflectionAgent()
         traces = [
@@ -46,3 +50,4 @@ async def test_memory_reflection_summarize_daily():
         assert "Busy day" in result["summary"]
         assert len(result["learnings"]) > 0
         mock_chain.ainvoke.assert_called_once()
+        mock_swarm_instance.record_learning.assert_called()


### PR DESCRIPTION
### Motivation
- Standardize cross-agent learning by introducing a Swarm Learning layer that aggregates L1/L2/L3 plus a shared learning ledger.
- Provide a clear promotion policy for what artifacts should be promoted from short-term to episodic (`L2`) and semantic (`L3`) storage.
- Ensure agents like the memory updater and reflection agent broadcast learned artifacts so learnings can be shared across agents.
- Expose swarm-scoped retrieval so `MemoryManager` can return cross-agent learnings alongside agent-local context.

### Description
- Added `backend/memory/swarm_learning.py` implementing `SwarmLearningMemory` with a Redis-backed ledger, `record_learning`, promotion rules, and `retrieve_swarm_context` that queries ledger, L2 (`pgvector`) and L3 (`semantic`) stores.
- Extended `MemoryManager.retrieve_context` to accept a `swarm_scope` parameter and include `swarm_learnings` when provided by calling `SwarmLearningMemory.retrieve_swarm_context`.
- Updated `backend/agents/memory_updater.py` to accept `workspace_id`, `agent_id`, and `swarm_scope` and persist style preferences via `SwarmLearningMemory.record_learning` after extraction.
- Updated `backend/agents/memory_reflection.py` to accept `swarm_scope` and broadcast reflection `learnings` into the swarm ledger via `SwarmLearningMemory.record_learning`, and adjusted `backend/tests/test_memory_reflection.py` to mock and assert the ledger broadcast.

### Testing
- Updated unit test `backend/tests/test_memory_reflection.py` to expect `SwarmLearningMemory.record_learning` is invoked by the reflection flow.
- No automated test suite was executed as part of this rollout, so no pass/fail status is reported for CI.
- Existing memory manager unit tests were not modified or run in this change set.
- Manual/static verification was used to ensure imports and function calls align with the new `SwarmLearningMemory` API.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cafe63d788332b3dd0ad98a51a454)