### PR TITLE
Make SwarmState capability/queue optional and initialize defaults in orchestrator

### DIFF
--- a/backend/graphs/swarm_orchestrator.py
+++ b/backend/graphs/swarm_orchestrator.py
@@ -13,6 +13,7 @@ from backend.models.cognitive import (
     RoutingMetadata,
     SharedMemoryHandles,
 )
+from backend.models.queue_controller import CapabilityProfile, QueueController
 
 logger = logging.getLogger("raptorflow.swarm.orchestrator")
 
@@ -207,6 +208,17 @@ class SwarmOrchestrator:
         state.setdefault("delegation_history", [])
         state.setdefault("shared_knowledge", {})
         state.setdefault("swarm_tasks", [])
+        queue_controller = state.get("queue_controller")
+        capability_profile = (
+            state.get("capability_profile")
+            or getattr(queue_controller, "capability_profile", None)
+            or CapabilityProfile()
+        )
+        state.setdefault("capability_profile", capability_profile)
+        state.setdefault(
+            "queue_controller",
+            queue_controller or QueueController(capability_profile=capability_profile),
+        )
         return state
 
     async def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/models/swarm.py
+++ b/backend/models/swarm.py
@@ -26,7 +26,7 @@ class SwarmTask(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
-class SwarmState(CognitiveIntelligenceState):
+class SwarmState(CognitiveIntelligenceState, total=False):
     """
     SOTA Swarm Intelligence State.
     Extends the base cognitive state with multi-agent coordination fields.


### PR DESCRIPTION
### Motivation
- Make swarm orchestration resilient to partially-populated state payloads by not requiring capability/queue objects to always be present. 
- Ensure the orchestrator will supply sane defaults for concurrency controls when state is constructed or received from external callers.

### Description
- Make `SwarmState` a partial `TypedDict` by adding `total=False` so `capability_profile` and `queue_controller` are optional.  
- Import `CapabilityProfile` and `QueueController` into `backend/graphs/swarm_orchestrator.py` and update `_ensure_metadata` to compute a `capability_profile` from `state`, fall back to `queue_controller.capability_profile` if present, or create a new `CapabilityProfile()` otherwise.  
- Ensure `_ensure_metadata` sets a `queue_controller` default using `QueueController(capability_profile=capability_profile)` when missing.  
- Modified files: `backend/models/swarm.py` and `backend/graphs/swarm_orchestrator.py`.

### Testing
- No automated tests were executed as part of this change.  
- Existing unit tests that reference `SwarmState` and queue behavior were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16bcefc083328ed9c58f42dee965)