### PR TITLE
Adopt SwarmState in muse orchestration flow

### DIFF
--- a/backend/api/v1/muse.py
+++ b/backend/api/v1/muse.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from backend.core.auth import get_current_user, get_tenant_id
 from backend.graphs.muse_create import build_muse_spine
 from backend.models.cognitive import CognitiveStatus
+from backend.models.swarm import SwarmState
 
 router = APIRouter(prefix="/v1/muse", tags=["muse"])
 
@@ -37,7 +38,7 @@ async def create_muse_asset(
         spine = build_muse_spine()
 
         # Initialize state
-        initial_state = {
+        initial_state: SwarmState = {
             "raw_prompt": request.prompt,
             "workspace_id": request.workspace_id,
             "tenant_id": str(tenant_id),
@@ -51,6 +52,17 @@ async def create_muse_asset(
             "research_bundle": {},
             "quality_score": 0.0,
             "error": None,
+            "current_plan": [],
+            "active_move": None,
+            "next_node": None,
+            "last_agent": "orchestrator",
+            "swarm_tasks": [],
+            "shared_knowledge": {},
+            "delegation_history": [],
+            "hierarchy": {},
+            "budgets": {},
+            "shared_memory_handles": {},
+            "learning_artifacts": [],
         }
 
         # Configuration for LangGraph (thread_id for persistence)

--- a/backend/graphs/muse_create.py
+++ b/backend/graphs/muse_create.py
@@ -6,18 +6,15 @@ from langgraph.graph import END, START, StateGraph
 from backend.agents.base import BaseCognitiveAgent
 from backend.agents.shared.agents import IntentRouter, QualityGate
 from backend.agents.shared.context_assembler import ContextAssemblerAgent
-from backend.models.cognitive import (
-    AgentMessage,
-    CognitiveIntelligenceState,
-    CognitiveStatus,
-)
+from backend.models.cognitive import AgentMessage, CognitiveStatus
+from backend.models.swarm import SwarmState
 
 logger = logging.getLogger("raptorflow.graphs.muse_create")
 
 # --- Nodes ---
 
 
-async def router_node(state: CognitiveIntelligenceState):
+async def router_node(state: SwarmState):
     """A00: Determines the intent and family of the asset."""
     router = IntentRouter()
     intent = await router.execute(state["raw_prompt"])
@@ -41,7 +38,7 @@ async def router_node(state: CognitiveIntelligenceState):
     }
 
 
-async def context_node(state: CognitiveIntelligenceState):
+async def context_node(state: SwarmState):
     """A03: Pulls full context including learned memories."""
     assembler = ContextAssemblerAgent()
     # Assuming workspace_id and tenant_id are present in state
@@ -68,7 +65,7 @@ async def context_node(state: CognitiveIntelligenceState):
     }
 
 
-async def drafting_node(state: CognitiveIntelligenceState):
+async def drafting_node(state: SwarmState):
     """A04: Generates the first draft of the asset."""
     family = state["brief"].get("asset_family", "text")
 
@@ -124,7 +121,7 @@ async def drafting_node(state: CognitiveIntelligenceState):
     }
 
 
-async def reflection_node(state: CognitiveIntelligenceState):
+async def reflection_node(state: SwarmState):
     """A05: Critiques the draft against the quality gate."""
     gate = QualityGate()
 
@@ -159,7 +156,7 @@ async def reflection_node(state: CognitiveIntelligenceState):
     }
 
 
-def decide_refinement(state: CognitiveIntelligenceState):
+def decide_refinement(state: SwarmState):
     """Conditional edge: Should we refine or finalize?"""
     last_reflection = state["reflection_log"][-1]
 
@@ -169,7 +166,7 @@ def decide_refinement(state: CognitiveIntelligenceState):
     return "finalize"
 
 
-async def refinement_node(state: CognitiveIntelligenceState):
+async def refinement_node(state: SwarmState):
     """A06: Refines the asset based on critique."""
     # last_asset = state["generated_assets"][-1]["content"]
     # fixes = state["reflection_log"][-1]["fixes"]
