### PR TITLE
Add peer-review step and shared memory for agent critiques

### DIFF
--- a/backend/agents/base.py
+++ b/backend/agents/base.py
@@ -7,6 +7,7 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
 from backend.inference import InferenceProvider
+from backend.memory.peer_review import PeerReviewMemory
 from backend.models.cognitive import AgentMessage, CognitiveIntelligenceState
 
 logger = logging.getLogger("raptorflow.agents.base")
@@ -61,7 +62,10 @@ class BaseCognitiveAgent(ABC):
         return lc_messages
 
     async def self_correct(
-        self, content: str, state: CognitiveIntelligenceState
+        self,
+        content: str,
+        state: CognitiveIntelligenceState,
+        use_peer_critiques: bool = False,
     ) -> str:
         """
         SOTA Self-Correction Loop.
@@ -69,11 +73,33 @@ class BaseCognitiveAgent(ABC):
         """
         logger.info(f"Agent {self.name} performing self-correction...")
 
+        peer_critiques = []
+        if use_peer_critiques:
+            peer_critiques = state.get("peer_critiques", []) or []
+            tenant_id = state.get("tenant_id")
+            if not peer_critiques and tenant_id:
+                memory = PeerReviewMemory(tenant_id, state.get("workspace_id"))
+                peer_critiques = await memory.get_recent_critiques()
+
+        peer_section = ""
+        if use_peer_critiques:
+            formatted = "\n".join(
+                [
+                    f"- {item.get('reviewer', 'Peer')}: {item.get('critique', '')}"
+                    for item in peer_critiques
+                ]
+            )
+            peer_section = (
+                "\n# PEER CRITIQUES:\n"
+                + (formatted if formatted else "None available.")
+            )
+
         # 1. Generate Critique
         critique_prompt = f"""
         # ROLE: Ruthless Editorial Skeptic
         # TASK: Critique the following content for {self.role} quality.
         # CONTENT: {content}
+        {peer_section}
         # CRITERIA: Factual density, brand alignment, logic gaps.
         """
         critique_res = await self.llm.ainvoke([SystemMessage(content=critique_prompt)])

--- a/backend/memory/peer_review.py
+++ b/backend/memory/peer_review.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Any, List, Optional
+
+from backend.memory.short_term import L1ShortTermMemory
+
+logger = logging.getLogger("raptorflow.memory.peer_review")
+
+
+class PeerReviewMemory:
+    """
+    Shared memory store for peer critiques across runs.
+    Persists critique artifacts in L1 memory for reuse during self-correction.
+    """
+
+    def __init__(self, tenant_id: str, workspace_id: Optional[str] = None):
+        self.tenant_id = tenant_id
+        self.workspace_id = workspace_id or "global"
+        self.l1 = L1ShortTermMemory()
+        self.key = f"peer_review:{self.tenant_id}:{self.workspace_id}"
+
+    async def append_critiques(
+        self, critiques: List[dict], ttl: int = 86400
+    ) -> bool:
+        if not self.l1.client:
+            logger.warning("Peer review memory unavailable; no L1 client.")
+            return False
+        existing = await self.l1.retrieve(self.key) or []
+        updated = existing + critiques
+        return await self.l1.store(self.key, updated, ttl=ttl)
+
+    async def get_recent_critiques(self, limit: int = 5) -> List[dict]:
+        if not self.l1.client:
+            logger.warning("Peer review memory unavailable; no L1 client.")
+            return []
+        data = await self.l1.retrieve(self.key) or []
+        return data[-limit:]
+
+    async def store_snapshot(self, snapshot: Any, ttl: int = 86400) -> bool:
+        if not self.l1.client:
+            logger.warning("Peer review memory unavailable; no L1 client.")
+            return False
+        return await self.l1.store(self.key, snapshot, ttl=ttl)

--- a/backend/tests/test_agent_self_correction.py
+++ b/backend/tests/test_agent_self_correction.py
@@ -36,3 +36,36 @@ async def test_agent_self_correction_flow():
 
         assert final_content == "Longer polished content."
         assert mock_llm.ainvoke.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_agent_self_correction_with_peer_critiques():
+    """
+    Phase 37: Verify self-correction uses peer critiques when enabled.
+    """
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke.side_effect = [
+        MagicMock(content="Needs more depth."),
+        MagicMock(content="Expanded polished content."),
+    ]
+
+    with patch("backend.agents.base.InferenceProvider") as mock_inference, patch(
+        "backend.agents.base.PeerReviewMemory"
+    ) as mock_peer_memory:
+        mock_inference.get_model.return_value = mock_llm
+        mock_peer_instance = MagicMock()
+        mock_peer_instance.get_recent_critiques = AsyncMock(
+            return_value=[{"reviewer": "Peer A", "critique": "Add more evidence."}]
+        )
+        mock_peer_memory.return_value = mock_peer_instance
+
+        agent = SkepticAgent(mock_llm)
+        state: CognitiveIntelligenceState = {"tenant_id": "test", "workspace_id": "ws1"}
+
+        final_content = await agent.self_correct(
+            "Short content", state, use_peer_critiques=True
+        )
+
+        first_call = mock_llm.ainvoke.call_args_list[0][0][0][0].content
+        assert "Peer A" in first_call
+        assert final_content == "Expanded polished content."


### PR DESCRIPTION
### Motivation

- Introduce a peer-review stage so agents can critique each other’s outputs before human review or downstream processing.
- Persist peer critiques in a short-term shared memory so future runs and self-correction loops can reuse prior feedback.
- Enable agents to optionally incorporate collective peer feedback into their self-correction logic to improve quality.

### Description

- Add a new `PeerReviewMemory` helper in `backend/memory/peer_review.py` to append and retrieve critique artifacts from L1 short-term memory using `L1ShortTermMemory`.
- Add a `peer_review` node to the Moves & Campaigns orchestrator and a `peer_critiques` field to the `MovesCampaignsState` schema, and wire the node into the workflow after `plan_campaign` and after `refine_moves`.
- Extend `BaseCognitiveAgent.self_correct` to accept `use_peer_critiques: bool` and to pull critiques from `state` or `PeerReviewMemory` and include them in the critique prompt.
- Update unit tests in `backend/tests/test_agent_self_correction.py` to add `test_agent_self_correction_with_peer_critiques` which mocks `PeerReviewMemory` and the LLM response.

### Testing

- No automated test suite was executed as part of this PR.
- Unit tests were updated: `backend/tests/test_agent_self_correction.py` now includes `test_agent_self_correction_with_peer_critiques` that asserts peer critiques are injected into the critique prompt and the self-correction flow completes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1cc540c83328ebc137e63a57c03)