### PR TITLE
Add BCM manifest generation, persistence, and retrieval (bcm_manifests + endpoints)

### DIFF
--- a/backend/migrations/005_bcm_manifests.sql
+++ b/backend/migrations/005_bcm_manifests.sql
@@ -1,0 +1,34 @@
+-- BCM Manifests Table
+-- Stores BCM JSON with versioning and timestamps
+
+CREATE TABLE IF NOT EXISTS bcm_manifests (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    session_id UUID REFERENCES onboarding_sessions(id) ON DELETE SET NULL,
+    version INTEGER NOT NULL,
+    checksum VARCHAR(64) NOT NULL,
+    manifest_json JSONB NOT NULL,
+    generated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(workspace_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bcm_manifests_workspace_id ON bcm_manifests(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_bcm_manifests_session_id ON bcm_manifests(session_id);
+CREATE INDEX IF NOT EXISTS idx_bcm_manifests_version ON bcm_manifests(workspace_id, version);
+
+CREATE OR REPLACE FUNCTION update_bcm_manifests_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_bcm_manifests_updated_at
+BEFORE UPDATE ON bcm_manifests
+FOR EACH ROW EXECUTE FUNCTION update_bcm_manifests_updated_at();
+
+COMMENT ON TABLE bcm_manifests IS 'BCM manifests with versioning and timestamps';
+COMMENT ON COLUMN bcm_manifests.version IS 'Incrementing version number per workspace';

--- a/backend/services/bcm_manifest_service.py
+++ b/backend/services/bcm_manifest_service.py
@@ -1,0 +1,232 @@
+"""
+BCM Manifest Service
+
+Builds BCM manifests from onboarding sessions and business_contexts,
+then persists them into the bcm_manifests table with versioning.
+"""
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from ..integration.bcm_reducer import BCMReducer
+from ..core.supabase_mgr import get_supabase_admin
+
+logger = logging.getLogger(__name__)
+
+
+class BCMManifestService:
+    """Service for BCM manifest generation and retrieval."""
+
+    def __init__(self, db_client=None):
+        self.db = db_client or get_supabase_admin()
+        self.reducer = BCMReducer()
+
+    async def generate_manifest(
+        self, workspace_id: str, force: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Generate a BCM manifest from onboarding + business_contexts and persist it.
+
+        Args:
+            workspace_id: Workspace identifier
+            force: Whether to force regeneration
+        """
+        latest_record = await self.get_latest_manifest_record(workspace_id)
+        if latest_record and not force:
+            generated_at = latest_record.get("generated_at")
+            if generated_at:
+                parsed = datetime.fromisoformat(generated_at)
+                if datetime.utcnow() - parsed < timedelta(hours=1):
+                    return {
+                        "success": False,
+                        "reason": "Recent BCM exists, use force=true to override",
+                    }
+
+        session_record = await self._get_latest_onboarding_session(workspace_id)
+        if not session_record:
+            raise ValueError("No onboarding session found for workspace")
+
+        steps_data = await self._get_onboarding_steps(session_record["id"])
+        session_data = session_record.get("session_data") or {}
+        raw_steps = self._normalize_step_data(steps_data, session_data)
+
+        metadata = session_record.get("metadata") or {}
+        metadata.update(
+            {
+                "workspace_id": workspace_id,
+                "user_id": session_record.get("user_id"),
+                "session_id": session_record.get("session_id"),
+            }
+        )
+
+        raw_step_data = {"metadata": metadata, **raw_steps}
+
+        business_context = await self._get_business_context(workspace_id)
+
+        if business_context:
+            raw_step_data["business_context"] = business_context
+
+        bcm_manifest = await self.reducer.reduce(raw_step_data)
+        manifest_payload = bcm_manifest.dict()
+
+        if business_context:
+            manifest_payload["business_context"] = business_context
+
+        checksum = self._compute_checksum(manifest_payload)
+        version = await self._next_version(workspace_id)
+
+        await self._store_manifest(
+            workspace_id=workspace_id,
+            session_id=session_record.get("id"),
+            version=version,
+            checksum=checksum,
+            manifest=manifest_payload,
+            generated_at=manifest_payload.get("generated_at"),
+        )
+
+        return {
+            "success": True,
+            "manifest": manifest_payload,
+            "version": version,
+            "checksum": checksum,
+            "generated_at": manifest_payload.get("generated_at"),
+        }
+
+    async def get_latest_manifest_record(self, workspace_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch the latest manifest record for a workspace."""
+        result = (
+            self.db.table("bcm_manifests")
+            .select("*")
+            .eq("workspace_id", workspace_id)
+            .order("version", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if result.data:
+            return result.data[0]
+        return None
+
+    async def get_manifest(
+        self, workspace_id: str, version: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Retrieve a manifest JSON for a workspace and optional version."""
+        query = self.db.table("bcm_manifests").select("*").eq(
+            "workspace_id", workspace_id
+        )
+        if version is not None:
+            query = query.eq("version", version)
+        else:
+            query = query.order("version", desc=True).limit(1)
+        result = query.execute()
+        if result.data:
+            return result.data[0]
+        return None
+
+    async def get_version_history(
+        self, workspace_id: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """Return version history for a workspace."""
+        result = (
+            self.db.table("bcm_manifests")
+            .select("id, workspace_id, version, checksum, generated_at, created_at")
+            .eq("workspace_id", workspace_id)
+            .order("version", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return result.data or []
+
+    async def _get_latest_onboarding_session(self, workspace_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.db.table("onboarding_sessions")
+            .select("id, session_id, user_id, workspace_id, session_data, metadata, updated_at")
+            .eq("workspace_id", workspace_id)
+            .order("updated_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if result.data:
+            return result.data[0]
+        return None
+
+    async def _get_onboarding_steps(self, session_id: str) -> List[Dict[str, Any]]:
+        result = (
+            self.db.table("onboarding_steps")
+            .select("step_number, step_name, status, step_data")
+            .eq("session_id", session_id)
+            .order("step_number", desc=False)
+            .execute()
+        )
+        return result.data or []
+
+    async def _get_business_context(self, workspace_id: str) -> Optional[Dict[str, Any]]:
+        result = (
+            self.db.table("business_contexts")
+            .select("*")
+            .eq("workspace_id", workspace_id)
+            .order("updated_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if result.data:
+            return result.data[0]
+        return None
+
+    def _normalize_step_data(
+        self, steps: List[Dict[str, Any]], session_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        if steps:
+            normalized: Dict[str, Any] = {}
+            for step in steps:
+                normalized[f"step_{step['step_number']}"] = {
+                    "data": step.get("step_data") or {},
+                    "status": step.get("status"),
+                    "name": step.get("step_name"),
+                }
+            return normalized
+
+        session_steps = session_data.get("steps") or session_data.get("step_data") or {}
+        normalized = {}
+        for key, value in session_steps.items():
+            step_key = f"step_{key}" if not str(key).startswith("step_") else str(key)
+            if isinstance(value, dict) and "data" in value:
+                normalized[step_key] = value
+            else:
+                normalized[step_key] = {"data": value}
+        return normalized
+
+    async def _next_version(self, workspace_id: str) -> int:
+        latest = await self.get_latest_manifest_record(workspace_id)
+        if not latest:
+            return 1
+        return int(latest.get("version", 0)) + 1
+
+    async def _store_manifest(
+        self,
+        workspace_id: str,
+        session_id: Optional[str],
+        version: int,
+        checksum: str,
+        manifest: Dict[str, Any],
+        generated_at: Optional[str],
+    ) -> None:
+        record = {
+            "workspace_id": workspace_id,
+            "session_id": session_id,
+            "version": version,
+            "checksum": checksum,
+            "manifest_json": manifest,
+            "generated_at": generated_at or datetime.utcnow().isoformat(),
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        result = self.db.table("bcm_manifests").insert(record).execute()
+        if not result.data:
+            raise RuntimeError("Failed to persist BCM manifest")
+
+    def _compute_checksum(self, manifest: Dict[str, Any]) -> str:
+        serialized = json.dumps(manifest, sort_keys=True)
+        return hashlib.sha256(serialized.encode()).hexdigest()


### PR DESCRIPTION
### Motivation

- Provide a repeatable BCM (Business Context Manifest) generator that combines onboarding step data and stored `business_contexts` and produces a versioned, checksummed JSON manifest.  
- Persist BCMs with incrementing versions and timestamps so the frontend can reliably fetch the latest or historical manifests.  
- Expose API endpoints so the frontend can rebuild, retrieve, export, and inspect BCMs and their history.

### Description

- Added a new manifest service `BCMManifestService` that builds BCMs from the latest onboarding session and optional `business_contexts`, computes checksums, assigns versions, and persists manifests to a new `bcm_manifests` table (`backend/services/bcm_manifest_service.py`).
- Created a DB migration to store manifests with versioning, timestamps and triggers: `backend/migrations/005_bcm_manifests.sql`.
- Extended onboarding finalization to include the latest `business_context` into BCM generation, cache a manifest payload in Upstash/Redis, persist to `bcm_manifests` with incremental versioning, and return the manifest payload in the finalize response (`backend/api/v1/onboarding_finalize.py`).
- Updated the context API endpoints to use `BCMManifestService` for rebuild and manifest retrieval flows and to return database-backed manifests and metadata (checksum/version) to the frontend (`backend/api/v1/context.py`).
- Small infra/import adjustments to use the existing Supabase manager and integrate with the new storage/orchestration logic.

### Testing

- Automated tests: none were executed as part of this change.  
- Code-level validation: basic static code updates and local file checks were performed during implementation but no unit/integration tests were run against Supabase/Redis in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b15a128508332a5721b800aef859c)