### PR TITLE
Add SwarmHealthService, record tool executions, expose API + frontend hook

### DIFF
--- a/backend/api/v1/matrix.py
+++ b/backend/api/v1/matrix.py
@@ -7,6 +7,7 @@ from backend.core.auth import get_current_user
 from backend.services.cost_governor import CostGovernor
 from backend.services.drift_detection import DriftDetectionService
 from backend.services.matrix_service import MatrixService
+from backend.services.swarm_health import SwarmHealthService
 
 router = APIRouter(prefix="/v1/matrix", tags=["matrix"])
 
@@ -14,6 +15,11 @@ router = APIRouter(prefix="/v1/matrix", tags=["matrix"])
 def get_matrix_service():
     """Dependency provider for MatrixService."""
     return MatrixService()
+
+
+def get_swarm_health_service():
+    """Dependency provider for SwarmHealthService."""
+    return SwarmHealthService()
 
 
 @router.get("/overview")
@@ -24,6 +30,16 @@ async def get_overview(
 ):
     """Retrieves the aggregated health dashboard for the entire ecosystem."""
     return await service.get_aggregated_overview(workspace_id)
+
+
+@router.get("/swarm-health")
+async def get_swarm_health(
+    workspace_id: str | None = None,
+    _current_user: dict = Depends(get_current_user),
+    service: SwarmHealthService = Depends(get_swarm_health_service),
+):
+    """Retrieves swarm health metrics for operational dashboards."""
+    return await service.get_health(workspace_id)
 
 
 @router.post("/kill-switch")

--- a/backend/services/swarm_health.py
+++ b/backend/services/swarm_health.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from backend.core.cache import CacheManager, get_cache_manager
+from backend.services.cost_governor import CostGovernor
+
+
+class SwarmHealthService:
+    """
+    Computes swarm health metrics for operational monitoring.
+
+    Tracks tool failure rates, budget overruns, and queue backlog.
+    """
+
+    TOOL_STATS_KEY = "swarm:tool_stats"
+    QUEUE_BACKLOG_KEY = "swarm:queue_backlog"
+
+    def __init__(
+        self,
+        cache_manager: Optional[CacheManager] = None,
+        cost_governor: Optional[CostGovernor] = None,
+    ) -> None:
+        self._cache = cache_manager or get_cache_manager()
+        self._cost = cost_governor or CostGovernor()
+
+    def record_tool_execution(self, tool_name: str, success: bool) -> None:
+        """Records a single tool execution outcome for failure-rate tracking."""
+        if not tool_name:
+            return
+
+        stats = self._cache.get_json(self.TOOL_STATS_KEY) or {"tools": {}}
+        tools = stats.get("tools", {})
+        entry = tools.get(tool_name, {"success": 0, "failure": 0})
+
+        if success:
+            entry["success"] = int(entry.get("success", 0)) + 1
+        else:
+            entry["failure"] = int(entry.get("failure", 0)) + 1
+
+        entry["last_seen"] = datetime.now().isoformat()
+        tools[tool_name] = entry
+        stats["tools"] = tools
+        stats["updated_at"] = datetime.now().isoformat()
+
+        self._cache.set_json(self.TOOL_STATS_KEY, stats, expiry_seconds=86400)
+
+    def record_queue_backlog(self, pending: int) -> None:
+        """Records the current backlog size for agent queueing systems."""
+        pending_count = max(int(pending), 0)
+        payload = {
+            "pending": pending_count,
+            "updated_at": datetime.now().isoformat(),
+        }
+        self._cache.set_json(self.QUEUE_BACKLOG_KEY, payload, expiry_seconds=600)
+
+    def get_queue_backlog(self) -> Dict[str, Any]:
+        """Returns the latest queued task backlog metrics."""
+        payload = self._cache.get_json(self.QUEUE_BACKLOG_KEY) or {}
+        pending = int(payload.get("pending", 0))
+
+        if pending == 0:
+            status = "clear"
+        elif pending < 50:
+            status = "backlogged"
+        else:
+            status = "overloaded"
+
+        return {
+            "pending": pending,
+            "status": status,
+            "updated_at": payload.get("updated_at"),
+        }
+
+    def get_tool_failure_rates(self) -> Dict[str, Any]:
+        """Calculates failure rates by tool and overall."""
+        stats = self._cache.get_json(self.TOOL_STATS_KEY) or {"tools": {}}
+        tools = stats.get("tools", {})
+
+        tool_rates: Dict[str, Any] = {}
+        total_success = 0
+        total_failure = 0
+
+        for name, entry in tools.items():
+            success = int(entry.get("success", 0))
+            failure = int(entry.get("failure", 0))
+            total = success + failure
+            failure_rate = (failure / total) if total else 0.0
+
+            tool_rates[name] = {
+                "success": success,
+                "failure": failure,
+                "total": total,
+                "failure_rate": failure_rate,
+                "last_seen": entry.get("last_seen"),
+            }
+
+            total_success += success
+            total_failure += failure
+
+        total = total_success + total_failure
+        overall_failure_rate = (total_failure / total) if total else 0.0
+
+        return {
+            "overall_failure_rate": overall_failure_rate,
+            "total_executions": total,
+            "tools": tool_rates,
+            "updated_at": stats.get("updated_at"),
+        }
+
+    async def get_budget_overrun(self, workspace_id: Optional[str]) -> Dict[str, Any]:
+        """Returns budget overrun status for a workspace."""
+        if not workspace_id:
+            return {
+                "over_budget": False,
+                "status": "unknown",
+                "daily_burn": 0,
+                "budget": 0,
+                "usage_percentage": 0,
+            }
+
+        report = await self._cost.get_burn_report(workspace_id)
+        over_budget = report.get("daily_burn", 0) > report.get("budget", 0)
+        return {**report, "over_budget": over_budget}
+
+    @staticmethod
+    def _merge_status(current: str, incoming: str) -> str:
+        order = {"healthy": 0, "warning": 1, "unhealthy": 2}
+        return incoming if order.get(incoming, 0) > order.get(current, 0) else current
+
+    async def get_health(self, workspace_id: Optional[str] = None) -> Dict[str, Any]:
+        """Aggregates swarm health metrics into a single payload."""
+        tool_rates = self.get_tool_failure_rates()
+        queue_backlog = self.get_queue_backlog()
+        budget_overrun = await self.get_budget_overrun(workspace_id)
+
+        status = "healthy"
+        signals = []
+
+        if budget_overrun.get("over_budget"):
+            status = self._merge_status(status, "unhealthy")
+            signals.append("budget_overrun")
+
+        if tool_rates.get("overall_failure_rate", 0) >= 0.2:
+            status = self._merge_status(status, "warning")
+            signals.append("tool_failures")
+
+        if queue_backlog.get("status") == "overloaded":
+            status = self._merge_status(status, "warning")
+            signals.append("queue_backlog")
+        elif queue_backlog.get("status") == "backlogged":
+            status = self._merge_status(status, "warning")
+            signals.append("queue_backlog")
+
+        return {
+            "status": status,
+            "signals": signals,
+            "tool_failure_rates": tool_rates,
+            "budget_overrun": budget_overrun,
+            "queue_backlog": queue_backlog,
+            "timestamp": datetime.now().isoformat(),
+        }

