### PR TITLE
Add shared memory retention policy and apply across L1/L2/L3/pruning

### DIFF
--- a/backend/memory/policy.py
+++ b/backend/memory/policy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+DEFAULT_IMPORTANCE = "standard"
+
+
+@dataclass(frozen=True)
+class RetentionRule:
+    max_items: int
+    max_tokens: int
+    ttl_seconds: int
+    retention_days: int
+    recall_limit: int
+
+    def combine(self, other: "RetentionRule") -> "RetentionRule":
+        return RetentionRule(
+            max_items=max(self.max_items, other.max_items),
+            max_tokens=max(self.max_tokens, other.max_tokens),
+            ttl_seconds=max(self.ttl_seconds, other.ttl_seconds),
+            retention_days=max(self.retention_days, other.retention_days),
+            recall_limit=max(self.recall_limit, other.recall_limit),
+        )
+
+
+IMPORTANCE_RULES: Dict[str, RetentionRule] = {
+    "low": RetentionRule(
+        max_items=10, max_tokens=2000, ttl_seconds=1800, retention_days=30, recall_limit=3
+    ),
+    "standard": RetentionRule(
+        max_items=20, max_tokens=4000, ttl_seconds=3600, retention_days=90, recall_limit=5
+    ),
+    "high": RetentionRule(
+        max_items=40, max_tokens=8000, ttl_seconds=7200, retention_days=180, recall_limit=8
+    ),
+    "critical": RetentionRule(
+        max_items=60,
+        max_tokens=12000,
+        ttl_seconds=14400,
+        retention_days=365,
+        recall_limit=12,
+    ),
+}
+
+
+class MemoryPolicy:
+    """Shared memory policy keyed by workspace and agent importance."""
+
+    def __init__(self, importance_rules: Dict[str, RetentionRule] | None = None):
+        self.importance_rules = importance_rules or IMPORTANCE_RULES
+
+    def resolve(
+        self,
+        workspace_importance: str = DEFAULT_IMPORTANCE,
+        agent_importance: str = DEFAULT_IMPORTANCE,
+    ) -> RetentionRule:
+        workspace_rule = self.importance_rules.get(
+            workspace_importance, self.importance_rules[DEFAULT_IMPORTANCE]
+        )
+        agent_rule = self.importance_rules.get(
+            agent_importance, self.importance_rules[DEFAULT_IMPORTANCE]
+        )
+        return workspace_rule.combine(agent_rule)
+
+    def retention_metadata(
+        self, workspace_importance: str, agent_importance: str
+    ) -> Dict[str, str | int]:
+        rule = self.resolve(workspace_importance, agent_importance)
+        return {
+            "workspace_importance": workspace_importance,
+            "agent_importance": agent_importance,
+            "retention_days": rule.retention_days,
+        }
+
+
+_POLICY = MemoryPolicy()
+
+
+def get_memory_policy() -> MemoryPolicy:
+    return _POLICY

--- a/backend/memory/pruning.py
+++ b/backend/memory/pruning.py
@@ -1,12 +1,19 @@
 from typing import Any, List
 
+from backend.memory.policy import DEFAULT_IMPORTANCE, get_memory_policy
+
 
 def count_tokens_heuristic(text: str) -> int:
     """SOTA Heuristic for token counting (approx 4 chars per token)."""
     return len(text) // 4
 
 
-def prune_context(context: List[str], max_tokens: int = 4000) -> List[str]:
+def prune_context(
+    context: List[str],
+    max_tokens: int | None = None,
+    workspace_importance: str = DEFAULT_IMPORTANCE,
+    agent_importance: str = DEFAULT_IMPORTANCE,
+) -> List[str]:
     """
     SOTA Context Pruning (Taulli Pattern).
     Ensures that the total business context fits within the LLM's surgical window.
@@ -14,6 +21,10 @@ def prune_context(context: List[str], max_tokens: int = 4000) -> List[str]:
     """
     if not context:
         return []
+
+    if max_tokens is None:
+        policy = get_memory_policy()
+        max_tokens = policy.resolve(workspace_importance, agent_importance).max_tokens
 
     pruned_list = []
     current_tokens = 0
@@ -37,9 +48,17 @@ class MemoryDecayPolicy:
     Supports count-based and token-based decay.
     """
 
-    def __init__(self, max_items: int = 20, max_tokens: int = 4000):
-        self.max_items = max_items
-        self.max_tokens = max_tokens
+    def __init__(
+        self,
+        max_items: int | None = None,
+        max_tokens: int | None = None,
+        workspace_importance: str = DEFAULT_IMPORTANCE,
+        agent_importance: str = DEFAULT_IMPORTANCE,
+    ):
+        policy = get_memory_policy()
+        rule = policy.resolve(workspace_importance, agent_importance)
+        self.max_items = rule.max_items if max_items is None else max_items
+        self.max_tokens = rule.max_tokens if max_tokens is None else max_tokens
 
     def prune_by_count(self, items: List[Any]) -> List[Any]:
         """Prunes a list of items to fit within max_items, keeping the newest."""


### PR DESCRIPTION
### Motivation
- Introduce a single, shared configuration for memory retention to standardize TTLs, token/item limits, and recall behavior across tiers.
- Allow retention to be driven by workspace and agent importance levels so more critical data is kept longer and recalled more widely.
- Reduce duplicated hard-coded values in pruning and memory tier implementations.

### Description
- Add `backend/memory/policy.py` with `RetentionRule`, `MemoryPolicy`, default `IMPORTANCE_RULES`, and `get_memory_policy()` to expose policy resolution by workspace/agent importance.
- Wire the policy into pruning by updating `prune_context()` and `MemoryDecayPolicy` in `backend/memory/pruning.py` to resolve `max_tokens`/`max_items` from the policy and accept importance parameters.
- Use policy defaults in L1 short-term storage by updating `L1ShortTermMemory.store()` in `backend/memory/short_term.py` to derive `ttl` from the policy when not provided.
- Persist retention metadata and policy-based recall limits in L2/L3 by updating `store_episode()`/`recall_similar()` in `backend/memory/episodic_l2.py` and `search_foundation()`/`remember_foundation()` in `backend/memory/semantic_l3.py` to accept importance parameters and include policy metadata/limits.

### Testing
- No automated tests were executed as part of this change.
- Existing tests in the repository were not modified by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1d776ac833291213d7ace12dc43)