### PR TITLE
Add migration to define core profiles, onboarding, business context, subscriptions and payments tables

### DIFF
--- a/supabase/migrations/20260130000000_define_core_tables.sql
+++ b/supabase/migrations/20260130000000_define_core_tables.sql
@@ -1,0 +1,159 @@
+-- Define core tables for profiles, workspaces, onboarding, business context, subscriptions, and payments
+
+BEGIN;
+
+-- Ensure UUID extension exists
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Users profiles table
+CREATE TABLE IF NOT EXISTS public.users_profiles (
+    id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    email TEXT UNIQUE NOT NULL,
+    full_name TEXT,
+    avatar_url TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Workspaces table (create if missing, keep existing schema if already defined)
+CREATE TABLE IF NOT EXISTS public.workspaces (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_id UUID NOT NULL REFERENCES public.users_profiles(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    slug TEXT UNIQUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Onboarding sessions table
+CREATE TABLE IF NOT EXISTS public.onboarding_sessions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    workspace_id UUID NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+    user_profile_id UUID NOT NULL REFERENCES public.users_profiles(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'in_progress' CHECK (status IN ('in_progress', 'completed', 'abandoned')),
+    started_at TIMESTAMPTZ DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (workspace_id, user_profile_id)
+);
+
+-- Onboarding steps table
+CREATE TABLE IF NOT EXISTS public.onboarding_steps (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    session_id UUID NOT NULL REFERENCES public.onboarding_sessions(id) ON DELETE CASCADE,
+    step_key TEXT NOT NULL,
+    step_status TEXT NOT NULL DEFAULT 'pending' CHECK (step_status IN ('pending', 'in_progress', 'completed', 'skipped')),
+    step_payload JSONB DEFAULT '{}'::jsonb,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (session_id, step_key)
+);
+
+-- Business contexts table
+CREATE TABLE IF NOT EXISTS public.business_contexts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    workspace_id UUID NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+    user_profile_id UUID NOT NULL REFERENCES public.users_profiles(id) ON DELETE CASCADE,
+    version TEXT NOT NULL DEFAULT '1.0.0',
+    context_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (workspace_id, user_profile_id, version)
+);
+
+-- BCM manifests table
+CREATE TABLE IF NOT EXISTS public.bcm_manifests (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    business_context_id UUID NOT NULL REFERENCES public.business_contexts(id) ON DELETE CASCADE,
+    workspace_id UUID NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+    user_profile_id UUID NOT NULL REFERENCES public.users_profiles(id) ON DELETE CASCADE,
+    manifest_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    version TEXT NOT NULL DEFAULT '1.0.0',
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'archived')),
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (business_context_id, version)
+);
+
+-- Subscriptions table
+CREATE TABLE IF NOT EXISTS public.subscriptions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_profile_id UUID NOT NULL REFERENCES public.users_profiles(id) ON DELETE CASCADE,
+    plan_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    current_period_start TIMESTAMPTZ NOT NULL,
+    current_period_end TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Payments table
+CREATE TABLE IF NOT EXISTS public.payments (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_profile_id UUID NOT NULL REFERENCES public.users_profiles(id) ON DELETE CASCADE,
+    transaction_id TEXT UNIQUE NOT NULL,
+    amount INTEGER NOT NULL,
+    currency TEXT DEFAULT 'INR',
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Ensure timestamps exist on existing tables
+ALTER TABLE public.payments ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.workspaces ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.workspaces ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.subscriptions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.subscriptions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+-- Updated_at triggers
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_users_profiles_updated_at') THEN
+        CREATE TRIGGER update_users_profiles_updated_at
+        BEFORE UPDATE ON public.users_profiles
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_onboarding_sessions_updated_at') THEN
+        CREATE TRIGGER update_onboarding_sessions_updated_at
+        BEFORE UPDATE ON public.onboarding_sessions
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_onboarding_steps_updated_at') THEN
+        CREATE TRIGGER update_onboarding_steps_updated_at
+        BEFORE UPDATE ON public.onboarding_steps
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_business_contexts_updated_at') THEN
+        CREATE TRIGGER update_business_contexts_updated_at
+        BEFORE UPDATE ON public.business_contexts
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_bcm_manifests_updated_at') THEN
+        CREATE TRIGGER update_bcm_manifests_updated_at
+        BEFORE UPDATE ON public.bcm_manifests
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_subscriptions_updated_at') THEN
+        CREATE TRIGGER update_subscriptions_updated_at
+        BEFORE UPDATE ON public.subscriptions
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_payments_updated_at') THEN
+        CREATE TRIGGER update_payments_updated_at
+        BEFORE UPDATE ON public.payments
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Provide a single, idempotent migration that defines core application tables required for identity, workspaces, onboarding, business context management, subscriptions, and payments with proper constraints and timestamps.
- Ensure new tables and existing tables have `created_at`/`updated_at` timestamps and `updated_at` triggers so the schema is ready for application logic and RLS policies used elsewhere.

### Description
- Added `supabase/migrations/20260130000000_define_core_tables.sql` which creates `users_profiles`, `workspaces`, `onboarding_sessions`, `onboarding_steps`, `business_contexts`, `bcm_manifests`, `subscriptions`, and `payments` with primary keys, foreign keys, unique constraints, sensible CHECKs, and timestamp columns.
- The migration ensures the `uuid-ossp` extension exists and references `auth.users` for `users_profiles.id` where appropriate.
- Adds `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` safeguards to add timestamp columns on existing `payments`, `workspaces`, and `subscriptions` if missing.
- Registers `updated_at` triggers (using the existing `update_updated_at_column()` function) for the new core tables to keep `updated_at` current on updates.

### Testing
- Attempted to run the automated migration script with `bash apply_migrations.sh`, which exited without applying the migration because the `SUPABASE_URL` environment variable was not set (no remote DB changes were made).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b13b0d0548332be3253db9f3b1107)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database infrastructure updates to support core platform capabilities, including user accounts, workspace management, onboarding workflows, subscriptions, and payment processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->