### PR TITLE
Add `swarm_cache` handle to SharedMemoryHandles schema

### DIFF
--- a/backend/models/cognitive.py
+++ b/backend/models/cognitive.py
@@ -144,6 +144,7 @@ class RoutingMetadata(TypedDict, total=False):
 class SharedMemoryHandles(TypedDict, total=False):
     """Shared memory identifiers for swarm execution."""
 
+    swarm_cache: Optional[str]
     workspace_memory_id: Optional[str]
     thread_memory_id: Optional[str]
     blackbox_memory_id: Optional[str]


### PR DESCRIPTION
### Motivation
- Tests and swarm code expect a `swarm_cache` key inside shared memory handles which the schema did not include.
- Align the cognitive state schema with swarm-specific usages so the API and tests agree on key names. 
- Ensure backward compatibility by adding an optional field rather than renaming existing keys.

### Description
- Add `swarm_cache: Optional[str]` to the `SharedMemoryHandles` TypedDict in `backend/models/cognitive.py`.
- This makes `shared_memory_handles` accept the `swarm_cache` identifier used by `backend/tests/test_swarm_state.py` and other swarm code.
- No other fields or files were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16bbc5e08332b1e441613409d096)