### PR TITLE
Add workspace-scoped RLS policies for business_context(s), bcm_manifests, onboarding and payments

### DIFF
--- a/supabase/migrations/20260205000000_workspace_rls_isolation.sql
+++ b/supabase/migrations/20260205000000_workspace_rls_isolation.sql
@@ -1,0 +1,375 @@
+-- Workspace-based RLS isolation for business contexts, BCM, onboarding, and payments
+
+BEGIN;
+
+-- Helper: match auth user to internal user identifiers
+CREATE OR REPLACE FUNCTION public.auth_user_matches(p_user_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    matches boolean := false;
+BEGIN
+    IF p_user_id IS NULL OR auth.uid() IS NULL THEN
+        RETURN false;
+    END IF;
+
+    IF p_user_id = auth.uid() THEN
+        RETURN true;
+    END IF;
+
+    IF to_regclass('public.users') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1 FROM public.users u
+            WHERE u.id = p_user_id
+              AND u.auth_user_id = auth.uid()
+        ) INTO matches;
+        IF matches THEN
+            RETURN true;
+        END IF;
+    END IF;
+
+    IF to_regclass('public.profiles') IS NOT NULL THEN
+        SELECT p_user_id = auth.uid() INTO matches;
+        IF matches THEN
+            RETURN true;
+        END IF;
+    END IF;
+
+    RETURN false;
+END;
+$$;
+
+-- Helper: verify auth user is in the workspace
+CREATE OR REPLACE FUNCTION public.is_workspace_member(p_workspace_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    member_match boolean := false;
+    owner_match boolean := false;
+BEGIN
+    IF p_workspace_id IS NULL OR auth.uid() IS NULL THEN
+        RETURN false;
+    END IF;
+
+    IF to_regclass('public.workspace_members') IS NOT NULL THEN
+        IF to_regclass('public.users') IS NOT NULL THEN
+            EXECUTE
+                'SELECT EXISTS (
+                    SELECT 1
+                    FROM public.workspace_members wm
+                    JOIN public.users u ON u.id = wm.user_id
+                    WHERE wm.workspace_id = $1
+                      AND wm.is_active = TRUE
+                      AND u.auth_user_id = auth.uid()
+                )'
+            INTO member_match
+            USING p_workspace_id;
+        ELSIF to_regclass('public.profiles') IS NOT NULL THEN
+            EXECUTE
+                'SELECT EXISTS (
+                    SELECT 1
+                    FROM public.workspace_members wm
+                    JOIN public.profiles p ON p.id = wm.user_id
+                    WHERE wm.workspace_id = $1
+                      AND wm.is_active = TRUE
+                      AND p.id = auth.uid()
+                )'
+            INTO member_match
+            USING p_workspace_id;
+        END IF;
+    END IF;
+
+    IF to_regclass('public.workspaces') IS NULL THEN
+        RETURN member_match;
+    END IF;
+
+    IF to_regclass('public.users') IS NOT NULL THEN
+        EXECUTE
+            'SELECT EXISTS (
+                SELECT 1
+                FROM public.workspaces w
+                JOIN public.users u ON u.id = w.owner_id
+                WHERE w.id = $1
+                  AND u.auth_user_id = auth.uid()
+            )'
+        INTO owner_match
+        USING p_workspace_id;
+    ELSIF to_regclass('public.profiles') IS NOT NULL THEN
+        EXECUTE
+            'SELECT EXISTS (
+                SELECT 1
+                FROM public.workspaces w
+                WHERE w.id = $1
+                  AND w.owner_id = auth.uid()
+            )'
+        INTO owner_match
+        USING p_workspace_id;
+    ELSE
+        EXECUTE
+            'SELECT EXISTS (
+                SELECT 1
+                FROM public.workspaces w
+                WHERE w.id = $1
+                  AND w.owner_id = auth.uid()
+            )'
+        INTO owner_match
+        USING p_workspace_id;
+    END IF;
+
+    RETURN member_match OR owner_match;
+END;
+$$;
+
+-- RLS for business_contexts (plural)
+DO $$
+DECLARE
+    has_workspace_id boolean;
+    has_user_id boolean;
+    policy_check text;
+BEGIN
+    IF to_regclass('public.business_contexts') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'business_contexts'
+              AND column_name = 'workspace_id'
+        ) INTO has_workspace_id;
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'business_contexts'
+              AND column_name = 'user_id'
+        ) INTO has_user_id;
+
+        EXECUTE 'ALTER TABLE public.business_contexts ENABLE ROW LEVEL SECURITY';
+        EXECUTE 'DROP POLICY IF EXISTS "business_contexts_workspace_isolation_select" ON public.business_contexts';
+        EXECUTE 'DROP POLICY IF EXISTS "business_contexts_workspace_isolation_insert" ON public.business_contexts';
+        EXECUTE 'DROP POLICY IF EXISTS "business_contexts_workspace_isolation_update" ON public.business_contexts';
+        EXECUTE 'DROP POLICY IF EXISTS "business_contexts_workspace_isolation_delete" ON public.business_contexts';
+
+        IF has_workspace_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.is_workspace_member(workspace_id)';
+        ELSIF has_user_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.auth_user_matches(user_id)';
+        ELSE
+            policy_check := 'false';
+        END IF;
+
+        EXECUTE format(
+            'CREATE POLICY "business_contexts_workspace_isolation_select" ON public.business_contexts FOR SELECT USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "business_contexts_workspace_isolation_insert" ON public.business_contexts FOR INSERT WITH CHECK (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "business_contexts_workspace_isolation_update" ON public.business_contexts FOR UPDATE USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "business_contexts_workspace_isolation_delete" ON public.business_contexts FOR DELETE USING (%s)',
+            policy_check
+        );
+    END IF;
+END $$;
+
+-- RLS for business_context (singular)
+DO $$
+DECLARE
+    has_workspace_id boolean;
+    has_user_id boolean;
+    policy_check text;
+BEGIN
+    IF to_regclass('public.business_context') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'business_context'
+              AND column_name = 'workspace_id'
+        ) INTO has_workspace_id;
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'business_context'
+              AND column_name = 'user_id'
+        ) INTO has_user_id;
+
+        EXECUTE 'ALTER TABLE public.business_context ENABLE ROW LEVEL SECURITY';
+        EXECUTE 'DROP POLICY IF EXISTS "business_context_workspace_isolation_select" ON public.business_context';
+        EXECUTE 'DROP POLICY IF EXISTS "business_context_workspace_isolation_insert" ON public.business_context';
+        EXECUTE 'DROP POLICY IF EXISTS "business_context_workspace_isolation_update" ON public.business_context';
+        EXECUTE 'DROP POLICY IF EXISTS "business_context_workspace_isolation_delete" ON public.business_context';
+
+        IF has_workspace_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.is_workspace_member(workspace_id)';
+        ELSIF has_user_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.auth_user_matches(user_id)';
+        ELSE
+            policy_check := 'false';
+        END IF;
+
+        EXECUTE format(
+            'CREATE POLICY "business_context_workspace_isolation_select" ON public.business_context FOR SELECT USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "business_context_workspace_isolation_insert" ON public.business_context FOR INSERT WITH CHECK (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "business_context_workspace_isolation_update" ON public.business_context FOR UPDATE USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "business_context_workspace_isolation_delete" ON public.business_context FOR DELETE USING (%s)',
+            policy_check
+        );
+    END IF;
+END $$;
+
+-- RLS for bcm_manifests
+DO $$
+DECLARE
+    has_workspace_id boolean;
+    has_user_id boolean;
+    policy_check text;
+BEGIN
+    IF to_regclass('public.bcm_manifests') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'bcm_manifests'
+              AND column_name = 'workspace_id'
+        ) INTO has_workspace_id;
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'bcm_manifests'
+              AND column_name = 'user_id'
+        ) INTO has_user_id;
+
+        EXECUTE 'ALTER TABLE public.bcm_manifests ENABLE ROW LEVEL SECURITY';
+        EXECUTE 'DROP POLICY IF EXISTS "bcm_manifests_workspace_isolation_select" ON public.bcm_manifests';
+        EXECUTE 'DROP POLICY IF EXISTS "bcm_manifests_workspace_isolation_insert" ON public.bcm_manifests';
+        EXECUTE 'DROP POLICY IF EXISTS "bcm_manifests_workspace_isolation_update" ON public.bcm_manifests';
+        EXECUTE 'DROP POLICY IF EXISTS "bcm_manifests_workspace_isolation_delete" ON public.bcm_manifests';
+
+        IF has_workspace_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.is_workspace_member(workspace_id)';
+        ELSIF has_user_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.auth_user_matches(user_id)';
+        ELSE
+            policy_check := 'false';
+        END IF;
+
+        EXECUTE format(
+            'CREATE POLICY "bcm_manifests_workspace_isolation_select" ON public.bcm_manifests FOR SELECT USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "bcm_manifests_workspace_isolation_insert" ON public.bcm_manifests FOR INSERT WITH CHECK (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "bcm_manifests_workspace_isolation_update" ON public.bcm_manifests FOR UPDATE USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "bcm_manifests_workspace_isolation_delete" ON public.bcm_manifests FOR DELETE USING (%s)',
+            policy_check
+        );
+    END IF;
+END $$;
+
+-- RLS for user_onboarding
+DO $$
+DECLARE
+    has_user_id boolean;
+BEGIN
+    IF to_regclass('public.user_onboarding') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'user_onboarding'
+              AND column_name = 'user_id'
+        ) INTO has_user_id;
+
+        EXECUTE 'ALTER TABLE public.user_onboarding ENABLE ROW LEVEL SECURITY';
+        EXECUTE 'DROP POLICY IF EXISTS "user_onboarding_owner_select" ON public.user_onboarding';
+        EXECUTE 'DROP POLICY IF EXISTS "user_onboarding_owner_insert" ON public.user_onboarding';
+        EXECUTE 'DROP POLICY IF EXISTS "user_onboarding_owner_update" ON public.user_onboarding';
+        EXECUTE 'DROP POLICY IF EXISTS "user_onboarding_owner_delete" ON public.user_onboarding';
+
+        IF has_user_id THEN
+            EXECUTE 'CREATE POLICY "user_onboarding_owner_select" ON public.user_onboarding FOR SELECT USING (auth.uid() IS NOT NULL AND public.auth_user_matches(user_id))';
+            EXECUTE 'CREATE POLICY "user_onboarding_owner_insert" ON public.user_onboarding FOR INSERT WITH CHECK (auth.uid() IS NOT NULL AND public.auth_user_matches(user_id))';
+            EXECUTE 'CREATE POLICY "user_onboarding_owner_update" ON public.user_onboarding FOR UPDATE USING (auth.uid() IS NOT NULL AND public.auth_user_matches(user_id))';
+            EXECUTE 'CREATE POLICY "user_onboarding_owner_delete" ON public.user_onboarding FOR DELETE USING (auth.uid() IS NOT NULL AND public.auth_user_matches(user_id))';
+        END IF;
+    END IF;
+END $$;
+
+-- RLS for payments
+DO $$
+DECLARE
+    has_workspace_id boolean;
+    has_user_id boolean;
+    policy_check text;
+BEGIN
+    IF to_regclass('public.payments') IS NOT NULL THEN
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'payments'
+              AND column_name = 'workspace_id'
+        ) INTO has_workspace_id;
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'payments'
+              AND column_name = 'user_id'
+        ) INTO has_user_id;
+
+        EXECUTE 'ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY';
+        EXECUTE 'DROP POLICY IF EXISTS "payments_workspace_isolation_select" ON public.payments';
+        EXECUTE 'DROP POLICY IF EXISTS "payments_workspace_isolation_insert" ON public.payments';
+        EXECUTE 'DROP POLICY IF EXISTS "payments_workspace_isolation_update" ON public.payments';
+        EXECUTE 'DROP POLICY IF EXISTS "payments_workspace_isolation_delete" ON public.payments';
+
+        IF has_workspace_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.is_workspace_member(workspace_id)';
+        ELSIF has_user_id THEN
+            policy_check := 'auth.uid() IS NOT NULL AND public.auth_user_matches(user_id)';
+        ELSE
+            policy_check := 'false';
+        END IF;
+
+        EXECUTE format(
+            'CREATE POLICY "payments_workspace_isolation_select" ON public.payments FOR SELECT USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "payments_workspace_isolation_insert" ON public.payments FOR INSERT WITH CHECK (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "payments_workspace_isolation_update" ON public.payments FOR UPDATE USING (%s)',
+            policy_check
+        );
+        EXECUTE format(
+            'CREATE POLICY "payments_workspace_isolation_delete" ON public.payments FOR DELETE USING (%s)',
+            policy_check
+        );
+    END IF;
+END $$;
+
+COMMIT;

