### PR TITLE
Add BudgetGovernor service and enforce budget checks before agent/tool execution

### DIFF
--- a/backend/graphs/research_deep_advanced.py
+++ b/backend/graphs/research_deep_advanced.py
@@ -7,13 +7,29 @@ from backend.core.config import get_settings
 from backend.core.crawler_advanced import AdvancedCrawler
 from backend.core.research_engine import SearchProvider
 from backend.models.research_schemas import FactClaim, ResearchDeepState, WebDocument
+from backend.services.budget_governor import BudgetGovernor
 
 # --- Nodes ---
+
+_budget_governor = BudgetGovernor()
+
+
+async def _guard_budget(state: ResearchDeepState, agent_id: str) -> dict:
+    workspace_id = state.get("workspace_id") or state.get("tenant_id")
+    budget_check = await _budget_governor.check_budget(
+        workspace_id=workspace_id, agent_id=agent_id
+    )
+    if not budget_check["allowed"]:
+        return {"status": "error", "final_report_md": budget_check["reason"]}
+    return {}
 
 
 async def planning_node(state: ResearchDeepState):
     """Librarian plans the next wave of search."""
     agent = LibrarianAgent()
+    budget_guard = await _guard_budget(state, "LibrarianAgent")
+    if budget_guard:
+        return budget_guard
     queries = await agent.plan_search(state.objective, state.research_logs)
     return {
         "queries": queries,
@@ -98,6 +114,9 @@ async def verification_node(state: ResearchDeepState):
 async def synthesis_node(state: ResearchDeepState):
     """Final Agent assembles the premium report."""
     agent = SynthesisAgent()
+    budget_guard = await _guard_budget(state, "SynthesisAgent")
+    if budget_guard:
+        return budget_guard
     report = await agent.generate_report(state.objective, state.claims)
     return {"final_report_md": report, "status": "completed"}
 

--- a/backend/services/budget_governor.py
+++ b/backend/services/budget_governor.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Any, Dict, Optional
+
+from backend.core.cache import get_cache_client
+from backend.services.cost_governor import CostGovernor
+from backend.skills.matrix_skills import InferenceThrottlingSkill
+
+logger = logging.getLogger("raptorflow.services.budget_governor")
+
+
+class BudgetGovernor:
+    """
+    SOTA Budget Governor Service.
+    Enforces workspace budget constraints before agent or tool execution.
+    Integrates with InferenceThrottlingSkill to rate-limit agents when over budget.
+    """
+
+    def __init__(self, daily_budget: float = 50.0, throttle_tpm_limit: int = 100):
+        self._cost_governor = CostGovernor(daily_budget=daily_budget)
+        self._throttle_tpm_limit = throttle_tpm_limit
+        self._throttling_skill = None
+
+        redis_client = get_cache_client()
+        if redis_client:
+            self._throttling_skill = InferenceThrottlingSkill(redis_client)
+
+    async def check_budget(
+        self, workspace_id: Optional[str], agent_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Evaluates budget constraints and applies throttling if necessary."""
+        if not workspace_id:
+            logger.warning("Budget check skipped: no workspace_id provided.")
+            return {
+                "allowed": True,
+                "reason": "workspace_id missing",
+                "throttled": False,
+            }
+
+        try:
+            is_over_budget = await self._cost_governor.is_over_budget(workspace_id)
+        except Exception as exc:
+            logger.error(f"Budget check failed for {workspace_id}: {exc}")
+            return {
+                "allowed": True,
+                "reason": "budget check failed",
+                "throttled": False,
+            }
+
+        if not is_over_budget:
+            return {"allowed": True, "reason": "", "throttled": False}
+
+        throttle_response = None
+        throttled = False
+        if agent_id and self._throttling_skill:
+            throttle_response = await self._throttling_skill.execute(
+                {
+                    "agent_id": agent_id,
+                    "tpm_limit": self._throttle_tpm_limit,
+                    "reason": "budget_exceeded",
+                }
+            )
+            if isinstance(throttle_response, dict):
+                throttled = bool(throttle_response.get("throttling_applied"))
+
+        reason = f"Budget exceeded for workspace {workspace_id}."
+        logger.warning(reason)
+
+        return {
+            "allowed": False,
+            "reason": reason,
+            "throttled": throttled,
+            "throttle_response": throttle_response,
+        }

--- a/backend/skills/matrix_skills.py
+++ b/backend/skills/matrix_skills.py
@@ -141,9 +141,15 @@ class InferenceThrottlingSkill(MatrixSkill):
     async def execute(self, params: Dict[str, Any]) -> Dict[str, Any]:
         agent_id = params.get("agent_id")
         tpm_limit = params.get("tpm_limit", 1000)  # Tokens Per Minute
+        reason = params.get("reason")
 
         if not agent_id:
             return {"error": "agent_id is required"}
+
+        if reason:
+            logger.info(
+                f"Inference throttling reason for {agent_id}: {reason}"
+            )
 
         logger.info(f"Applying throttling to {agent_id}: {tpm_limit} TPM")
 
@@ -156,6 +162,7 @@ class InferenceThrottlingSkill(MatrixSkill):
                 "throttling_applied": True,
                 "agent_id": agent_id,
                 "tpm_limit": tpm_limit,
+                "reason": reason,
                 "status": "active",
             }
         except Exception as e:


### PR DESCRIPTION
### Motivation
- Provide a central service to prevent runaway cost by enforcing workspace-level budget constraints before agents or tools execute.
- Integrate budget enforcement with existing throttling primitives so agents can be rate-limited when over budget.
- Ensure orchestration graphs and the toolbelt respect budget constraints to avoid unexpected spend during multi-agent runs.

### Description
- Added `backend/services/budget_governor.py` which wraps `CostGovernor` and, when possible, calls `InferenceThrottlingSkill` to throttle agent TPMs when budgets are exceeded.
- Extended `InferenceThrottlingSkill.execute` in `backend/skills/matrix_skills.py` to accept a `reason` and return it in the throttle response for observability.
- Enforced budget checks in the tool dispatcher by instantiating `BudgetGovernor` in `backend/core/toolbelt.py` and performing `check_budget` before calling `run_tool` (supports `workspace_id` and `agent_id` kwargs).
- Added budget guard checks to orchestration graphs and subgraphs (`moves_campaigns_orchestrator.py`, `spine_v3.py`, `spine_v2.py`, `muse_create.py`, `research_deep_advanced.py`, `blackbox_analysis.py`, `blackbox_industrial.py`, and `subgraphs/campaign_planner.py`) so agents are short-circuited when the budget governor blocks execution.

### Testing
- No automated tests were executed as part of this change (no test run requested).
- Existing unit tests for matrix skills (e.g., `backend/tests/test_matrix_skills.py`) remain in the repository but were not run during this rollout.
- Manual static checks (imports/format) were performed during development but not formalized into an automated test run.
- Recommend running the existing test suite and targeted integration tests for orchestration graphs and tool execution after deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cb1cadffc8332b3d1afe9353a8abe)