### PR TITLE
Tool fallback routing and telemetry-backed reliability tracking

### DIFF
--- a/backend/core/toolbelt.py
+++ b/backend/core/toolbelt.py
@@ -1,9 +1,12 @@
 import json
 import logging
+from dataclasses import dataclass, field
 from functools import wraps
 from typing import Any, Dict, List
 
 from backend.core.cache import get_cache_manager
+from backend.core.base_tool import BaseRaptorTool
+from backend.services.telemetry import get_telemetry
 from backend.tools.image_gen import NanoBananaImageTool
 from backend.tools.muse import AssetGenTool
 from backend.tools.search import (
@@ -57,23 +60,69 @@ class ToolbeltV2:
     """
 
     def __init__(self):
+        self.registry = ToolRegistry()
+        self.reliability = ToolReliabilityTracker(get_telemetry())
+
+        self.registry.register(
+            RaptorSearchTool(),
+            fallbacks=["tavily_search", "perplexity_search"],
+        )
+        self.registry.register(
+            TavilyMultiHopTool(),
+            fallbacks=["raptor_search", "perplexity_search"],
+        )
+        self.registry.register(
+            PerplexitySearchTool(),
+            fallbacks=["raptor_search", "tavily_search"],
+        )
+        self.registry.register(AssetGenTool())
+        self.registry.register(NanoBananaImageTool())
         self.tools = {
-            "raptor_search": RaptorSearchTool(),
-            "tavily_search": TavilyMultiHopTool(),
-            "perplexity_search": PerplexitySearchTool(),
-            "asset_gen": AssetGenTool(),
-            "nano_banana_gen": NanoBananaImageTool(),
+            name: registration.tool for name, registration in self.registry.items()
         }
 
     async def run_tool(self, tool_name: str, **kwargs) -> Dict[str, Any]:
         """SOTA Dispatcher for tool execution."""
-        tool = self.tools.get(tool_name)
-        if not tool:
+        registration = self.registry.get(tool_name)
+        if not registration:
             return {
                 "success": False,
                 "error": f"Tool '{tool_name}' not found in registry.",
             }
-        return await tool.run(**kwargs)
+        result = await registration.tool.run(**kwargs)
+        self.reliability.record(tool_name, result.get("success", False), result)
+        if result.get("success"):
+            return result
+
+        fallback_attempts = []
+        for fallback_name in self.reliability.rank_fallbacks(registration.fallbacks):
+            fallback_registration = self.registry.get(fallback_name)
+            if not fallback_registration:
+                continue
+            fallback_attempts.append(fallback_name)
+            fallback_result = await fallback_registration.tool.run(**kwargs)
+            self.reliability.record(
+                fallback_name,
+                fallback_result.get("success", False),
+                fallback_result,
+                fallback_of=tool_name,
+            )
+            if fallback_result.get("success"):
+                fallback_result["fallback"] = {
+                    "primary": tool_name,
+                    "selected": fallback_name,
+                    "attempted": fallback_attempts,
+                }
+                return fallback_result
+
+        error_details = result.get("error") or "Unknown error"
+        return {
+            "success": False,
+            "error": (
+                f"Tool '{tool_name}' failed ({error_details}). "
+                f"Fallbacks attempted: {fallback_attempts or 'none'}."
+            ),
+        }
 
     # --- T01-T04: Context & Search ---
     async def get_workspace_context(self, workspace_id: str) -> Dict:
@@ -134,3 +183,71 @@ class ToolbeltV2:
     async def human_approval_required(self, thread_id: str, action: str):
         """Triggers a LangGraph interrupt hook."""
         pass
+
+
+@dataclass(frozen=True)
+class ToolRegistration:
+    tool: BaseRaptorTool
+    fallbacks: List[str] = field(default_factory=list)
+
+
+class ToolRegistry:
+    """Unified tool registry with fallback rules."""
+
+    def __init__(self):
+        self._registry: Dict[str, ToolRegistration] = {}
+
+    def register(self, tool: BaseRaptorTool, fallbacks: List[str] | None = None):
+        self._registry[tool.name] = ToolRegistration(
+            tool=tool, fallbacks=list(fallbacks or [])
+        )
+
+    def get(self, tool_name: str) -> ToolRegistration | None:
+        return self._registry.get(tool_name)
+
+    def items(self):
+        return self._registry.items()
+
+
+class ToolReliabilityTracker:
+    """Tracks tool reliability via telemetry and local counters."""
+
+    def __init__(self, telemetry):
+        self._telemetry = telemetry
+        self._stats: Dict[str, Dict[str, int]] = {}
+
+    def record(
+        self,
+        tool_name: str,
+        success: bool,
+        result: Dict[str, Any],
+        fallback_of: str | None = None,
+    ):
+        stats = self._stats.setdefault(tool_name, {"successes": 0, "failures": 0})
+        if success:
+            stats["successes"] += 1
+        else:
+            stats["failures"] += 1
+        if self._telemetry:
+            self._telemetry.capture_tool_execution(
+                tool_name=tool_name,
+                success=success,
+                latency_ms=result.get("latency_ms", 0),
+                fallback_of=fallback_of,
+            )
+
+    def success_rate(self, tool_name: str) -> float:
+        stats = self._stats.get(tool_name)
+        if not stats:
+            return 0.5
+        total = stats["successes"] + stats["failures"]
+        if total == 0:
+            return 0.5
+        return stats["successes"] / total
+
+    def rank_fallbacks(self, fallbacks: List[str]) -> List[str]:
+        indexed = list(enumerate(fallbacks))
+        ranked = sorted(
+            indexed, key=lambda item: (-self.success_rate(item[1]), item[0])
+        )
+        return [fallbacks[i] for i, _ in ranked]

--- a/backend/services/telemetry.py
+++ b/backend/services/telemetry.py
@@ -52,6 +52,24 @@ class Telemetry:
             },
         )
 
+    @staticmethod
+    def capture_tool_execution(
+        tool_name: str,
+        success: bool,
+        latency_ms: float,
+        fallback_of: str | None = None,
+    ):
+        logger.info(
+            f"TOOL_EXECUTION: {tool_name}",
+            extra={
+                "event_type": "tool_execution",
+                "tool_name": tool_name,
+                "success": success,
+                "latency_ms": latency_ms,
+                "fallback_of": fallback_of,
+            },
+        )
+
 
 def get_telemetry() -> Telemetry:
     return Telemetry()


### PR DESCRIPTION
### Motivation
- Provide deterministic fallback routing for tools (e.g., `backend/tools/search.py`) so agents can recover when a primary tool fails.
- Use telemetry to measure tool success and failure to inform selection of alternate tools.
- Centralize fallback rules and tool metadata in a unified registry to keep routing logic consistent and maintainable.

### Description
- Add `ToolRegistry` and `ToolRegistration` to register tools and their `fallbacks`, replacing the previous hard-coded `tools` mapping in `ToolbeltV2`.
- Implement `ToolReliabilityTracker` to record success/failure counters and rank fallback candidates, and wire it to telemetry via `get_telemetry().capture_tool_execution`.
- Update `ToolbeltV2` to register search, asset, and image tools with fallback lists and to route failed executions through ranked fallbacks while annotating successful fallback responses with a `fallback` metadata block.
- Add `Telemetry.capture_tool_execution` to `backend/services/telemetry.py` to log tool-level events including `latency_ms` and `fallback_of`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1d23374833299e39659301bac82)