### PR TITLE
Introduce Swarm controller orchestrator and update graph routing

### DIFF
--- a/backend/graphs/muse_create.py
+++ b/backend/graphs/muse_create.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from langgraph.graph import END, START, StateGraph
 
 from backend.agents.base import BaseCognitiveAgent
-from backend.agents.shared.agents import IntentRouter, QualityGate
+from backend.agents.shared.agents import QualityGate
+from backend.graphs.swarm_orchestrator import SwarmController
 from backend.agents.shared.context_assembler import ContextAssemblerAgent
 from backend.models.cognitive import (
     AgentMessage,
@@ -19,8 +20,8 @@ logger = logging.getLogger("raptorflow.graphs.muse_create")
 
 async def router_node(state: CognitiveIntelligenceState):
     """A00: Determines the intent and family of the asset."""
-    router = IntentRouter()
-    intent = await router.execute(state["raw_prompt"])
+    controller = SwarmController()
+    intent = await controller.route_intent(state["raw_prompt"])
 
     # Initialize brief with intent
     brief = state.get("brief", {})

--- a/backend/graphs/spine_v2.py
+++ b/backend/graphs/spine_v2.py
@@ -2,7 +2,8 @@ from typing import List, TypedDict
 
 from langgraph.graph import END, START, StateGraph
 
-from backend.agents.shared.agents import IntentRouter, QualityGate
+from backend.agents.shared.agents import QualityGate
+from backend.graphs.swarm_orchestrator import SwarmController
 from backend.agents.specialists.creatives import EmailSpecialistAgent
 from backend.memory.cognitive.engine import CognitiveMemoryEngine
 
@@ -40,12 +41,12 @@ async def initialize_spine(state: SpineState):
         state["workspace_id"], state["prompt"]
     )
 
-    router = IntentRouter()
-    intent = await router.execute(state["prompt"])
+    controller = SwarmController()
+    intent = await controller.route_intent(state["prompt"])
 
     return {
         "learned_rules": rules,
-        "intent": intent.dict(),
+        "intent": intent.to_intent_payload(),
         "status": "planning",
         "iterations": 0,
     }

