### PR TITLE
Extract HandoffProtocol to shared module

### DIFF
--- a/backend/agents/shared/handoff.py
+++ b/backend/agents/shared/handoff.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Any, Dict
+
+
+class HandoffProtocol:
+    """
+    Standardized protocol for agent-to-agent communication and context transfer.
+    """
+
+    @staticmethod
+    def create_packet(
+        source: str, target: str, context: Dict[str, Any], priority: str = "normal"
+    ) -> Dict[str, Any]:
+        """
+        Creates a standardized handoff packet.
+        """
+        return {
+            "source": source,
+            "target": target,
+            "context": context,
+            "priority": priority,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    @staticmethod
+    def validate(packet: Dict[str, Any]) -> bool:
+        """
+        Validates the structure of a handoff packet.
+        """
+        required_keys = ["source", "target", "context", "priority"]
+        return all(key in packet for key in required_keys)

--- a/backend/agents/supervisor.py
+++ b/backend/agents/supervisor.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Annotated, Any, Dict, List, Optional, TypedDict
 
 from langchain_core.messages import BaseMessage
@@ -164,35 +163,6 @@ class HierarchicalSupervisor:
             summary_parts.append(f"- [{source}]: {text}")
 
         return "\n".join(summary_parts)
-
-
-class HandoffProtocol:
-    """
-    Standardized protocol for agent-to-agent communication and context transfer.
-    """
-
-    @staticmethod
-    def create_packet(
-        source: str, target: str, context: Dict[str, Any], priority: str = "normal"
-    ) -> Dict[str, Any]:
-        """
-        Creates a standardized handoff packet.
-        """
-        return {
-            "source": source,
-            "target": target,
-            "context": context,
-            "priority": priority,
-            "timestamp": datetime.now().isoformat(),
-        }
-
-    @staticmethod
-    def validate(packet: Dict[str, Any]) -> bool:
-        """
-        Validates the structure of a handoff packet.
-        """
-        required_keys = ["source", "target", "context", "priority"]
-        return all(key in packet for key in required_keys)
 
 
 class HumanInTheLoopNode:

--- a/backend/tests/test_matrix_handoff.py
+++ b/backend/tests/test_matrix_handoff.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.agents.supervisor import HandoffProtocol
+from backend.agents.shared.handoff import HandoffProtocol
 
 
 def test_handoff_message_creation():


### PR DESCRIPTION
### Motivation
- Centralize the agent-to-agent handoff logic into a shared location for reuse across agents.
- Remove duplicate protocol definitions from specialist/supervisor modules to reduce maintenance burden.
- Make it easier to standardize and replace custom handoff patterns across `backend/agents`.
- Improve discoverability by placing the protocol under `backend/agents/shared`.

### Description
- Added `backend/agents/shared/handoff.py` containing the `HandoffProtocol` with `create_packet` and `validate` helpers.
- Removed the `HandoffProtocol` class from `backend/agents/supervisor.py` to avoid duplication.
- Updated `backend/tests/test_matrix_handoff.py` to import `HandoffProtocol` from `backend.agents.shared.handoff`.
- Changes committed with message `Move HandoffProtocol to shared module`.

### Testing
- Updated unit test `backend/tests/test_matrix_handoff.py` to reference the new module path for `HandoffProtocol`.
- No automated tests were executed as part of this change.
- Developers should run `pytest backend/tests/test_matrix_handoff.py` to validate the handoff behavior after the change.
- No CI results are included in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1cf2fc08332a94e313fe68fc5db)