### PR TITLE
Add feedback ingestion and swarm-learning biasing for routing/tool selection

### DIFF
--- a/backend/agents/matrix_agents.py
+++ b/backend/agents/matrix_agents.py
@@ -1,9 +1,11 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
+from backend.core.config import get_settings
+from backend.memory.swarm_learning import SwarmLearningMemory
 from backend.skills.matrix_skills import SkillRegistry
 
 logger = logging.getLogger("raptorflow.matrix.agents")
@@ -29,6 +31,8 @@ class SkillSelectorAgent:
     def __init__(self, llm: Any, registry: SkillRegistry):
         self.llm = llm
         self.registry = registry
+        self.memory = SwarmLearningMemory()
+        self.settings = get_settings()
 
         self.prompt = ChatPromptTemplate.from_messages(
             [
@@ -44,13 +48,18 @@ Rules:
 1. Only select from the available skills list.
 2. If no skill is a clear match, return 'none'.
 3. Prioritize 'emergency_halt' for any mention of stopping, killing, or system failure.
+
+Feedback to bias selection:
+{feedback_context}
 """,
                 ),
                 ("human", "{intent}"),
             ]
         )
 
-    async def pick_best_tool(self, intent: str) -> Dict[str, Any]:
+    async def pick_best_tool(
+        self, intent: str, workspace_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         Analyzes the intent and selects the optimal skill from the registry.
         """
@@ -60,9 +69,11 @@ Rules:
         # For now, we list the registered names.
         skills = self.registry.list_skills()
         skill_descriptions = "\n".join([f"- {s}" for s in skills])
+        feedback_context = await self._get_feedback_context(intent, workspace_id)
 
         chain = self.prompt.partial(
-            skill_descriptions=skill_descriptions
+            skill_descriptions=skill_descriptions,
+            feedback_context=feedback_context or "None",
         ) | self.llm.with_structured_output(SkillSelection)
 
         try:
@@ -71,3 +82,31 @@ Rules:
         except Exception as e:
             logger.error(f"Skill selection failed: {e}")
             return {"skill_name": "none", "reasoning": f"Error: {str(e)}"}
+
+    async def _get_feedback_context(
+        self, intent: str, workspace_id: Optional[str]
+    ) -> str:
+        resolved_workspace_id = workspace_id or self.settings.DEFAULT_TENANT_ID
+        if not resolved_workspace_id:
+            return ""
+
+        feedback = await self.memory.recall_feedback(
+            workspace_id=resolved_workspace_id, query=intent, limit=3
+        )
+        if not feedback:
+            return ""
+
+        return "\n".join(self._format_feedback_entry(entry) for entry in feedback)
+
+    @staticmethod
+    def _format_feedback_entry(entry: dict) -> str:
+        metadata = entry.get("metadata", {}) or {}
+        signal = metadata.get("signal", "neutral")
+        tool_hint = metadata.get("tool_hint") or "n/a"
+        agent_hint = metadata.get("agent_hint") or "n/a"
+        context = metadata.get("context") or "n/a"
+        content = entry.get("content", "")
+        return (
+            f"- [{signal}] tool={tool_hint} agent={agent_hint} "
+            f"context={context} feedback={content}"
+        )

--- a/backend/agents/router.py
+++ b/backend/agents/router.py
@@ -3,7 +3,9 @@ from typing import List, Optional
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
+from backend.core.config import get_settings
 from backend.inference import InferenceProvider
+from backend.memory.swarm_learning import SwarmLearningMemory
 
 
 class RouterOutput(BaseModel):
@@ -26,8 +28,11 @@ class IntentRouterAgent:
         self.llm = InferenceProvider.get_model(
             model_tier="fast", temperature=0.0
         ).with_structured_output(RouterOutput)
+        self.memory = SwarmLearningMemory()
+        self.settings = get_settings()
 
-    async def route(self, prompt: str) -> RouterOutput:
+    async def route(self, prompt: str, workspace_id: Optional[str] = None) -> RouterOutput:
+        feedback_context = await self._get_feedback_context(prompt, workspace_id)
         system_msg = SystemMessage(
             content="""
             You are the Intent Router for RaptorFlow.
@@ -35,7 +40,44 @@ class IntentRouterAgent:
             Extract @mentions which represent campaigns, cohorts, or competitors.
             Assign confidence based on how much detail is provided.
             If the prompt is vague (e.g. 'write an email'), confidence must be < 0.7.
+            Use relevant feedback from similar requests to bias routing decisions.
         """
         )
+        if feedback_context:
+            system_msg = SystemMessage(
+                content=f"""{system_msg.content}
+
+Relevant feedback:
+{feedback_context}
+"""
+            )
 
         return await self.llm.ainvoke([system_msg, HumanMessage(content=prompt)])
+
+    async def _get_feedback_context(
+        self, prompt: str, workspace_id: Optional[str]
+    ) -> str:
+        resolved_workspace_id = workspace_id or self.settings.DEFAULT_TENANT_ID
+        if not resolved_workspace_id:
+            return ""
+
+        feedback = await self.memory.recall_feedback(
+            workspace_id=resolved_workspace_id, query=prompt, limit=3
+        )
+        if not feedback:
+            return ""
+
+        return "\n".join(self._format_feedback_entry(entry) for entry in feedback)
+
+    @staticmethod
+    def _format_feedback_entry(entry: dict) -> str:
+        metadata = entry.get("metadata", {}) or {}
+        signal = metadata.get("signal", "neutral")
+        tool_hint = metadata.get("tool_hint") or "n/a"
+        agent_hint = metadata.get("agent_hint") or "n/a"
+        context = metadata.get("context") or "n/a"
+        content = entry.get("content", "")
+        return (
+            f"- [{signal}] tool={tool_hint} agent={agent_hint} "
+            f"context={context} feedback={content}"
+        )

--- a/backend/api/v1/feedback.py
+++ b/backend/api/v1/feedback.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from backend.core.auth import get_current_user, get_tenant_id
+from backend.memory.swarm_learning import SwarmLearningMemory
+
+router = APIRouter(prefix="/v1/feedback", tags=["feedback"])
+
+
+class FeedbackPayload(BaseModel):
+    feedback: str = Field(..., min_length=1, description="User feedback text.")
+    context: str = Field(
+        ..., min_length=1, description="Context of the request or outcome."
+    )
+    signal: Optional[str] = Field(
+        default="neutral",
+        description="Optional sentiment signal (positive, negative, neutral).",
+    )
+    tool_hint: Optional[str] = Field(
+        default=None,
+        description="Optional tool name hint to influence tool selection.",
+    )
+    agent_hint: Optional[str] = Field(
+        default=None,
+        description="Optional agent name hint to influence routing.",
+    )
+    timestamp: Optional[datetime] = Field(
+        default=None, description="Optional client-provided timestamp."
+    )
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def ingest_feedback(
+    payload: FeedbackPayload,
+    tenant_id=Depends(get_tenant_id),
+    current_user: dict = Depends(get_current_user),
+):
+    """Ingests user feedback and persists it to swarm learning memory."""
+    metadata = {
+        "user_id": current_user.get("id"),
+        "user_email": current_user.get("email"),
+        "context": payload.context,
+        "signal": payload.signal,
+        "tool_hint": payload.tool_hint,
+        "agent_hint": payload.agent_hint,
+        "timestamp": _normalize_timestamp(payload.timestamp),
+    }
+
+    memory = SwarmLearningMemory()
+    try:
+        feedback_id = await memory.store_feedback(
+            workspace_id=str(tenant_id),
+            feedback=payload.feedback,
+            context=payload.context,
+            metadata=metadata,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to store feedback: {exc}",
+        ) from exc
+
+    return {"status": "stored", "feedback_id": feedback_id}
+
+
+def _normalize_timestamp(value: Optional[datetime]) -> str:
+    if not value:
+        return datetime.now(timezone.utc).isoformat()
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from backend.api.v1.blackbox_memory import router as blackbox_memory_router
 from backend.api.v1.blackbox_roi import router as blackbox_roi_router
 from backend.api.v1.blackbox_telemetry import router as blackbox_telemetry_router
 from backend.api.v1.campaigns import router as campaigns_router
+from backend.api.v1.feedback import router as feedback_router
 from backend.api.v1.foundation import router as foundation_router
 from backend.api.v1.matrix import router as matrix_router
 from backend.api.v1.moves import router as moves_router
@@ -60,6 +61,7 @@ app.include_router(payments_router)
 app.include_router(radar_router)
 app.include_router(muse_router)
 app.include_router(assets_router)
+app.include_router(feedback_router)
 
 
 # Global Exception Handler

--- a/backend/memory/swarm_learning.py
+++ b/backend/memory/swarm_learning.py
@@ -1,0 +1,98 @@
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from backend.db import save_memory, vector_search
+from backend.inference import InferenceProvider
+
+logger = logging.getLogger("raptorflow.memory.swarm_learning")
+
+
+class SwarmLearningMemory:
+    """
+    Swarm feedback memory for tool selection and agent routing biases.
+    """
+
+    def __init__(self, table: str = "muse_assets"):
+        self.table = table
+        self.memory_type = "swarm_feedback"
+
+    async def store_feedback(
+        self,
+        workspace_id: str,
+        feedback: str,
+        context: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Stores user feedback as swarm learning memory."""
+        if metadata is None:
+            metadata = {}
+
+        metadata.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
+        metadata.setdefault("subtype", "feedback")
+        metadata["type"] = self.memory_type
+
+        content = self._build_content(feedback, context, metadata)
+
+        try:
+            embedder = InferenceProvider.get_embeddings()
+            embedding = await embedder.aembed_query(content)
+            feedback_id = await save_memory(
+                workspace_id=workspace_id,
+                content=content,
+                embedding=embedding,
+                memory_type=self.memory_type,
+                metadata=metadata,
+            )
+            logger.info(
+                "Swarm feedback stored for workspace %s with id %s",
+                workspace_id,
+                feedback_id,
+            )
+            return feedback_id
+        except Exception as exc:
+            logger.error("Failed to store swarm feedback: %s", exc)
+            raise
+
+    async def recall_feedback(
+        self,
+        workspace_id: str,
+        query: str,
+        limit: int = 3,
+    ) -> List[Dict[str, Any]]:
+        """Recalls feedback relevant to the current intent/query."""
+        try:
+            embedder = InferenceProvider.get_embeddings()
+            query_embedding = await embedder.aembed_query(query)
+
+            raw_results = await vector_search(
+                workspace_id=workspace_id,
+                embedding=query_embedding,
+                table=self.table,
+                limit=limit,
+                filters={"type": self.memory_type, "subtype": "feedback"},
+            )
+
+            return [
+                {"id": r[0], "content": r[1], "metadata": r[2], "similarity": r[3]}
+                for r in raw_results
+            ]
+        except Exception as exc:
+            logger.error("Swarm feedback recall failed: %s", exc)
+            return []
+
+    @staticmethod
+    def _build_content(feedback: str, context: str, metadata: Dict[str, Any]) -> str:
+        parts = [f"Feedback: {feedback}", f"Context: {context}"]
+        signal = metadata.get("signal")
+        tool_hint = metadata.get("tool_hint")
+        agent_hint = metadata.get("agent_hint")
+
+        if signal:
+            parts.append(f"Signal: {signal}")
+        if tool_hint:
+            parts.append(f"Tool Hint: {tool_hint}")
+        if agent_hint:
+            parts.append(f"Agent Hint: {agent_hint}")
+
+        return "\n".join(parts)


### PR DESCRIPTION
### Motivation

- Provide an API to capture user feedback and persist it as swarm learning memory for future routing and tool-selection decisions.
- Record feedback with contextual metadata (user, tenant/workspace, timestamp, signal, tool/agent hints) so agent behaviors can be adapted over time.
- Surface relevant historical feedback into routing and skill-selection prompts to bias agents toward known good outcomes.

### Description

- Add a new API route `POST /v1/feedback` implemented in `backend/api/v1/feedback.py` which accepts `FeedbackPayload` and persists entries to memory.  
- Implement `SwarmLearningMemory` in `backend/memory/swarm_learning.py` with `store_feedback` and `recall_feedback` using `InferenceProvider` embeddings and `save_memory`/`vector_search`.  
- Wire feedback into decision-making by updating `IntentRouterAgent.route` in `backend/agents/router.py` and `SkillSelectorAgent.pick_best_tool` in `backend/agents/matrix_agents.py` to fetch and inject relevant feedback context.  
- Register the feedback router in `backend/main.py` and add a timestamp normalization helper `_normalize_timestamp` in the feedback API.  

### Testing

- No automated tests were executed as part of this change.  
- Manual sanity: code was added and committed, but no unit or integration test runs were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1d3c1e483329a6b1a1bd98b863b)