### PR TITLE
Add capability profiles and RBAC enforcement for tools and matrix skills

### DIFF
--- a/backend/agents/moves.py
+++ b/backend/agents/moves.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 from backend.core.prompts import MovePrompts
 from backend.core.toolbelt import ToolbeltV2
+from backend.models.capabilities import CapabilityProfile
 from backend.db import log_agent_decision, save_move
 
 logger = logging.getLogger("raptorflow.agents.moves")
@@ -193,8 +194,8 @@ class SkillExecutor:
     Orchestrates tool calls for a move based on its required skills.
     """
 
-    def __init__(self):
-        self.belt = ToolbeltV2()
+    def __init__(self, capability_profile: Optional[CapabilityProfile] = None):
+        self.belt = ToolbeltV2(capability_profile=capability_profile)
 
     async def __call__(self, state: TypedDict):
         """Execute tools for the current moves."""

--- a/backend/core/toolbelt.py
+++ b/backend/core/toolbelt.py
@@ -1,9 +1,10 @@
 import json
 import logging
 from functools import wraps
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from backend.core.cache import get_cache_manager
+from backend.models.capabilities import CapabilityProfile
 from backend.tools.image_gen import NanoBananaImageTool
 from backend.tools.muse import AssetGenTool
 from backend.tools.search import (
@@ -56,7 +57,8 @@ class ToolbeltV2:
     The complete implementation of the deterministic agent layer.
     """
 
-    def __init__(self):
+    def __init__(self, capability_profile: Optional[CapabilityProfile] = None):
+        self.capability_profile = capability_profile
         self.tools = {
             "raptor_search": RaptorSearchTool(),
             "tavily_search": TavilyMultiHopTool(),
@@ -67,6 +69,13 @@ class ToolbeltV2:
 
     async def run_tool(self, tool_name: str, **kwargs) -> Dict[str, Any]:
         """SOTA Dispatcher for tool execution."""
+        if self.capability_profile and not self.capability_profile.allows_tool(
+            tool_name
+        ):
+            return {
+                "success": False,
+                "error": f"Tool '{tool_name}' not permitted by capability profile.",
+            }
         tool = self.tools.get(tool_name)
         if not tool:
             return {

--- a/backend/models/capabilities.py
+++ b/backend/models/capabilities.py
@@ -1,0 +1,30 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from backend.skills.matrix_skills import SkillPrivilegeMatrix, UserRole
+
+
+class CapabilityProfile(BaseModel):
+    """Defines which tools and skills an agent is allowed to use."""
+
+    name: str
+    allowed_tools: Optional[List[str]] = Field(default=None)
+    allowed_skills: Optional[List[str]] = Field(default=None)
+    rbac_role: Optional[UserRole] = Field(default=None)
+
+    def allows_tool(self, tool_name: str) -> bool:
+        if self.allowed_tools is None:
+            return True
+        return tool_name in self.allowed_tools
+
+    def allows_skill(
+        self, skill_name: str, rbac_matrix: Optional[SkillPrivilegeMatrix] = None
+    ) -> bool:
+        if self.allowed_skills is not None and skill_name not in self.allowed_skills:
+            return False
+
+        if self.rbac_role and rbac_matrix:
+            return rbac_matrix.has_permission(self.rbac_role, skill_name)
+
+        return True


### PR DESCRIPTION
### Motivation

- Introduce a capability profile abstraction to express which deterministic tools and matrix skills an agent may use.  
- Enforce least-privilege access for agentic tool/skill execution via allowlists and existing RBAC matrix.  
- Prevent agents from being bound to or invoking tools/skills they are not permitted to use.  

### Description

- Add `CapabilityProfile` model in `backend/models/capabilities.py` with `allowed_tools`, `allowed_skills`, and optional `rbac_role`, and helper methods `allows_tool` and `allows_skill`.  
- Extend `BaseCognitiveAgent` (`backend/agents/base.py`) to accept `capability_profile` and filter bound tools via a new `_filter_tools` method.  
- Update `ToolbeltV2` (`backend/core/toolbelt.py`) to accept a `capability_profile` and refuse execution of tools not permitted by the profile.  
- Enforce skill-level checks in the Matrix flow by filtering available skills in `SkillSelectorAgent` (`backend/agents/matrix_agents.py`), gating `MatrixService.execute_skill` (`backend/services/matrix_service.py`) on capability/RBAC, and deriving a `CapabilityProfile` from the API caller role in `backend/api/v1/matrix.py`; also propagate profile usage to `SkillExecutor` (`backend/agents/moves.py`).  

### Testing

- No automated tests were executed as part of this change.  
- Existing test suite was not run; integration or unit tests should be added/updated to validate tool and skill gating behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1c9fdd883329ab146033a18e35c)