### PR TITLE
Add queue controller for agent concurrency limits

### DIFF
--- a/backend/models/fortress.py
+++ b/backend/models/fortress.py
@@ -4,6 +4,7 @@ from typing import Annotated, List, Optional, TypedDict
 
 from pydantic import BaseModel, Field
 
+from backend.models.queue_controller import CapabilityProfile, QueueController
 
 class FortressTask(BaseModel):
     """SOTA structured task representation."""
@@ -34,6 +35,8 @@ class FortressState(TypedDict):
     task_queue: Annotated[List[FortressTask], operator.add]
     current_task_id: Optional[str]
     next_node: str  # The routing signal
+    capability_profile: CapabilityProfile
+    queue_controller: QueueController
 
     # Memory & Context
     messages: Annotated[List[any], operator.add]

--- a/backend/models/queue_controller.py
+++ b/backend/models/queue_controller.py
@@ -1,0 +1,68 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CapabilityProfile(BaseModel):
+    """Defines per-agent concurrency capabilities."""
+
+    default_concurrency: int = 1
+    per_agent_concurrency: Dict[str, int] = Field(default_factory=dict)
+
+    def limit_for(self, agent_type: str) -> int:
+        limit = self.per_agent_concurrency.get(agent_type, self.default_concurrency)
+        return max(1, limit)
+
+
+class QueuedTask(BaseModel):
+    """Represents a queued or in-flight agent task."""
+
+    task_id: str
+    agent_type: str
+    metadata: Optional[Dict[str, str]] = None
+
+
+class QueueController(BaseModel):
+    """Caps in-flight agent tasks and manages a FIFO queue."""
+
+    capability_profile: CapabilityProfile = Field(default_factory=CapabilityProfile)
+    inflight_by_agent: Dict[str, int] = Field(default_factory=dict)
+    queue: List[QueuedTask] = Field(default_factory=list)
+
+    def can_dispatch(self, agent_type: str) -> bool:
+        return self.inflight_by_agent.get(agent_type, 0) < self.capability_profile.limit_for(
+            agent_type
+        )
+
+    def enqueue(self, task: QueuedTask) -> bool:
+        if self.can_dispatch(task.agent_type):
+            self._increment_inflight(task.agent_type)
+            return True
+        self.queue.append(task)
+        return False
+
+    def complete(self, agent_type: str) -> List[QueuedTask]:
+        self._decrement_inflight(agent_type)
+        return self.dispatch_ready()
+
+    def dispatch_ready(self) -> List[QueuedTask]:
+        dispatched: List[QueuedTask] = []
+        remaining: List[QueuedTask] = []
+        for task in self.queue:
+            if self.can_dispatch(task.agent_type):
+                self._increment_inflight(task.agent_type)
+                dispatched.append(task)
+            else:
+                remaining.append(task)
+        self.queue = remaining
+        return dispatched
+
+    def _increment_inflight(self, agent_type: str) -> None:
+        self.inflight_by_agent[agent_type] = self.inflight_by_agent.get(agent_type, 0) + 1
+
+    def _decrement_inflight(self, agent_type: str) -> None:
+        current = self.inflight_by_agent.get(agent_type, 0)
+        if current <= 1:
+            self.inflight_by_agent.pop(agent_type, None)
+        else:
+            self.inflight_by_agent[agent_type] = current - 1

--- a/backend/models/swarm.py
+++ b/backend/models/swarm.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from backend.models.cognitive import CognitiveIntelligenceState
+from backend.models.queue_controller import CapabilityProfile, QueueController
 
 
 class SwarmTaskStatus(str, Enum):
@@ -39,3 +40,7 @@ class SwarmState(CognitiveIntelligenceState):
 
     # History of delegations and specialist interactions
     delegation_history: Annotated[List[Dict[str, Any]], operator.add]
+
+    # Concurrency management
+    capability_profile: CapabilityProfile
+    queue_controller: QueueController

--- a/backend/tests/test_queue_controller.py
+++ b/backend/tests/test_queue_controller.py
@@ -1,0 +1,29 @@
+from backend.models.queue_controller import CapabilityProfile, QueueController, QueuedTask
+
+
+def test_queue_controller_enforces_per_agent_concurrency():
+    profile = CapabilityProfile(default_concurrency=1, per_agent_concurrency={"researcher": 2})
+    controller = QueueController(capability_profile=profile)
+
+    task_one = QueuedTask(task_id="t1", agent_type="researcher")
+    task_two = QueuedTask(task_id="t2", agent_type="researcher")
+    task_three = QueuedTask(task_id="t3", agent_type="researcher")
+
+    assert controller.enqueue(task_one) is True
+    assert controller.enqueue(task_two) is True
+    assert controller.enqueue(task_three) is False
+    assert len(controller.queue) == 1
+
+    released = controller.complete("researcher")
+    assert [task.task_id for task in released] == ["t3"]
+    assert controller.inflight_by_agent["researcher"] == 2
+
+
+def test_queue_controller_respects_default_limit():
+    controller = QueueController()
+
+    task_one = QueuedTask(task_id="t1", agent_type="strategist")
+    task_two = QueuedTask(task_id="t2", agent_type="strategist")
+
+    assert controller.enqueue(task_one) is True
+    assert controller.enqueue(task_two) is False


### PR DESCRIPTION
### Motivation
- Limit and coordinate concurrent agent work by capping in-flight specialist tasks to avoid resource contention and cascading costs.
- Provide a per-agent and default concurrency profile so different specialist types can run with tailored parallelism.
- Integrate concurrency control with existing global state schemas to allow supervisors and orchestrators to consult/consume the queue.

### Description
- Add `backend/models/queue_controller.py` introducing `CapabilityProfile`, `QueuedTask`, and `QueueController` with `enqueue`, `complete`, and `dispatch_ready` semantics.
- Wire the new concurrency primitives into state schemas by adding `capability_profile` and `queue_controller` fields to `FortressState` (`backend/models/fortress.py`) and `SwarmState` (`backend/models/swarm.py`).
- Add unit tests in `backend/tests/test_queue_controller.py` that validate per-agent concurrency limits and the default limit behavior.

### Testing
- Added `backend/tests/test_queue_controller.py` covering per-agent concurrency and default concurrency scenarios (tests included in the commit).
- Ran `pytest -q backend/tests/test_queue_controller.py` which failed during collection with `ModuleNotFoundError: No module named 'backend'` due to the test environment import path, not the controller logic.
- Commit contains the new files and modifications and the failing test run is documented so CI/path fixes can be addressed next.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1d157c08332a6500b0c80a12239)