### PR TITLE
Shared learning broadcast pipeline and agent subscriptions

### DIFF
--- a/backend/agents/researchers.py
+++ b/backend/agents/researchers.py
@@ -5,6 +5,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
 from backend.db import get_memory, save_entity, summarize_recursively
+from backend.models.cognitive import hydrate_shared_learnings
 
 logger = logging.getLogger("raptorflow.researchers.reddit")
 
@@ -53,6 +54,7 @@ class RedditSentimentAnalyst:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         # In a real SOTA graph, 'raw_research_data' would be populated by a search tool
         raw_data = state.get("research_bundle", {}).get(
             "raw_social_data", "No data available"
@@ -105,6 +107,7 @@ class LinkedInProfiler:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         raw_data = state.get("research_bundle", {}).get(
             "raw_linkedin_data", "No data available"
         )
@@ -155,6 +158,7 @@ class CompetitorFeatureMapper:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         raw_data = state.get("research_bundle", {}).get(
             "raw_competitor_data", "No data available"
         )
@@ -196,6 +200,7 @@ class EvidenceBundler:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         bundle_data = state.get("research_bundle", {})
         logger.info("Bundling research evidence...")
 
@@ -241,6 +246,7 @@ class SourceValidator:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         urls = state.get("research_bundle", {}).get("raw_urls", [])
         logger.info(f"Validating {len(urls)} sources...")
 
@@ -284,6 +290,7 @@ class TrendExtractor:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Extracting market trends...")
 
@@ -329,6 +336,7 @@ class GapFinder:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         comp_data = state.get("research_bundle", {}).get("competitor_map", {})
         logger.info("Finding market gaps...")
 
@@ -348,6 +356,7 @@ class CompetitorTracker:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         workspace_id = state.get("workspace_id")
         comp_map = state.get("research_bundle", {}).get("competitor_map", {})
 
@@ -386,6 +395,7 @@ class BrandHistoryContextualizer:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         workspace_id = state.get("workspace_id")
         logger.info(f"Retrieving brand history for workspace: {workspace_id}")
 
@@ -420,6 +430,7 @@ class ResearchSummarizer:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Summarizing research bundle...")
 
@@ -467,6 +478,7 @@ class VisualTrendAnalyzer:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         images = state.get("research_bundle", {}).get("raw_images", [])
         logger.info(f"Analyzing {len(images)} images multimodal style...")
 
@@ -508,6 +520,7 @@ class PositioningMapper:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         comp_data = state.get("research_bundle", {}).get("competitor_map", {})
         logger.info("Mapping market positioning...")
 
@@ -550,6 +563,7 @@ class SWOTAnalyzer:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Generating SWOT analysis...")
 
@@ -590,6 +604,7 @@ class ResearchQAGuard:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         brief = state.get("research_bundle", {}).get("executive_brief", "")
         logger.info("Auditing research quality...")
 

--- a/backend/agents/strategists.py
+++ b/backend/agents/strategists.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from backend.core.prompts import CampaignPrompts
 from backend.db import save_entity
+from backend.models.cognitive import hydrate_shared_learnings
 
 logger = logging.getLogger("raptorflow.strategists.icp")
 
@@ -44,6 +45,7 @@ class ICPDemographicProfiler:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Profiling target demographics...")
 
@@ -90,6 +92,7 @@ class ICPPsychographicProfiler:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Profiling target psychographics...")
 
@@ -135,6 +138,7 @@ class PainPointMapper:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Mapping customer pain points...")
 
@@ -180,6 +184,7 @@ class UVPArchitect:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         pain_points = state.get("context_brief", {}).get("pain_points", {})
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Architecting UVPs...")
@@ -229,6 +234,7 @@ class BrandVoiceAligner:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         brand_kit = state.get("context_brief", {}).get(
             "brand_kit", "Default RaptorFlow Kit"
         )
@@ -277,6 +283,7 @@ class AntiPersonaProfiler:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         icp = state.get("context_brief", {}).get("icp_demographics", {})
         logger.info("Profiling Anti-Personas...")
@@ -325,6 +332,7 @@ class CategoryArchitect:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         uvps = state.get("context_brief", {}).get("uvps", {})
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Architecting market categories...")
@@ -372,6 +380,7 @@ class TaglineGenerator:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         uvps = state.get("context_brief", {}).get("uvps", {})
         logger.info("Generating surgical taglines...")
 
@@ -406,6 +415,7 @@ class StrategyReplanner:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         alignments = (
             state.get("context_brief", {})
             .get("brand_alignment", {})
@@ -464,6 +474,7 @@ class CampaignArcDesigner:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         uvps = state.get("context_brief", {}).get("uvps", {})
         evidence = state.get("business_context", [])  # Pull from injected RAG context
         logger.info("Designing 90-day campaign arc...")
@@ -513,6 +524,7 @@ class MoveSequencer:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         arc = state.get("context_brief", {}).get("campaign_arc", {})
         logger.info("Sequencing weekly execution moves...")
 
@@ -561,6 +573,7 @@ class BudgetAllocator:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         icp = state.get("context_brief", {}).get("icp_demographics", {})
         logger.info("Allocating marketing budget...")
@@ -607,6 +620,7 @@ class ChannelSelector:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         icp = state.get("context_brief", {}).get("icp_demographics", {})
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Selecting optimal distribution channels...")
@@ -655,6 +669,7 @@ class KPIDefiner:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         channels = state.get("context_brief", {}).get("channels", {})
         arc = state.get("context_brief", {}).get("campaign_arc", {})
         logger.info("Defining success metrics (KPIs)...")
@@ -702,6 +717,7 @@ class FunnelDesigner:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         arc = state.get("context_brief", {}).get("campaign_arc", {})
         channels = state.get("context_brief", {}).get("channels", {})
         logger.info("Designing conversion funnel...")
@@ -749,6 +765,7 @@ class StrategicConflictResolver:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         arc = state.get("context_brief", {}).get("campaign_arc", {})
         history = state.get("research_bundle", {}).get("historical_context", [])
         logger.info("Checking for strategic conflicts...")
@@ -773,6 +790,7 @@ class StrategyRefreshHook:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
 
         logger.info("Evaluating strategic data sufficiency...")
@@ -827,6 +845,7 @@ class FounderArchetypeProfiler:
 
     async def __call__(self, state: TypedDict):
         """Node execution logic."""
+        state = await hydrate_shared_learnings(state)
         workspace_id = state.get("workspace_id")
         evidence = state.get("research_bundle", {}).get("final_evidence", {})
         logger.info("Profiling founder archetype...")

--- a/backend/models/cognitive.py
+++ b/backend/models/cognitive.py
@@ -6,6 +6,8 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from backend.memory.short_term import L1ShortTermMemory
+
 
 class ModelTier(str, Enum):
     ULTRA = "ultra"
@@ -108,7 +110,92 @@ class AgentSharedState(BaseModel):
 
     workspace_id: str
     context_pool: Dict[str, Any] = Field(default_factory=dict)
+    learning_artifacts: List[Dict[str, Any]] = Field(default_factory=list)
     active_locks: List[str] = Field(default_factory=list)  # For resource coordination
     updated_at: datetime = Field(default_factory=datetime.now)
 
     model_config = ConfigDict(from_attributes=True)
+
+    def add_learning_artifacts(
+        self,
+        artifacts: List[Dict[str, Any]],
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Append learning artifacts with provenance metadata."""
+        timestamp = datetime.now().isoformat()
+        payload = metadata or {}
+        for artifact in artifacts:
+            self.learning_artifacts.append(
+                {
+                    "source": source,
+                    "artifact": artifact,
+                    "metadata": payload,
+                    "timestamp": timestamp,
+                }
+            )
+        self.context_pool["learning_artifacts"] = self.learning_artifacts
+        self.updated_at = datetime.now()
+
+    def apply_to_state(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge shared learnings into an agent state payload."""
+        state.setdefault("shared_state", {})
+        state["shared_state"].update(self.model_dump())
+        state.setdefault("shared_learnings", self.learning_artifacts)
+        context_brief = state.setdefault("context_brief", {})
+        context_brief.setdefault("shared_learnings", self.learning_artifacts)
+        return state
+
+
+class LearningBroadcastPipeline:
+    """Broadcasts strategic learnings into the workspace shared state."""
+
+    def __init__(self, memory: Optional[L1ShortTermMemory] = None) -> None:
+        self.memory = memory or L1ShortTermMemory()
+
+    async def publish(
+        self,
+        workspace_id: str,
+        artifacts: List[Dict[str, Any]],
+        source: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> AgentSharedState:
+        shared_state = await self._load_shared_state(workspace_id)
+        if shared_state is None:
+            shared_state = AgentSharedState(workspace_id=workspace_id)
+        shared_state.add_learning_artifacts(artifacts, source, metadata)
+        await self._store_shared_state(shared_state)
+        return shared_state
+
+    async def subscribe(self, workspace_id: str) -> Optional[AgentSharedState]:
+        return await self._load_shared_state(workspace_id)
+
+    async def _load_shared_state(
+        self, workspace_id: str
+    ) -> Optional[AgentSharedState]:
+        if not self.memory.client:
+            return None
+        raw = await self.memory.retrieve(f"shared_state:{workspace_id}")
+        if not raw:
+            return None
+        return AgentSharedState(**raw)
+
+    async def _store_shared_state(self, shared_state: AgentSharedState) -> None:
+        if not self.memory.client:
+            return
+        await self.memory.store(
+            f"shared_state:{shared_state.workspace_id}",
+            shared_state.model_dump(mode="json"),
+        )
+
+
+async def hydrate_shared_learnings(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach shared learnings to the agent state if available."""
+    workspace_id = state.get("workspace_id")
+    if not workspace_id:
+        return state
+    pipeline = LearningBroadcastPipeline()
+    shared_state = await pipeline.subscribe(workspace_id)
+    if shared_state is None:
+        return state
+    return shared_state.apply_to_state(state)


### PR DESCRIPTION
### Motivation
- Provide a workspace-level mechanism to publish strategic learnings so multiple agents can consume them.  
- Store learning artifacts with provenance so downstream specialists can reference prior findings.  
- Ensure specialist agents (researchers/strategists) read updated learnings before performing work to improve context and reduce redundant work.  

### Description
- Added `learning_artifacts` plus `add_learning_artifacts` and `apply_to_state` to `AgentSharedState` in `backend/models/cognitive.py` to persist and merge learnings.  
- Implemented `LearningBroadcastPipeline` with `publish`/`subscribe` backed by `L1ShortTermMemory` to store shared state at `shared_state:{workspace_id}`.  
- Added `hydrate_shared_learnings(state)` helper that loads shared state and merges learnings into agent payloads.  
- Updated `backend/agents/researchers.py` and `backend/agents/strategists.py` to import and call `hydrate_shared_learnings` at the start of agent `__call__` flows so agents see the latest shared learnings before execution.  

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1c7f990833285678a63836d3857)