### PR TITLE
Add SwarmLearningMemory to handle feedback across L1/L2/L3

### DIFF
--- a/backend/memory/swarm_learning.py
+++ b/backend/memory/swarm_learning.py
@@ -129,3 +129,149 @@ class SwarmLearning:
         except Exception as e:
             logger.error(f"SwarmLearning promote_learning failed: {e}")
             return False
+
+
+class SwarmLearningMemory:
+    """
+    Swarm memory manager for user feedback and swarm context recall.
+    """
+
+    def __init__(self, memory_manager: Optional[MemoryManager] = None):
+        self.memory = memory_manager or MemoryManager()
+
+    @staticmethod
+    def _normalize_feedback_metadata(
+        context: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        normalized = dict(metadata or {})
+        normalized.setdefault("context", context)
+        normalized.setdefault("signal", normalized.get("signal") or "neutral")
+        normalized.setdefault("tool_hint", normalized.get("tool_hint"))
+        normalized.setdefault("agent_hint", normalized.get("agent_hint"))
+        return normalized
+
+    @staticmethod
+    def _matches_scope(metadata: Dict[str, Any], swarm_scope: Optional[str]) -> bool:
+        if not swarm_scope:
+            return True
+        return any(
+            hint == swarm_scope
+            for hint in (
+                metadata.get("swarm_scope"),
+                metadata.get("agent_hint"),
+                metadata.get("tool_hint"),
+            )
+        )
+
+    async def store_feedback(
+        self,
+        workspace_id: str,
+        feedback: str,
+        context: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        ttl: int = 3600 * 24,
+    ) -> str:
+        """Stores user feedback in L1/L2 and promotes to L3 for swarm recall."""
+        normalized_metadata = self._normalize_feedback_metadata(context, metadata)
+        entry = {"content": feedback, "metadata": normalized_metadata}
+
+        l1_key = f"swarm:feedback:{workspace_id}"
+        existing = await self.memory.l1.retrieve(l1_key) or []
+        if not isinstance(existing, list):
+            existing = [existing]
+        existing.append(entry)
+        await self.memory.l1.store(l1_key, existing, ttl=ttl)
+
+        embedder = InferenceProvider.get_embeddings()
+        embedding_text = f"{feedback}\nContext: {context}"
+        embedding = await embedder.aembed_query(embedding_text)
+        feedback_id = await self.memory.l2.store_episode(
+            workspace_id=workspace_id,
+            content=feedback,
+            embedding=embedding,
+            metadata={**normalized_metadata, "subtype": "swarm_feedback"},
+        )
+
+        await self.memory.l3.remember_foundation(
+            workspace_id=workspace_id,
+            content=feedback,
+            embedding=embedding,
+            metadata={**normalized_metadata, "subtype": "swarm_feedback"},
+        )
+
+        return feedback_id
+
+    async def recall_feedback(
+        self,
+        workspace_id: str,
+        query: str,
+        limit: int = 5,
+        swarm_scope: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Recalls similar feedback from L2, optionally filtered by swarm scope."""
+        embedder = InferenceProvider.get_embeddings()
+        query_embedding = await embedder.aembed_query(query)
+
+        results = await self.memory.l2.recall_similar(
+            workspace_id,
+            query_embedding,
+            limit=limit,
+            filters={"subtype": "swarm_feedback"},
+        )
+
+        return [
+            entry
+            for entry in results
+            if self._matches_scope(entry.get("metadata", {}), swarm_scope)
+        ]
+
+    async def retrieve_swarm_context(
+        self,
+        workspace_id: str,
+        query: str,
+        swarm_scope: Optional[str] = None,
+        limit: int = 5,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Aggregates L1/L2/L3 feedback for swarm-aware recall."""
+        context: Dict[str, List[Dict[str, Any]]] = {
+            "short_term": [],
+            "episodic": [],
+            "semantic": [],
+        }
+
+        l1_key = f"swarm:feedback:{workspace_id}"
+        l1_data = await self.memory.l1.retrieve(l1_key) or []
+        if not isinstance(l1_data, list):
+            l1_data = [l1_data]
+        scoped_l1 = [
+            entry
+            for entry in l1_data
+            if self._matches_scope(entry.get("metadata", {}), swarm_scope)
+        ]
+        context["short_term"] = scoped_l1[-limit:]
+
+        embedder = InferenceProvider.get_embeddings()
+        query_embedding = await embedder.aembed_query(query)
+        episodic_results = await self.memory.l2.recall_similar(
+            workspace_id,
+            query_embedding,
+            limit=limit,
+            filters={"subtype": "swarm_feedback"},
+        )
+        context["episodic"] = [
+            entry
+            for entry in episodic_results
+            if self._matches_scope(entry.get("metadata", {}), swarm_scope)
+        ]
+
+        semantic_results = await self.memory.l3.search_foundation(
+            workspace_id, query, limit=limit
+        )
+        context["semantic"] = [
+            entry
+            for entry in semantic_results
+            if entry.get("metadata", {}).get("subtype") == "swarm_feedback"
+            and self._matches_scope(entry.get("metadata", {}), swarm_scope)
+        ]
+
+        return context


### PR DESCRIPTION
### Motivation
- Provide a dedicated feedback-focused swarm memory that aligns metadata with router and feedback API usage.
- Enable storing user feedback into the multi-tier memory system (L1 short-term, L2 episodic, L3 semantic) for later recall and routing bias.
- Allow scope-aware filtering so router and MemoryManager can retrieve feedback relevant to a specific swarm, agent, or tool.
- Reuse existing memory components and the existing `InferenceProvider` for embeddings to keep behavior consistent with other memory paths.

### Description
- Added a new class `SwarmLearningMemory` with methods `store_feedback`, `recall_feedback`, and `retrieve_swarm_context` to `backend/memory/swarm_learning.py`.
- Normalizes feedback metadata via `_normalize_feedback_metadata` and uses `_matches_scope` to filter by `swarm_scope`, `agent_hint`, or `tool_hint`.
- Persists feedback into L1 (Redis) under `swarm:feedback:{workspace_id}`, stores episodes in L2 with `subtype: "swarm_feedback"`, and promotes a copy to L3 foundation memory for long-term retrieval.
- Uses `MemoryManager` (`l1`, `l2`, `l3`) and `InferenceProvider` embeddings for semantic recall and integrates with the existing `MemoryManager.retrieve_context` flow.

### Testing
- No automated tests were run on this change.
- (If desired) Run unit tests with `pytest backend/tests` to validate integration with memory backends and the router feedback flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16b5875c8332a8f2e3f146e8289a)