### PR TITLE
Add SwarmSubtaskSpec model and include `subtask_specs` in `SwarmState`

### DIFF
--- a/backend/models/swarm.py
+++ b/backend/models/swarm.py
@@ -7,12 +7,30 @@ from pydantic import BaseModel, Field
 from backend.models.cognitive import CognitiveIntelligenceState
 from backend.models.queue_controller import CapabilityProfile, QueueController
 
+__all__ = [
+    "SwarmSubtaskSpec",
+    "SwarmTask",
+    "SwarmTaskStatus",
+    "SwarmState",
+]
+
 
 class SwarmTaskStatus(str, Enum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+class SwarmSubtaskSpec(BaseModel):
+    """Structured specification for a swarm subtask."""
+
+    id: str
+    specialist_type: str
+    objective: str
+    success_criteria: List[str] = Field(default_factory=list)
+    dependencies: List[str] = Field(default_factory=list)
+    inputs: Dict[str, Any] = Field(default_factory=dict)
 
 
 class SwarmTask(BaseModel):
@@ -31,6 +49,8 @@ class SwarmState(CognitiveIntelligenceState):
     SOTA Swarm Intelligence State.
     Extends the base cognitive state with multi-agent coordination fields.
     """
+
+    subtask_specs: Annotated[List[SwarmSubtaskSpec], operator.add]
 
     # List of delegated sub-tasks
     swarm_tasks: Annotated[List[SwarmTask], operator.add]


### PR DESCRIPTION
### Motivation
- Provide a structured, typed model for subtasks produced by the decomposition chain so downstream code can rely on a stable schema.
- Ensure the fields used by the decomposer (`id`, `specialist_type`, `objective`, `success_criteria`, `dependencies`, `inputs`) are available as a Pydantic model.
- Make the model importable from `backend.models.swarm` and include subtask specs in the runtime swarm state for consistent use across the decomposition and controller logic.

### Description
- Add `SwarmSubtaskSpec` Pydantic model to `backend/models/swarm.py` with fields `id`, `specialist_type`, `objective`, `success_criteria`, `dependencies`, and `inputs`.
- Add `subtask_specs: Annotated[List[SwarmSubtaskSpec], operator.add]` to `SwarmState` so decomposition results become part of the state schema.
- Export the new model and related symbols via `__all__` in `backend.models.swarm` for consistent imports.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16b46fa08332a2d9e4ec4c10daa8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced swarm subtask specifications enabling detailed task configuration with objectives, success criteria, and dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->