### PR TITLE
Add Swarm decomposer, controller, and subtask spec model

### DIFF
--- a/backend/agents/swarm_controller.py
+++ b/backend/agents/swarm_controller.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Any, Dict, List
+
+from backend.agents.supervisor import HierarchicalSupervisor
+from backend.agents.swarm_decomposer import SwarmTaskDecomposer
+from backend.models.swarm import SwarmState
+
+logger = logging.getLogger("raptorflow.agents.swarm_controller")
+
+
+class SwarmController:
+    """
+    Swarm Controller that decomposes missions before routing to specialists.
+    """
+
+    def __init__(
+        self,
+        llm: Any,
+        team_members: List[str],
+        system_prompt: str,
+        decomposer: SwarmTaskDecomposer | None = None,
+    ):
+        self.decomposer = decomposer or SwarmTaskDecomposer(llm)
+        self.supervisor = HierarchicalSupervisor(llm, team_members, system_prompt)
+
+    async def route(self, state: SwarmState) -> Dict[str, Any]:
+        """
+        Ensures decomposition runs before routing to specialists.
+        """
+        if not state.get("subtask_specs"):
+            logger.info("SwarmController running decomposition before routing.")
+            decomposition = await self.decomposer(state)
+            state = {**state, **decomposition}
+
+        return await self.supervisor(state)
+
+    async def execute(self, state: SwarmState, nodes: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Executes the swarm loop with decomposition enforced up front.
+        """
+        if not state.get("subtask_specs"):
+            logger.info("SwarmController running decomposition before execution loop.")
+            decomposition = await self.decomposer(state)
+            state = {**state, **decomposition}
+
+        return await self.supervisor.execute_loop(state, nodes)

--- a/backend/agents/swarm_decomposer.py
+++ b/backend/agents/swarm_decomposer.py
@@ -1,0 +1,68 @@
+import logging
+from typing import Any, List, TypedDict
+
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field
+
+from backend.inference import InferenceProvider
+from backend.models.swarm import SwarmSubtaskSpec, SwarmTask
+
+logger = logging.getLogger("raptorflow.agents.swarm_decomposer")
+
+
+class SwarmDecompositionPlan(BaseModel):
+    """Structured decomposition plan for a swarm mission."""
+
+    subtasks: List[SwarmSubtaskSpec] = Field(
+        description="Ordered list of subtasks the swarm should execute."
+    )
+
+
+class SwarmTaskDecomposer:
+    """
+    Swarm-focused decomposition agent.
+    Breaks a large goal into specialist-ready subtask specifications.
+    """
+
+    def __init__(self, llm: Any | None = None):
+        self.llm = llm or InferenceProvider.get_model(model_tier="reasoning")
+        self.prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are the Swarm Decomposition Agent for RaptorFlow. "
+                    "Break the user's mission into concise, specialist-owned subtasks. "
+                    "Use specialist types like research, strategy, creative, operator, or qa. "
+                    "Each subtask must be independently executable with clear success criteria.",
+                ),
+                ("user", "{goal}"),
+            ]
+        )
+        self.chain = self.prompt | self.llm.with_structured_output(SwarmDecompositionPlan)
+
+    async def __call__(self, state: TypedDict) -> dict:
+        """Generate swarm subtask specs from the incoming state."""
+        goal = state.get("raw_prompt") or state.get("prompt") or "No goal provided"
+        logger.info("Decomposing swarm goal into subtasks.")
+
+        plan = await self.chain.ainvoke({"goal": goal})
+        specs = plan.subtasks
+        tasks = [
+            SwarmTask(
+                id=spec.id,
+                specialist_type=spec.specialist_type,
+                description=spec.objective,
+                metadata={
+                    "success_criteria": spec.success_criteria,
+                    "dependencies": spec.dependencies,
+                    "inputs": spec.inputs,
+                },
+            )
+            for spec in specs
+        ]
+
+        return {"subtask_specs": specs, "swarm_tasks": tasks}
+
+
+def create_swarm_decomposer(llm: Any | None = None) -> SwarmTaskDecomposer:
+    return SwarmTaskDecomposer(llm=llm)

--- a/backend/models/swarm.py
+++ b/backend/models/swarm.py
@@ -25,11 +25,25 @@ class SwarmTask(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
+class SwarmSubtaskSpec(BaseModel):
+    """Structured specification for a swarm subtask before execution."""
+
+    id: str
+    specialist_type: str
+    objective: str
+    success_criteria: List[str] = Field(default_factory=list)
+    dependencies: List[str] = Field(default_factory=list)
+    inputs: Dict[str, Any] = Field(default_factory=dict)
+
+
 class SwarmState(CognitiveIntelligenceState):
     """
     SOTA Swarm Intelligence State.
     Extends the base cognitive state with multi-agent coordination fields.
     """
+
+    # Planned subtask specifications before execution
+    subtask_specs: Annotated[List[SwarmSubtaskSpec], operator.add]
 
     # List of delegated sub-tasks
     swarm_tasks: Annotated[List[SwarmTask], operator.add]


### PR DESCRIPTION
### Motivation

- Introduce a dedicated decomposition step so large missions can be split into specialist-ready subtasks before execution. 
- Ensure orchestration enforces decomposition so supervisors route only after structured specs are available. 
- Persist planned subtask specifications in the swarm state to allow downstream nodes and memory managers to inspect planned work. 
- Provide a reusable decomposer and controller that integrate with the existing `HierarchicalSupervisor` for minimal disruption.

### Description

- Add `SwarmSubtaskSpec` model and `subtask_specs` field to `backend/models/swarm.py` to store planned subtask specs in the `SwarmState`.
- Implement `backend/agents/swarm_decomposer.py` with `SwarmTaskDecomposer` and `SwarmDecompositionPlan` to generate `subtask_specs` and create `SwarmTask` entries from a goal using the LLM.
- Add `backend/agents/swarm_controller.py` implementing `SwarmController` that runs the decomposer when `subtask_specs` are missing and then delegates routing/execution to `HierarchicalSupervisor`.
- Wire the decomposer output to produce both `subtask_specs` and `swarm_tasks` so downstream controllers and memory layers can consume structured plans.

### Testing

- No automated tests were executed as part of this change.
- Existing unit tests in the repo were not modified by this patch.
- Basic linting and import checks were not run during this rollout.
- Manual verification is recommended for `SwarmState` consumers and supervisor integrations due to new fields and agents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1cfeefc8332aaf0c269b5a43210)