### PR TITLE
Normalize Swarm Orchestrator message shape

### DIFF
--- a/backend/graphs/swarm_orchestrator.py
+++ b/backend/graphs/swarm_orchestrator.py
@@ -2,13 +2,14 @@ import inspect
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from pydantic import BaseModel, Field
 
 from backend.agents.router import IntentRouterAgent
 from backend.inference import InferenceProvider
 from backend.models.cognitive import (
+    AgentMessage,
     ResourceBudget,
     RoutingMetadata,
     SharedMemoryHandles,
@@ -213,7 +214,11 @@ class SwarmOrchestrator:
         logger.info("Swarm Controller evaluating state...")
         state = self._ensure_metadata(state)
 
-        response = await self.chain.ainvoke(state)
+        state_for_chain = state.copy()
+        state_for_chain["messages"] = self._format_messages(
+            state_for_chain.get("messages", [])
+        )
+        response = await self.chain.ainvoke(state_for_chain)
         next_node = getattr(response, "next_node", None) or response.get("next_node")
         instructions = getattr(response, "instructions", None) or response.get(
             "instructions"
@@ -284,7 +289,14 @@ class SwarmOrchestrator:
 
                 summary = result.get("analysis_summary", "Task completed.")
                 current_state["messages"].append(
-                    AIMessage(content=f"[{next_node}]: {summary}")
+                    AgentMessage(
+                        role=next_node,
+                        content=f"[{next_node}]: {summary}",
+                        metadata={
+                            "source": next_node,
+                            "instructions": instructions,
+                        },
+                    )
                 )
                 current_state["delegation_history"].append(
                     {
@@ -301,6 +313,36 @@ class SwarmOrchestrator:
 
         current_state["next"] = "FINISH"
         return current_state
+
+    def _format_messages(self, state_messages: List[Any]) -> List[BaseMessage]:
+        lc_messages: List[BaseMessage] = []
+        for message in state_messages:
+            if isinstance(message, BaseMessage):
+                lc_messages.append(message)
+                continue
+
+            if isinstance(message, AgentMessage):
+                role = message.role
+                content = message.content
+            elif isinstance(message, dict):
+                role = message.get("role", "human")
+                content = message.get("content", "")
+            else:
+                role = "human"
+                content = str(message)
+
+            if role in {"human", "user"}:
+                lc_messages.append(HumanMessage(content=content))
+            elif role == "system":
+                lc_messages.append(SystemMessage(content=content))
+            else:
+                prefix = f"[{role}]: "
+                formatted = (
+                    content if content.startswith(prefix) else f"{prefix}{content}"
+                )
+                lc_messages.append(AIMessage(content=formatted))
+
+        return lc_messages
 
     async def delegate_to_specialist(
         self, specialist_name: str, state: Dict[str, Any], specialist_node: Any


### PR DESCRIPTION
### Motivation

- Ensure the Swarm Controller and specialist nodes use a consistent message shape (either `AgentMessage`-like dicts or `langchain_core` messages) to avoid mismatches during orchestration.
- Make controller prompts consume `langchain_core.messages.BaseMessage` instances reliably so the `ChatPromptTemplate` and LLM chains receive uniform input.
- Preserve provenance for delegated summaries by storing them as structured `AgentMessage` entries with metadata.

### Description

- Import `AgentMessage` and `BaseMessage` and add a `_format_messages` helper that converts `AgentMessage`, plain `dict`, and raw strings into `HumanMessage`/`SystemMessage`/`AIMessage` for the chain.
- Before invoking the controller chain, copy the state and set `state_for_chain["messages"]` to the formatted LangChain messages via `_format_messages`.
- Replace appended LangChain `AIMessage` summary entries with structured `AgentMessage` objects that include `role`, `content`, and `metadata` (source/instructions).
- Keep existing delegation and routing behavior while normalizing message shape across producers and consumers.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16ba3ac48332b0bce923169a376d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced orchestration system with improved message handling capabilities, including support for agent-generated messages and standardized formatting for better message processing consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->