--- a/backend/graphs/swarm_orchestrator.py
+++ b/backend/graphs/swarm_orchestrator.py
@@ -1,0 +1,269 @@
+import inspect
+import logging
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from pydantic import BaseModel, Field
+
+from backend.inference import InferenceProvider
+
+logger = logging.getLogger("raptorflow.swarm.orchestrator")
+
+
+class SwarmIntent(BaseModel):
+    asset_type: str = Field(
+        description="The family of asset (email, social, meme, strategy)"
+    )
+    confidence: float = Field(description="Confidence score 0.0 - 1.0")
+    extracted_goal: str = Field(description="What the user wants to achieve")
+    entities: List[str] = Field(
+        description="Extracted @mentions like cohorts or campaigns"
+    )
+    ambiguity_reasons: Optional[List[str]] = Field(
+        description="Reasons for low confidence",
+        default=None,
+    )
+
+    @property
+    def asset_family(self) -> str:
+        return self.asset_type
+
+    @property
+    def goal(self) -> str:
+        return self.extracted_goal
+
+    def to_intent_payload(self) -> Dict[str, Any]:
+        return {
+            "asset_family": self.asset_type,
+            "goal": self.extracted_goal,
+            "entities": self.entities,
+            "confidence": self.confidence,
+            "ambiguity_reasons": self.ambiguity_reasons,
+        }
+
+
+class SwarmRouteDecision(BaseModel):
+    """Structured output for the Swarm controller router."""
+
+    next_node: str = Field(
+        description="The next specialist crew to call, or 'FINISH' to deliver to user."
+    )
+    instructions: str = Field(
+        description="Specific sub-task instructions for the specialist."
+    )
+
+
+class SwarmAgentAdapter:
+    """Adapter to normalize different agent call signatures."""
+
+    def __init__(
+        self,
+        name: str,
+        handler: Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]],
+    ) -> None:
+        self.name = name
+        self._handler = handler
+
+    async def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        result = self._handler(state)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    @staticmethod
+    def _wrap_result(result: Any) -> Awaitable[Dict[str, Any]]:
+        async def _wrapper() -> Dict[str, Any]:
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return _wrapper()
+
+    @classmethod
+    def from_callable(cls, name: str, agent: Callable[[Dict[str, Any]], Any]):
+        async def handler(state: Dict[str, Any]) -> Dict[str, Any]:
+            return await cls._wrap_result(agent(state))
+
+        return cls(name, handler)
+
+    @classmethod
+    def from_run_method(
+        cls,
+        name: str,
+        agent: Any,
+        *,
+        identifier_key: str = "move_id",
+        payload_builder: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+    ):
+        def build_payload(state: Dict[str, Any]) -> Dict[str, Any]:
+            return payload_builder(state) if payload_builder else state
+
+        async def handler(state: Dict[str, Any]) -> Dict[str, Any]:
+            identifier = state.get(identifier_key)
+            return await cls._wrap_result(agent.run(identifier, build_payload(state)))
+
+        return cls(name, handler)
+
+    @classmethod
+    def from_execute_method(
+        cls,
+        name: str,
+        agent: Any,
+        *,
+        prompt_key: str = "prompt",
+    ):
+        async def handler(state: Dict[str, Any]) -> Dict[str, Any]:
+            return await cls._wrap_result(agent.execute(state[prompt_key]))
+
+        return cls(name, handler)
+
+
+class SwarmController:
+    """Unified controller for intent routing and multi-agent supervision."""
+
+    def __init__(
+        self,
+        supervisor_llm: Optional[Any] = None,
+        team_members: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        intent_llm: Optional[Any] = None,
+    ) -> None:
+        self.supervisor_llm = supervisor_llm
+        self.team_members = team_members or []
+        self.system_prompt = system_prompt
+        self.intent_chain = (
+            intent_llm
+            or InferenceProvider.get_model(model_tier="fast", temperature=0.0)
+        ).with_structured_output(SwarmIntent)
+        self._supervisor_chain = None
+
+    @property
+    def supervisor_chain(self):
+        if self._supervisor_chain is None:
+            if not self.supervisor_llm or not self.system_prompt:
+                raise ValueError("Supervisor LLM and system prompt must be provided.")
+
+            options = self.team_members + ["FINISH"]
+            prompt = ChatPromptTemplate.from_messages(
+                [
+                    ("system", self.system_prompt),
+                    MessagesPlaceholder(variable_name="messages"),
+                    (
+                        "system",
+                        "Given the conversation above, who should act next?"
+                        " Or should we FINISH? Select one of: {options}",
+                    ),
+                ]
+            ).partial(options=str(options))
+
+            self._supervisor_chain = (
+                prompt | self.supervisor_llm.with_structured_output(SwarmRouteDecision)
+            )
+        return self._supervisor_chain
+
+    async def __call__(self, state: Dict[str, Any]) -> Dict[str, str]:
+        return await self.decide_next(state)
+
+    async def route_intent(self, prompt: str) -> SwarmIntent:
+        system_msg = SystemMessage(
+            content=(
+                "You are the Intent Router for RaptorFlow.\n"
+                "Classify user prompts into asset families: email, social, meme, or strategy.\n"
+                "Extract @mentions which represent campaigns, cohorts, or competitors.\n"
+                "Assign confidence based on how much detail is provided.\n"
+                "If the prompt is vague (e.g. 'write an email'), confidence must be < 0.7."
+            )
+        )
+
+        return await self.intent_chain.ainvoke(
+            [system_msg, HumanMessage(content=prompt)]
+        )
+
+    async def decide_next(
+        self,
+        state: Dict[str, Any],
+        *,
+        chain: Optional[Any] = None,
+    ) -> Dict[str, str]:
+        logger.info("Swarm controller evaluating state...")
+        router = chain or self.supervisor_chain
+        response = await router.ainvoke(state)
+
+        if hasattr(response, "next_node"):
+            next_node = response.next_node
+            instructions = response.instructions
+        else:
+            next_node = response.get("next_node")
+            instructions = response.get("instructions")
+
+        logger.info("Swarm controller delegated to: %s", next_node)
+        return {"next": str(next_node), "instructions": str(instructions)}
+
+    async def delegate_to_specialist(
+        self,
+        specialist_name: str,
+        state: Dict[str, Any],
+        specialist_node: Any,
+    ) -> Dict[str, Any]:
+        logger.info("Delegating task to specialist: %s", specialist_name)
+
+        adapter = (
+            specialist_node
+            if isinstance(specialist_node, SwarmAgentAdapter)
+            else SwarmAgentAdapter.from_callable(specialist_name, specialist_node)
+        )
+        return await adapter(state)
+
+    async def execute_loop(
+        self,
+        initial_state: Dict[str, Any],
+        nodes: Dict[str, Any],
+        *,
+        max_loops: int = 10,
+        chain: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        current_state = initial_state.copy()
+        if "messages" not in current_state:
+            current_state["messages"] = []
+
+        loop_count = 0
+
+        while loop_count < max_loops:
+            decision = await self.decide_next(current_state, chain=chain)
+            next_node = decision["next"]
+            instructions = decision["instructions"]
+
+            if next_node == "FINISH":
+                break
+
+            if next_node in nodes:
+                specialist_node = nodes[next_node]
+                current_state["instructions"] = instructions
+                result = await self.delegate_to_specialist(
+                    next_node, current_state, specialist_node
+                )
+
+                summary = result.get("analysis_summary", "Task completed.")
+                current_state["messages"].append(
+                    AIMessage(content=f"[{next_node}]: {summary}")
+                )
+            else:
+                logger.error("Specialist %s not found in nodes.", next_node)
+                break
+
+            loop_count += 1
+
+        current_state["next"] = "FINISH"
+        return current_state
+
+    def aggregate_findings(self, findings: List[Dict[str, Any]]) -> str:
+        logger.info("Aggregating %s specialist findings...", len(findings))
+
+        summary_parts = ["### MATRIX BOARDROOM SUMMARY ###"]
+        for i, finding in enumerate(findings):
+            source = finding.get("source", f"Specialist {i+1}")
+            text = finding.get("analysis_summary", "No summary provided.")
+            summary_parts.append(f"- [{source}]: {text}")
+
+        return "\n".join(summary_parts)

--- a/backend/tests/test_matrix_aggregation.py
+++ b/backend/tests/test_matrix_aggregation.py
@@ -1,16 +1,11 @@
-from unittest.mock import MagicMock
-
 import pytest
 
-from backend.agents.supervisor import HierarchicalSupervisor
+from backend.graphs.swarm_orchestrator import SwarmController
 
 
 def test_aggregate_findings_logic():
     """Test that the supervisor can aggregate multiple specialist findings."""
-    mock_llm = MagicMock()
-    supervisor = HierarchicalSupervisor(
-        llm=mock_llm, team_members=[], system_prompt="..."
-    )
+    supervisor = SwarmController()
 
     findings = [
         {"analysis_summary": "Drift detected in zone A", "drift_detected": True},

--- a/backend/tests/test_matrix_delegation.py
+++ b/backend/tests/test_matrix_delegation.py
@@ -1,17 +1,14 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.agents.supervisor import HierarchicalSupervisor
+from backend.graphs.swarm_orchestrator import SwarmController
 
 
 @pytest.mark.asyncio
 async def test_delegate_to_specialist_logic():
     """Test that the supervisor can delegate work to a specialist node."""
-    mock_llm = MagicMock()
-    supervisor = HierarchicalSupervisor(
-        llm=mock_llm, team_members=["DriftAnalyzer"], system_prompt="..."
-    )
+    supervisor = SwarmController()
 
     # Mock specialist node
     mock_specialist = AsyncMock()

--- a/backend/tests/test_matrix_supervisor.py
+++ b/backend/tests/test_matrix_supervisor.py
@@ -3,7 +3,11 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 from langchain_core.messages import HumanMessage
 
-from backend.agents.supervisor import HierarchicalSupervisor
+from backend.graphs.swarm_orchestrator import (
+    SwarmController,
+    SwarmIntent,
+    SwarmRouteDecision,
+)
 
 
 @pytest.mark.asyncio
@@ -11,21 +15,21 @@ async def test_matrix_supervisor_delegation():
     """Test that the supervisor correctly delegates to a specialist."""
     # Mock LLM since it's passed to __init__
     mock_llm = MagicMock()
-    supervisor = HierarchicalSupervisor(
-        llm=mock_llm,
+    supervisor = SwarmController(
+        supervisor_llm=mock_llm,
         team_members=["DriftAnalyzer", "Governor"],
         system_prompt="You are the Matrix Supervisor.",
     )
     # Define response
-    mock_response = MagicMock()
-    mock_response.next_node = "DriftAnalyzer"
-    mock_response.instructions = "Check GCS for drift"
+    mock_response = SwarmRouteDecision(
+        next_node="DriftAnalyzer", instructions="Check GCS for drift"
+    )
     # Mock the chain property directly
     mock_chain = AsyncMock()
     mock_chain.ainvoke.return_value = mock_response
 
     with patch.object(
-        HierarchicalSupervisor, "chain", new_callable=PropertyMock
+        SwarmController, "supervisor_chain", new_callable=PropertyMock
     ) as mock_chain_prop:
         mock_chain_prop.return_value = mock_chain
         state = {"messages": [HumanMessage(content="Is there data drift?")]}
@@ -38,51 +42,46 @@ async def test_matrix_supervisor_delegation():
 async def test_matrix_supervisor_route_intent_drift():
     """Test that the supervisor routes to DriftAnalyzer for drift-related queries."""
     mock_llm = MagicMock()
-    # Mock chain to return DriftAnalyzer
-    mock_response = MagicMock()
-    mock_response.next_node = "DriftAnalyzer"
-    mock_chain = AsyncMock()
-    mock_chain.ainvoke.return_value = mock_response
-
-    supervisor = HierarchicalSupervisor(
-        llm=mock_llm, team_members=["DriftAnalyzer"], system_prompt="..."
+    mock_intent = SwarmIntent(
+        asset_type="strategy",
+        confidence=0.9,
+        extracted_goal="Drift check",
+        entities=[],
+    )
+    mock_llm.with_structured_output.return_value = AsyncMock(
+        ainvoke=AsyncMock(return_value=mock_intent)
     )
 
-    with patch.object(
-        HierarchicalSupervisor, "chain", new_callable=PropertyMock
-    ) as mock_chain_prop:
-        mock_chain_prop.return_value = mock_chain
-        intent = await supervisor.route_intent("Is there any data drift?")
-        assert intent == "DriftAnalyzer"
+    supervisor = SwarmController(intent_llm=mock_llm)
+    intent = await supervisor.route_intent("Is there any data drift?")
+    assert intent.asset_type == "strategy"
 
 
 @pytest.mark.asyncio
 async def test_matrix_supervisor_route_intent_unknown():
     """Test that the supervisor routes to FINISH for unknown intents."""
     mock_llm = MagicMock()
-    mock_response = MagicMock()
-    mock_response.next_node = "FINISH"
-    mock_chain = AsyncMock()
-    mock_chain.ainvoke.return_value = mock_response
-
-    supervisor = HierarchicalSupervisor(
-        llm=mock_llm, team_members=["DriftAnalyzer"], system_prompt="..."
+    mock_intent = SwarmIntent(
+        asset_type="strategy",
+        confidence=0.4,
+        extracted_goal="Unknown",
+        entities=[],
+    )
+    mock_llm.with_structured_output.return_value = AsyncMock(
+        ainvoke=AsyncMock(return_value=mock_intent)
     )
 
-    with patch.object(
-        HierarchicalSupervisor, "chain", new_callable=PropertyMock
-    ) as mock_chain_prop:
-        mock_chain_prop.return_value = mock_chain
-        intent = await supervisor.route_intent("Tell me a joke")
-        assert intent == "FINISH"
+    supervisor = SwarmController(intent_llm=mock_llm)
+    intent = await supervisor.route_intent("Tell me a joke")
+    assert intent.asset_type == "strategy"
 
 
 @pytest.mark.asyncio
 async def test_matrix_supervisor_execute_loop_success():
     """Test that the supervisor can execute a full multi-turn loop."""
     mock_llm = MagicMock()
-    supervisor = HierarchicalSupervisor(
-        llm=mock_llm, team_members=["DriftAnalyzer"], system_prompt="..."
+    supervisor = SwarmController(
+        supervisor_llm=mock_llm, team_members=["DriftAnalyzer"], system_prompt="..."
     )
 
     # Mock chain returns DriftAnalyzer then FINISH
@@ -97,7 +96,7 @@ async def test_matrix_supervisor_execute_loop_success():
     nodes = {"DriftAnalyzer": mock_drift}
 
     with patch.object(
-        HierarchicalSupervisor, "chain", new_callable=PropertyMock
+        SwarmController, "supervisor_chain", new_callable=PropertyMock
     ) as mock_chain_prop:
         mock_chain_prop.return_value = mock_chain
 


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `HierarchicalSupervisor` routing and fragmented router logic with a single, testable Swarm controller to centralize intent routing and multi-agent supervision.
- Migrate routing responsibilities from the agent-level modules into a dedicated controller to simplify graph entrypoints and enable adapter-based agent invocation.
- Ensure existing agents with differing call signatures can be invoked via adapters without changing their implementations.
- Make graph entrypoints call a unified controller so routing and supervision logic is consistent across workflows.

### Description
- Add `backend/graphs/swarm_orchestrator.py` implementing `SwarmController`, `SwarmIntent`, `SwarmRouteDecision`, `SwarmAgentAdapter`, and helpers including `route_intent`, `decide_next`, `delegate_to_specialist`, `execute_loop`, and `aggregate_findings`.
- Update graph entrypoints to use the controller by replacing `IntentRouter` usage with `SwarmController().route_intent` in `backend/graphs/muse_create.py` and `backend/graphs/spine_v2.py` and adapt intent payload handling via `to_intent_payload`.
- Provide `SwarmAgentAdapter` with factory methods (`from_callable`, `from_run_method`, `from_execute_method`) to normalize existing agent `__call__`, `run`, and `execute` signatures.
- Update unit tests to exercise the new controller by replacing `HierarchicalSupervisor` references with `SwarmController` and updating mocks to use `SwarmIntent` / `SwarmRouteDecision` (files modified: `backend/tests/test_matrix_delegation.py`, `backend/tests/test_matrix_aggregation.py`, `backend/tests/test_matrix_supervisor.py`, and `backend/tests/test_logic.py`).

### Testing
- No automated test suite was executed as part of this change (no `pytest` runs were performed).
- Unit test files were updated to reference `SwarmController` and adjusted mock returns to match `SwarmIntent` / `SwarmRouteDecision` structures.
- Basic local sanity verified by committing the changes and confirming modified files compile syntactically (no runtime test execution was performed).
- Recommend running the full test suite with `pytest -q` to validate behavior across graphs and agent integrations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1c50fcc8332bf8db9a4dce18da6)