@@ -206,7 +203,7 @@ async def refinement_node(state: CognitiveIntelligenceState):
     }
 
 
-async def finalize_node(state: CognitiveIntelligenceState):
+async def finalize_node(state: SwarmState):
     """A07: Finalizes the asset and prepares for delivery."""
     last_asset = state["generated_assets"][-1]
     last_asset["version"] = "final"
@@ -222,7 +219,7 @@ async def finalize_node(state: CognitiveIntelligenceState):
     }
 
 
-async def memory_update_node(state: CognitiveIntelligenceState):
+async def memory_update_node(state: SwarmState):
     """A06: Learns from the final result vs initial draft."""
     if len(state["generated_assets"]) > 1:
         # Placeholder for actual memory update logic
@@ -239,7 +236,7 @@ async def memory_update_node(state: CognitiveIntelligenceState):
 
 
 def build_muse_spine():
-    workflow = StateGraph(CognitiveIntelligenceState)
+    workflow = StateGraph(SwarmState)
 
     workflow.add_node("router", router_node)
     workflow.add_node("context", context_node)

--- a/backend/models/swarm.py
+++ b/backend/models/swarm.py
@@ -39,3 +39,15 @@ class SwarmState(CognitiveIntelligenceState):
 
     # History of delegations and specialist interactions
     delegation_history: Annotated[List[Dict[str, Any]], operator.add]
+
+    # Organizational hierarchy for multi-agent coordination
+    hierarchy: Annotated[Dict[str, Any], dict]
+
+    # Budget allocations across agents or tasks
+    budgets: Annotated[Dict[str, float], dict]
+
+    # References to shared memory handles (e.g., Redis keys, vector IDs)
+    shared_memory_handles: Annotated[Dict[str, str], dict]
+
+    # Artifacts produced during learning cycles (reports, embeddings, summaries)
+    learning_artifacts: Annotated[List[Dict[str, Any]], operator.add]

--- a/backend/tests/test_swarm_state.py
+++ b/backend/tests/test_swarm_state.py
@@ -32,6 +32,10 @@ def test_swarm_state_schema():
         ],
         "shared_knowledge": {"competitors": []},
         "delegation_history": [],
+        "hierarchy": {"lead": "supervisor", "roles": ["researcher"]},
+        "budgets": {"token_budget": 10000.0},
+        "shared_memory_handles": {"swarm_cache": "swarm:thread_1"},
+        "learning_artifacts": [{"type": "summary", "content": "Initial learnings"}],
     }
 
     assert state["swarm_tasks"][0]["id"] == "task_1"


### PR DESCRIPTION
### Motivation

- Provide a richer, typed orchestration state for multi-agent runs by extending the swarm state schema with coordination and learning fields.
- Replace loosely-typed ad-hoc `state` dictionaries in the Muse orchestration with a single `SwarmState` schema to improve consistency and enable new swarm features.

### Description

- Extended `SwarmState` in `backend/models/swarm.py` with `hierarchy`, `budgets`, `shared_memory_handles`, and `learning_artifacts` fields and kept existing swarm task/knowledge fields. 
- Updated Muse graph nodes and graph builder in `backend/graphs/muse_create.py` to accept `SwarmState` (and built the `StateGraph` with `SwarmState`).
- Updated the Muse API initial state in `backend/api/v1/muse.py` to be annotated as `SwarmState` and populated the new fields when starting the spine. 
- Updated the test fixture in `backend/tests/test_swarm_state.py` to include the newly added `SwarmState` fields.

### Testing

- No automated test suite was executed as part of this change. 
- The unit test fixture `backend/tests/test_swarm_state.py` was updated to reflect the new schema but not run here. 
- Local commit of the changes succeeded without file application errors. 
- Manual review ensured imports and type annotations were updated to reference `SwarmState`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1c63fd083329dcaad2253caf2a4)