--- a/supabase/verification/rls_workspace_isolation_checks.sql
+++ b/supabase/verification/rls_workspace_isolation_checks.sql
@@ -1,0 +1,50 @@
+-- RLS verification queries for workspace isolation
+-- Replace the UUID placeholders with real values from your environment.
+
+-- Example variables:
+--   :auth_user_id_a (auth.uid for user A)
+--   :auth_user_id_b (auth.uid for user B)
+--   :workspace_id_a (workspace owned/joined by user A)
+--   :workspace_id_b (workspace owned/joined by user B)
+
+-- Ensure RLS is enforced for authenticated users in workspace A
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config('request.jwt.claim.sub', ':auth_user_id_a', true);
+
+-- Business contexts (plural)
+SELECT * FROM public.business_contexts WHERE workspace_id = ':workspace_id_a';
+SELECT * FROM public.business_contexts WHERE workspace_id = ':workspace_id_b';
+
+-- Business context (singular)
+SELECT * FROM public.business_context WHERE workspace_id = ':workspace_id_a';
+SELECT * FROM public.business_context WHERE workspace_id = ':workspace_id_b';
+
+-- BCM manifests
+SELECT * FROM public.bcm_manifests WHERE workspace_id = ':workspace_id_a';
+SELECT * FROM public.bcm_manifests WHERE workspace_id = ':workspace_id_b';
+
+-- Onboarding records (user scoped)
+SELECT * FROM public.user_onboarding WHERE user_id = ':auth_user_id_a';
+SELECT * FROM public.user_onboarding WHERE user_id = ':auth_user_id_b';
+
+-- Payments (user scoped, or workspace if column exists)
+SELECT * FROM public.payments WHERE user_id = ':auth_user_id_a';
+SELECT * FROM public.payments WHERE user_id = ':auth_user_id_b';
+
+-- Repeat for user B
+SELECT set_config('request.jwt.claim.sub', ':auth_user_id_b', true);
+
+SELECT * FROM public.business_contexts WHERE workspace_id = ':workspace_id_b';
+SELECT * FROM public.business_contexts WHERE workspace_id = ':workspace_id_a';
+
+SELECT * FROM public.business_context WHERE workspace_id = ':workspace_id_b';
+SELECT * FROM public.business_context WHERE workspace_id = ':workspace_id_a';
+
+SELECT * FROM public.bcm_manifests WHERE workspace_id = ':workspace_id_b';
+SELECT * FROM public.bcm_manifests WHERE workspace_id = ':workspace_id_a';
+
+SELECT * FROM public.user_onboarding WHERE user_id = ':auth_user_id_b';
+SELECT * FROM public.user_onboarding WHERE user_id = ':auth_user_id_a';
+
+SELECT * FROM public.payments WHERE user_id = ':auth_user_id_b';
+SELECT * FROM public.payments WHERE user_id = ':auth_user_id_a';


