### PR TITLE
Add business context intake schema, validation endpoint, and frontend form

### DIFF
--- a/backend/api/v1/business_contexts.py
+++ b/backend/api/v1/business_contexts.py
@@ -1,0 +1,86 @@
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from core.auth import get_auth_context
+from core.supabase_mgr import get_supabase_admin
+from schemas.business_context_input import BusinessContextInput
+from validators.business_context_validator import (
+    BusinessContextValidationError,
+    business_context_validator,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/business-contexts", tags=["business-contexts"])
+
+
+class BusinessContextResponse(BaseModel):
+    success: bool
+    business_context: Optional[Dict[str, Any]] = None
+    validation: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+
+
+@router.post("", response_model=BusinessContextResponse, status_code=status.HTTP_201_CREATED)
+async def create_business_context(
+    request: BusinessContextInput, auth_context=Depends(get_auth_context)
+):
+    try:
+        context = request.to_business_context(
+            workspace_id=auth_context.workspace_id, user_id=auth_context.user.id
+        )
+        validated_context, validation_results = (
+            business_context_validator.validate_from_dict(context.model_dump())
+        )
+    except BusinessContextValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "message": exc.message,
+                "errors": exc.errors,
+                "warnings": exc.warnings,
+            },
+        ) from exc
+    except Exception as exc:
+        logger.error(f"Business context validation failed: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Business context validation failed",
+        ) from exc
+
+    supabase = get_supabase_admin()
+    metadata = dict(validated_context.metadata)
+    metadata["validation"] = validation_results
+
+    payload = {
+        "workspace_id": auth_context.workspace_id,
+        "user_id": auth_context.user.id,
+        "ucid": validated_context.ucid,
+        "identity": validated_context.identity.model_dump(),
+        "audience": validated_context.audience.model_dump(),
+        "positioning": validated_context.positioning.model_dump(),
+        "evidence_ids": validated_context.evidence_ids,
+        "noteworthy_insights": validated_context.noteworthy_insights,
+        "metadata": metadata,
+        "created_at": validated_context.created_at.isoformat(),
+        "updated_at": validated_context.updated_at.isoformat(),
+    }
+
+    try:
+        result = supabase.table("business_contexts").upsert(payload).execute()
+    except Exception as exc:
+        logger.error(f"Failed to persist business context: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to persist business context",
+        ) from exc
+
+    return BusinessContextResponse(
+        success=True,
+        business_context=validated_context.model_dump(),
+        validation=validation_results,
+        message="Business context saved successfully",
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from api.v1 import (  # episodes,
     approvals,
     auth,
     blackbox,
+    business_contexts,
     campaigns,
     config,
     context,
@@ -405,6 +406,11 @@ app.include_router(titan.router, prefix="/api/v1/titan", tags=["titan"])
 app.include_router(campaigns.router, prefix="/api/v1/campaigns", tags=["campaigns"])
 app.include_router(daily_wins.router, prefix="/api/v1/daily_wins", tags=["daily_wins"])
 app.include_router(blackbox.router, prefix="/api/v1/blackbox", tags=["blackbox"])
+app.include_router(
+    business_contexts.router,
+    prefix="/api/v1",
+    tags=["business-contexts"],
+)
 
 
 # Root health endpoint

--- a/backend/schemas/business_context_input.py
+++ b/backend/schemas/business_context_input.py
@@ -1,0 +1,221 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, validator
+
+from schemas.business_context import (
+    BrandIdentity,
+    BusinessContext,
+    ChannelStrategy,
+    CompetitivePosition,
+    ICPProfile,
+    Intelligence,
+    MarketPosition,
+    MessagingFramework,
+    StrategicAudience,
+    StrategyPath,
+)
+
+
+class ICPProfileInput(BaseModel):
+    name: str = Field(..., min_length=2, description="ICP name")
+    description: str = Field(..., min_length=10, description="ICP description")
+    company_size: Optional[str] = Field(None, description="Target company size")
+    industry: Optional[str] = Field(None, description="Target industry")
+    revenue_range: Optional[str] = Field(None, description="Revenue range")
+    geographic_focus: List[str] = Field(default_factory=list)
+    pain_points: List[str] = Field(default_factory=list)
+    value_proposition: str = Field(..., min_length=10)
+    priority: int = Field(1, ge=1, le=3)
+
+    @validator(
+        "geographic_focus",
+        "pain_points",
+        pre=True,
+    )
+    def normalize_list_fields(cls, value):
+        if value is None:
+            return []
+        return [item.strip() for item in value if item and item.strip()]
+
+
+class ChannelStrategyInput(BaseModel):
+    channel: str = Field(..., min_length=2)
+    priority: str = Field(..., min_length=2)
+    budget_allocation: Optional[float] = Field(None, ge=0, le=100)
+    key_metrics: List[str] = Field(default_factory=list)
+    tactics: List[str] = Field(default_factory=list)
+
+    @validator("key_metrics", "tactics", pre=True)
+    def normalize_list_fields(cls, value):
+        if value is None:
+            return []
+        return [item.strip() for item in value if item and item.strip()]
+
+
+class BusinessContextInput(BaseModel):
+    brand_name: str = Field(..., min_length=2)
+    tagline: Optional[str] = Field(None, max_length=120)
+    core_promise: str = Field(..., min_length=10)
+    mission_statement: Optional[str] = Field(None, max_length=300)
+    vision_statement: Optional[str] = Field(None, max_length=300)
+    manifesto_summary: str = Field(..., min_length=10)
+    values: List[str] = Field(default_factory=list)
+    tone_of_voice: List[str] = Field(default_factory=list)
+    personality_traits: List[str] = Field(default_factory=list)
+    primary_audience: str = Field(..., min_length=5)
+    secondary_audiences: List[str] = Field(default_factory=list)
+    pain_points: List[str] = Field(default_factory=list)
+    desires: List[str] = Field(default_factory=list)
+    challenges: List[str] = Field(default_factory=list)
+    goals: List[str] = Field(default_factory=list)
+    media_consumption: List[str] = Field(default_factory=list)
+    decision_factors: List[str] = Field(default_factory=list)
+    market_category: str = Field(..., min_length=3)
+    market_subcategory: Optional[str] = Field(None, max_length=120)
+    differentiator: str = Field(..., min_length=10)
+    perceptual_quadrant: str = Field(..., min_length=3)
+    strategy_path: StrategyPath
+    positioning_statement: str = Field(..., min_length=15)
+    messaging_core_message: str = Field(..., min_length=15)
+    messaging_value_proposition: str = Field(..., min_length=10)
+    messaging_supporting_points: List[str] = Field(default_factory=list)
+    messaging_proof_points: List[str] = Field(default_factory=list)
+    messaging_call_to_action: str = Field(..., min_length=3)
+    messaging_tone_guidelines: List[str] = Field(default_factory=list)
+    competitive_market_position: str = Field(..., min_length=8)
+    competitive_positioning_statement: str = Field(..., min_length=15)
+    primary_competitors: List[str] = Field(default_factory=list)
+    competitive_advantages: List[str] = Field(default_factory=list)
+    competitive_differentiators: List[str] = Field(default_factory=list)
+    icp_profiles: List[ICPProfileInput] = Field(default_factory=list)
+    channel_strategies: List[ChannelStrategyInput] = Field(default_factory=list)
+
+    @validator(
+        "values",
+        "tone_of_voice",
+        "personality_traits",
+        "secondary_audiences",
+        "pain_points",
+        "desires",
+        "challenges",
+        "goals",
+        "media_consumption",
+        "decision_factors",
+        "messaging_supporting_points",
+        "messaging_proof_points",
+        "messaging_tone_guidelines",
+        "primary_competitors",
+        "competitive_advantages",
+        "competitive_differentiators",
+        pre=True,
+    )
+    def normalize_list_fields(cls, value):
+        if value is None:
+            return []
+        return [item.strip() for item in value if item and item.strip()]
+
+    @validator("brand_name")
+    def validate_brand_name(cls, value):
+        if not re.match(r"^[a-zA-Z0-9 .,&'-]+$", value):
+            raise ValueError("Brand name contains unsupported characters")
+        return value.strip()
+
+    @validator("pain_points", "desires")
+    def validate_core_lists(cls, value, field):
+        if len(value) < 2:
+            raise ValueError(f"{field.name.replace('_', ' ').title()} must include at least 2 items")
+        return value
+
+    def to_business_context(self, workspace_id: str, user_id: str) -> BusinessContext:
+        ucid = f"bcx_{uuid4().hex}"
+        identity = BrandIdentity(
+            name=self.brand_name,
+            tagline=self.tagline,
+            core_promise=self.core_promise,
+            mission_statement=self.mission_statement,
+            vision_statement=self.vision_statement,
+            values=self.values,
+            tone_of_voice=self.tone_of_voice,
+            manifesto_summary=self.manifesto_summary,
+            personality_traits=self.personality_traits,
+        )
+        audience = StrategicAudience(
+            primary_segment=self.primary_audience,
+            secondary_segments=self.secondary_audiences,
+            pain_points=self.pain_points,
+            desires=self.desires,
+            challenges=self.challenges,
+            goals=self.goals,
+            media_consumption=self.media_consumption,
+            decision_factors=self.decision_factors,
+        )
+        positioning = MarketPosition(
+            category=self.market_category,
+            subcategory=self.market_subcategory,
+            differentiator=self.differentiator,
+            perceptual_quadrant=self.perceptual_quadrant,
+            strategy_path=self.strategy_path,
+            positioning_statement=self.positioning_statement,
+        )
+        messaging = MessagingFramework(
+            core_message=self.messaging_core_message,
+            value_proposition=self.messaging_value_proposition,
+            supporting_points=self.messaging_supporting_points,
+            proof_points=self.messaging_proof_points,
+            call_to_action=self.messaging_call_to_action,
+            tone_guidelines=self.messaging_tone_guidelines,
+        )
+        competitive_position = CompetitivePosition(
+            primary_competitors=self.primary_competitors,
+            competitive_advantages=self.competitive_advantages,
+            differentiators=self.competitive_differentiators,
+            market_position=self.competitive_market_position,
+            positioning_statement=self.competitive_positioning_statement,
+        )
+        icp_profiles = [
+            ICPProfile(
+                name=icp.name,
+                description=icp.description,
+                company_size=icp.company_size,
+                industry=icp.industry,
+                revenue_range=icp.revenue_range,
+                geographic_focus=icp.geographic_focus,
+                pain_points=icp.pain_points,
+                value_proposition=icp.value_proposition,
+                priority=icp.priority,
+            )
+            for icp in self.icp_profiles
+        ]
+        channel_strategies = [
+            ChannelStrategy(
+                channel=strategy.channel,
+                priority=strategy.priority,
+                budget_allocation=strategy.budget_allocation,
+                key_metrics=strategy.key_metrics,
+                tactics=strategy.tactics,
+            )
+            for strategy in self.channel_strategies
+        ]
+        metadata: Dict[str, Any] = {
+            "source": "business_context_form",
+            "input_timestamp": datetime.utcnow().isoformat(),
+        }
+        return BusinessContext(
+            ucid=ucid,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            identity=identity,
+            audience=audience,
+            positioning=positioning,
+            messaging_framework=messaging,
+            competitive_position=competitive_position,
+            icp_profiles=icp_profiles,
+            channel_strategies=channel_strategies,
+            intelligence=Intelligence(),
+            evidence_ids=[],
+            noteworthy_insights=[],
+            metadata=metadata,
+        )

--- a/frontend/src/components/BusinessContextForm.tsx
+++ b/frontend/src/components/BusinessContextForm.tsx
@@ -1,0 +1,597 @@
+import type { ChangeEvent, FormEvent } from 'react';
+import { useState } from 'react';
+
+type BusinessContextFormState = {
+  brandName: string;
+  tagline: string;
+  corePromise: string;
+  missionStatement: string;
+  visionStatement: string;
+  manifestoSummary: string;
+  values: string;
+  toneOfVoice: string;
+  personalityTraits: string;
+  primaryAudience: string;
+  secondaryAudiences: string;
+  painPoints: string;
+  desires: string;
+  challenges: string;
+  goals: string;
+  mediaConsumption: string;
+  decisionFactors: string;
+  marketCategory: string;
+  marketSubcategory: string;
+  differentiator: string;
+  perceptualQuadrant: string;
+  strategyPath: 'safe' | 'clever' | 'bold';
+  positioningStatement: string;
+  messagingCoreMessage: string;
+  messagingValueProposition: string;
+  messagingSupportingPoints: string;
+  messagingProofPoints: string;
+  messagingCallToAction: string;
+  messagingToneGuidelines: string;
+  competitiveMarketPosition: string;
+  competitivePositioningStatement: string;
+  primaryCompetitors: string;
+  competitiveAdvantages: string;
+  competitiveDifferentiators: string;
+};
+
+type SubmissionStatus = {
+  type: 'idle' | 'success' | 'error';
+  message?: string;
+  details?: string[];
+};
+
+const initialState: BusinessContextFormState = {
+  brandName: '',
+  tagline: '',
+  corePromise: '',
+  missionStatement: '',
+  visionStatement: '',
+  manifestoSummary: '',
+  values: '',
+  toneOfVoice: '',
+  personalityTraits: '',
+  primaryAudience: '',
+  secondaryAudiences: '',
+  painPoints: '',
+  desires: '',
+  challenges: '',
+  goals: '',
+  mediaConsumption: '',
+  decisionFactors: '',
+  marketCategory: '',
+  marketSubcategory: '',
+  differentiator: '',
+  perceptualQuadrant: '',
+  strategyPath: 'safe',
+  positioningStatement: '',
+  messagingCoreMessage: '',
+  messagingValueProposition: '',
+  messagingSupportingPoints: '',
+  messagingProofPoints: '',
+  messagingCallToAction: '',
+  messagingToneGuidelines: '',
+  competitiveMarketPosition: '',
+  competitivePositioningStatement: '',
+  primaryCompetitors: '',
+  competitiveAdvantages: '',
+  competitiveDifferentiators: '',
+};
+
+const splitList = (value: string) =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const buildPayload = (state: BusinessContextFormState) => ({
+  brand_name: state.brandName,
+  tagline: state.tagline || null,
+  core_promise: state.corePromise,
+  mission_statement: state.missionStatement || null,
+  vision_statement: state.visionStatement || null,
+  manifesto_summary: state.manifestoSummary,
+  values: splitList(state.values),
+  tone_of_voice: splitList(state.toneOfVoice),
+  personality_traits: splitList(state.personalityTraits),
+  primary_audience: state.primaryAudience,
+  secondary_audiences: splitList(state.secondaryAudiences),
+  pain_points: splitList(state.painPoints),
+  desires: splitList(state.desires),
+  challenges: splitList(state.challenges),
+  goals: splitList(state.goals),
+  media_consumption: splitList(state.mediaConsumption),
+  decision_factors: splitList(state.decisionFactors),
+  market_category: state.marketCategory,
+  market_subcategory: state.marketSubcategory || null,
+  differentiator: state.differentiator,
+  perceptual_quadrant: state.perceptualQuadrant,
+  strategy_path: state.strategyPath,
+  positioning_statement: state.positioningStatement,
+  messaging_core_message: state.messagingCoreMessage,
+  messaging_value_proposition: state.messagingValueProposition,
+  messaging_supporting_points: splitList(state.messagingSupportingPoints),
+  messaging_proof_points: splitList(state.messagingProofPoints),
+  messaging_call_to_action: state.messagingCallToAction,
+  messaging_tone_guidelines: splitList(state.messagingToneGuidelines),
+  competitive_market_position: state.competitiveMarketPosition,
+  competitive_positioning_statement: state.competitivePositioningStatement,
+  primary_competitors: splitList(state.primaryCompetitors),
+  competitive_advantages: splitList(state.competitiveAdvantages),
+  competitive_differentiators: splitList(state.competitiveDifferentiators),
+});
+
+const validateForm = (state: BusinessContextFormState) => {
+  const errors: string[] = [];
+  if (state.brandName.trim().length < 2) errors.push('Brand name must be at least 2 characters.');
+  if (state.corePromise.trim().length < 10) errors.push('Core promise must be at least 10 characters.');
+  if (state.manifestoSummary.trim().length < 10) errors.push('Manifesto summary must be at least 10 characters.');
+  if (state.primaryAudience.trim().length < 5) errors.push('Primary audience must be at least 5 characters.');
+  if (splitList(state.painPoints).length < 2) errors.push('Add at least 2 pain points.');
+  if (splitList(state.desires).length < 2) errors.push('Add at least 2 desires.');
+  if (state.marketCategory.trim().length < 3) errors.push('Market category must be at least 3 characters.');
+  if (state.differentiator.trim().length < 10) errors.push('Differentiator must be at least 10 characters.');
+  if (state.perceptualQuadrant.trim().length < 3) errors.push('Perceptual quadrant is required.');
+  if (state.positioningStatement.trim().length < 15) errors.push('Positioning statement must be at least 15 characters.');
+  if (state.messagingCoreMessage.trim().length < 15) errors.push('Messaging core message must be at least 15 characters.');
+  if (state.messagingValueProposition.trim().length < 10) {
+    errors.push('Messaging value proposition must be at least 10 characters.');
+  }
+  if (state.messagingCallToAction.trim().length < 3) errors.push('Messaging CTA must be at least 3 characters.');
+  if (state.competitiveMarketPosition.trim().length < 8) {
+    errors.push('Competitive market position must be at least 8 characters.');
+  }
+  if (state.competitivePositioningStatement.trim().length < 15) {
+    errors.push('Competitive positioning statement must be at least 15 characters.');
+  }
+  return errors;
+};
+
+export default function BusinessContextForm() {
+  const [formState, setFormState] = useState(initialState);
+  const [status, setStatus] = useState<SubmissionStatus>({ type: 'idle' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (field: keyof BusinessContextFormState) => (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    setFormState((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setStatus({ type: 'idle' });
+
+    const validationErrors = validateForm(formState);
+    if (validationErrors.length) {
+      setStatus({ type: 'error', message: 'Fix the highlighted issues.', details: validationErrors });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch('/api/proxy/api/v1/business-contexts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildPayload(formState)),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        const errorDetails = data?.detail?.errors || data?.detail?.warnings || data?.detail?.message;
+        setStatus({
+          type: 'error',
+          message: 'Unable to save business context.',
+          details: Array.isArray(errorDetails) ? errorDetails : errorDetails ? [errorDetails] : undefined,
+        });
+        return;
+      }
+      setStatus({ type: 'success', message: data?.message || 'Business context saved.' });
+      setFormState(initialState);
+    } catch (error) {
+      setStatus({
+        type: 'error',
+        message: 'Unexpected error while saving business context.',
+        details: error instanceof Error ? [error.message] : undefined,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6 mb-8">
+      <div className="flex flex-col gap-2 mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">🧭 Business Context Intake</h2>
+        <p className="text-sm text-gray-600">
+          Capture the essentials needed to validate and persist a structured business context.
+        </p>
+      </div>
+
+      {status.type !== 'idle' && (
+        <div
+          className={`mb-6 rounded-lg border px-4 py-3 text-sm ${
+            status.type === 'success'
+              ? 'border-green-200 bg-green-50 text-green-700'
+              : 'border-red-200 bg-red-50 text-red-700'
+          }`}
+        >
+          <p className="font-medium">{status.message}</p>
+          {status.details && (
+            <ul className="mt-2 list-disc list-inside space-y-1">
+              {status.details.map((detail) => (
+                <li key={detail}>{detail}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">Brand identity</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="text-sm text-gray-700">
+              Brand name
+              <input
+                value={formState.brandName}
+                onChange={handleChange('brandName')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="RaptorFlow"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Tagline
+              <input
+                value={formState.tagline}
+                onChange={handleChange('tagline')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Operations clarity for growth teams"
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Core promise
+              <textarea
+                value={formState.corePromise}
+                onChange={handleChange('corePromise')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Describe the main promise delivered to customers."
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Manifesto summary
+              <textarea
+                value={formState.manifestoSummary}
+                onChange={handleChange('manifestoSummary')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Summarize the brand manifesto."
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Mission statement
+              <textarea
+                value={formState.missionStatement}
+                onChange={handleChange('missionStatement')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Optional mission statement."
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Vision statement
+              <textarea
+                value={formState.visionStatement}
+                onChange={handleChange('visionStatement')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Optional vision statement."
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Values (comma separated)
+              <input
+                value={formState.values}
+                onChange={handleChange('values')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Transparency, speed, trust"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Tone of voice (comma separated)
+              <input
+                value={formState.toneOfVoice}
+                onChange={handleChange('toneOfVoice')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Confident, helpful, direct"
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Personality traits (comma separated)
+              <input
+                value={formState.personalityTraits}
+                onChange={handleChange('personalityTraits')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Analytical, ambitious, pragmatic"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">Audience</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Primary audience
+              <textarea
+                value={formState.primaryAudience}
+                onChange={handleChange('primaryAudience')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Describe the primary audience segment."
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Secondary audiences (comma separated)
+              <input
+                value={formState.secondaryAudiences}
+                onChange={handleChange('secondaryAudiences')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Operations leaders, growth marketers"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Pain points (comma separated)
+              <textarea
+                value={formState.painPoints}
+                onChange={handleChange('painPoints')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Slow reporting, unclear priorities"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Desires (comma separated)
+              <textarea
+                value={formState.desires}
+                onChange={handleChange('desires')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Faster insights, confident decisions"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Challenges (comma separated)
+              <input
+                value={formState.challenges}
+                onChange={handleChange('challenges')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Tool sprawl, resource constraints"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Goals (comma separated)
+              <input
+                value={formState.goals}
+                onChange={handleChange('goals')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Predictable pipeline, measurable ROI"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Media consumption (comma separated)
+              <input
+                value={formState.mediaConsumption}
+                onChange={handleChange('mediaConsumption')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="LinkedIn, industry newsletters"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Decision factors (comma separated)
+              <input
+                value={formState.decisionFactors}
+                onChange={handleChange('decisionFactors')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="ROI proof, ease of onboarding"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">Market positioning</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="text-sm text-gray-700">
+              Market category
+              <input
+                value={formState.marketCategory}
+                onChange={handleChange('marketCategory')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Marketing operations platform"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Market subcategory
+              <input
+                value={formState.marketSubcategory}
+                onChange={handleChange('marketSubcategory')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Workflow automation"
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Differentiator
+              <textarea
+                value={formState.differentiator}
+                onChange={handleChange('differentiator')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Explain what makes you distinct."
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Perceptual quadrant
+              <input
+                value={formState.perceptualQuadrant}
+                onChange={handleChange('perceptualQuadrant')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="High-touch / high-automation"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Strategy path
+              <select
+                value={formState.strategyPath}
+                onChange={handleChange('strategyPath')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+              >
+                <option value="safe">Safe</option>
+                <option value="clever">Clever</option>
+                <option value="bold">Bold</option>
+              </select>
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Positioning statement
+              <textarea
+                value={formState.positioningStatement}
+                onChange={handleChange('positioningStatement')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Positioning statement for the market."
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">Messaging framework</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Core message
+              <textarea
+                value={formState.messagingCoreMessage}
+                onChange={handleChange('messagingCoreMessage')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="The one message you want customers to remember."
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Value proposition
+              <textarea
+                value={formState.messagingValueProposition}
+                onChange={handleChange('messagingValueProposition')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Describe the value proposition."
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Supporting points (comma separated)
+              <input
+                value={formState.messagingSupportingPoints}
+                onChange={handleChange('messagingSupportingPoints')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Proof, ease, speed"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Proof points (comma separated)
+              <input
+                value={formState.messagingProofPoints}
+                onChange={handleChange('messagingProofPoints')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Case studies, benchmarks"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Call to action
+              <input
+                value={formState.messagingCallToAction}
+                onChange={handleChange('messagingCallToAction')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Book a strategy call"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Tone guidelines (comma separated)
+              <input
+                value={formState.messagingToneGuidelines}
+                onChange={handleChange('messagingToneGuidelines')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Authoritative, practical"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">Competitive positioning</h3>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Market position
+              <textarea
+                value={formState.competitiveMarketPosition}
+                onChange={handleChange('competitiveMarketPosition')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="Describe current competitive position."
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Competitive positioning statement
+              <textarea
+                value={formState.competitivePositioningStatement}
+                onChange={handleChange('competitivePositioningStatement')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                rows={2}
+                placeholder="How you position against competitors."
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Primary competitors (comma separated)
+              <input
+                value={formState.primaryCompetitors}
+                onChange={handleChange('primaryCompetitors')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Competitor A, Competitor B"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              Competitive advantages (comma separated)
+              <input
+                value={formState.competitiveAdvantages}
+                onChange={handleChange('competitiveAdvantages')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Faster setup, richer insights"
+              />
+            </label>
+            <label className="text-sm text-gray-700 md:col-span-2">
+              Differentiators (comma separated)
+              <input
+                value={formState.competitiveDifferentiators}
+                onChange={handleChange('competitiveDifferentiators')}
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm"
+                placeholder="Proactive guidance, automation"
+              />
+            </label>
+          </div>
+        </section>
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting ? 'Saving...' : 'Save business context'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/SystemIntegrationDashboard.tsx
+++ b/frontend/src/components/SystemIntegrationDashboard.tsx
@@ -11,6 +11,7 @@ import { useToolsStore } from '../stores/toolsStore';
 import { useAgentsStore } from '../stores/agentsStore';
 import { useAnalyticsStore } from '../stores/analyticsStore';
 import { getCurrentWorkspaceId, getCurrentUserId } from '../lib/auth-helpers';
+import BusinessContextForm from './BusinessContextForm';
 
 interface SystemStatus {
   name: string;
@@ -286,6 +287,8 @@ export default function SystemIntegrationDashboard() {
             </div>
           </div>
         )}
+
+        <BusinessContextForm />
 
         {/* Tools and Services Status */}
         {toolsStore.servicesStatus && (


### PR DESCRIPTION
### Motivation
- Provide a structured, validated input surface for capturing business context during onboarding and manual intake.  
- Reuse existing BusinessContext schema and validation rules to ensure consistent quality and completeness before persistence.  
- Persist validated business context records into the `business_contexts` table so other services (BCM, memory tiers, agents) can consume them.

### Description
- Add `backend/schemas/business_context_input.py` which defines a concise input schema (`BusinessContextInput`, `ICPProfileInput`, `ChannelStrategyInput`), normalizes lists, enforces field-level validation, and maps inputs to the full `BusinessContext` model.  
- Add `backend/api/v1/business_contexts.py` which exposes a POST endpoint that converts incoming input, runs `business_context_validator.validate_from_dict(...)`, augments metadata with validation results, and upserts the record into the `business_contexts` table via Supabase admin client.  
- Wire the new router into the backend app (`backend/main.py`) so the endpoint is reachable under the API prefix.  
- Add a frontend intake component `frontend/src/components/BusinessContextForm.tsx` and embed it into the `SystemIntegrationDashboard` to collect, perform client-side checks, and submit structured payloads through the existing proxy to the new backend endpoint.

### Testing
- `npm install --legacy-peer-deps` completed successfully in the environment and dependencies were installed.  
- Attempted to run the Next.js dev server (`npm run dev`) which compiled but runtime initialization failed due to missing environment variables (e.g. `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SENTRY_DSN`, `RESEND_API_KEY`, `UPSTASH_REDIS_URL`, `UPSTASH_REDIS_TOKEN`), preventing full end-to-end UI verification.  
- A Playwright screenshot attempt timed out (UI interactions could not be completed because the app did not bootstrap fully).  
- No backend unit/e2e tests were executed against the new endpoint in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b15a0eac48332882c4fbbfc014849)