--- a/raptorflow-app/src/hooks/useMatrixOverview.ts
+++ b/raptorflow-app/src/hooks/useMatrixOverview.ts
@@ -20,6 +20,36 @@ export interface MatrixOverview {
     budget: number;
     status: string;
   };
+  swarm_health?: {
+    status: "healthy" | "warning" | "unhealthy";
+    signals: string[];
+    tool_failure_rates: {
+      overall_failure_rate: number;
+      total_executions: number;
+      tools: Record<string, {
+        success: number;
+        failure: number;
+        total: number;
+        failure_rate: number;
+        last_seen?: string;
+      }>;
+      updated_at?: string;
+    };
+    budget_overrun: {
+      daily_burn: number;
+      budget: number;
+      usage_percentage: number;
+      status: string;
+      over_budget: boolean;
+      timestamp?: string;
+    };
+    queue_backlog: {
+      pending: number;
+      status: string;
+      updated_at?: string;
+    };
+    timestamp: string;
+  };
   p95_latency_ms?: number;
   recent_events?: Array<{
     event_id: string;

--- a/raptorflow-app/src/hooks/useSwarmHealth.ts
+++ b/raptorflow-app/src/hooks/useSwarmHealth.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+export interface SwarmHealth {
+  status: "healthy" | "warning" | "unhealthy";
+  signals: string[];
+  tool_failure_rates: {
+    overall_failure_rate: number;
+    total_executions: number;
+    tools: Record<string, {
+      success: number;
+      failure: number;
+      total: number;
+      failure_rate: number;
+      last_seen?: string;
+    }>;
+    updated_at?: string;
+  };
+  budget_overrun: {
+    daily_burn: number;
+    budget: number;
+    usage_percentage: number;
+    status: string;
+    over_budget: boolean;
+    timestamp?: string;
+  };
+  queue_backlog: {
+    pending: number;
+    status: string;
+    updated_at?: string;
+  };
+  timestamp: string;
+}
+
+export function useSwarmHealth(workspaceId?: string) {
+  const [data, setData] = useState<SwarmHealth | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+  useEffect(() => {
+    async function fetchHealth() {
+      try {
+        const url = new URL(`${API_URL}/v1/matrix/swarm-health`);
+        if (workspaceId) {
+          url.searchParams.set("workspace_id", workspaceId);
+        }
+
+        const res = await fetch(url.toString());
+        if (!res.ok) throw new Error("Failed to fetch swarm health");
+        const json = await res.json();
+        setData(json);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchHealth();
+    const interval = setInterval(fetchHealth, 30000);
+    return () => clearInterval(interval);
+  }, [workspaceId]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
### Motivation
- Provide an operational view of the agent swarm by computing health signals like tool failure rates, budget overruns, and queue backlog.
- Surface these signals to operator tooling and dashboards so operators can act (throttle, halt, scale) quickly.
- Capture tool execution outcomes centrally to produce failure-rate metrics for remediation and alerting.
- Offer a simple API and frontend hook to consume swarm health data in the Matrix dashboard and UI.

### Description
- Adds a new service `SwarmHealthService` in `backend/services/swarm_health.py` that records tool executions, queue backlog, computes per-tool and overall failure rates, and queries budget/usage via `CostGovernor`.
- Integrates health recording into the tool wrapper by invoking `SwarmHealthService.record_tool_execution` from `ToolExecutionWrapper` in `backend/skills/matrix_skills.py` for success/failure cases.
- Exposes swarm health via a new API endpoint `GET /v1/matrix/swarm-health` implemented in `backend/api/v1/matrix.py` and included `swarm_health` in `MatrixService.get_aggregated_overview` in `backend/services/matrix_service.py`.
- Adds frontend support with a new hook `raptorflow-app/src/hooks/useSwarmHealth.ts` and extends `useMatrixOverview.ts` types to include `swarm_health` for UI consumption.

### Testing
- No automated tests were run against these changes.
- Basic static / type updates were added to the frontend TypeScript hook and types, but no build/test pipeline was executed.
- Manual runtime validation was not recorded as part of this change.
- Further unit/integration tests should be added to cover `SwarmHealthService` logic and API responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1d7b2108332a4d22ec45ce56dc3)