### PR DESCRIPTION
### Motivation
- Enforce row-level security so only authenticated users scoped to the same workspace or owning user can access business context, BCM, onboarding and payments data.

### Description
- Add helper security functions `public.auth_user_matches` and `public.is_workspace_member` to map `auth.uid()` to internal `users`/`profiles` and to verify workspace membership in `supabase/migrations/20260205000000_workspace_rls_isolation.sql`.
- Enable RLS and create workspace-scoped policies for both plural and singular business context tables (`business_contexts` and `business_context`) with conditional logic based on whether each table has `workspace_id` or `user_id` columns.
- Add workspace-scoped RLS policy creation for `bcm_manifests`, `user_onboarding`, and `payments`, with policies using `auth.uid()` combined with the helper functions to limit SELECT/INSERT/UPDATE/DELETE.
- Add a verification script `supabase/verification/rls_workspace_isolation_checks.sql` containing example queries and JWT claim settings to exercise isolation between two users/workspaces.

### Testing
- No automated tests were executed; these are SQL migration changes that must be applied to a running database to validate behavior.
- A verification SQL file `supabase/verification/rls_workspace_isolation_checks.sql` was added to manually confirm isolation between two users/workspaces by setting `request.jwt.claim.sub` and querying the affected tables.
- The migration `supabase/migrations/20260205000000_workspace_rls_isolation.sql` is idempotent and contains conditional checks (`to_regclass` / information_schema) so it can be applied safely in environments with different table variants.
- Recommend running the verification script against a staging database after applying the migration to confirm policies behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b13b48e588332accd36e6ec6c770b)