### PR TITLE
Add `SwarmController` alias and export alongside `SwarmOrchestrator`

### DIFF
--- a/backend/graphs/swarm_orchestrator.py
+++ b/backend/graphs/swarm_orchestrator.py
@@ -387,3 +387,8 @@ class SwarmOrchestrator:
             summary_parts.append(f"- [{source}]: {text}")
 
         return "\n".join(summary_parts)
+
+
+SwarmController = SwarmOrchestrator
+
+__all__ = ["SwarmController", "SwarmOrchestrator"]


### PR DESCRIPTION
### Motivation
- Provide a backwards-compatible name so downstream imports referencing `SwarmController` resolve to the existing implementation.
- Avoid breaking changes when renaming or re-exporting the orchestrator implementation.
- Make the public API of the module explicit by listing exported symbols.

### Description
- Added `SwarmController = SwarmOrchestrator` at the end of `backend/graphs/swarm_orchestrator.py` to create an alias.
- Added `__all__ = ["SwarmController", "SwarmOrchestrator"]` to explicitly export both names from the module.
- No behavioral changes to `SwarmOrchestrator` logic were made.

### Testing
- No automated tests were executed for this change.
- The change is limited to symbol aliasing and module exports, so runtime behavior should remain unchanged for existing callers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d16b74d94833296847f926a6c37f4)