### PR TITLE
Default swarm metadata TypedDicts to empty dicts

### DIFF
--- a/backend/graphs/swarm_orchestrator.py
+++ b/backend/graphs/swarm_orchestrator.py
@@ -1,6 +1,6 @@
 import inspect
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, cast
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -201,9 +201,9 @@ class SwarmOrchestrator:
 
     def _ensure_metadata(self, state: Dict[str, Any]) -> Dict[str, Any]:
         state = state.copy()
-        state.setdefault("routing_metadata", RoutingMetadata())
-        state.setdefault("shared_memory_handles", SharedMemoryHandles())
-        state.setdefault("resource_budget", ResourceBudget())
+        state.setdefault("routing_metadata", cast(RoutingMetadata, {}))
+        state.setdefault("shared_memory_handles", cast(SharedMemoryHandles, {}))
+        state.setdefault("resource_budget", cast(ResourceBudget, {}))
         state.setdefault("delegation_history", [])
         state.setdefault("shared_knowledge", {})
         state.setdefault("swarm_tasks", [])


### PR DESCRIPTION
### Motivation
- Avoid constructing TypedDict types directly and provide plain dictionaries compatible with the TypedDict schemas to prevent runtime/type issues.
- Keep the swarm orchestration state initialization consistent with the `TypedDict` definitions in `backend/models/cognitive.py`.

### Description
- Import `cast` from `typing` and use `cast(RoutingMetadata, {})`, `cast(SharedMemoryHandles, {})`, and `cast(ResourceBudget, {})` as defaults in `_ensure_metadata` instead of calling the TypedDict classes.
- Update `_ensure_metadata` to `state.setdefault("routing_metadata", cast(RoutingMetadata, {}))`, `state.setdefault("shared_memory_handles", cast(SharedMemoryHandles, {}))`, and `state.setdefault("resource_budget", cast(ResourceBudget, {}))` while keeping other keys unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16b8617c8332af32d0ac15e7d031)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal system initialization and type handling for better code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->