### PR TITLE
Add onboarding wizard resume flow and autosave sync

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useOnboardingStore } from "@/stores/onboardingStore";
 import { clientAuth } from '@/lib/auth-service';
 import { Loader2, Zap } from "lucide-react";
@@ -9,7 +9,10 @@ import { BlueprintButton } from "@/components/ui/BlueprintButton";
 
 export default function OnboardingPage() {
   const router = useRouter();
-  const { session, initSession } = useOnboardingStore();
+  const searchParams = useSearchParams();
+  const { session, initSession, currentStep, hasHydrated } = useOnboardingStore();
+
+  const sessionIdParam = searchParams.get("sessionId") || searchParams.get("session_id");
 
   useEffect(() => {
     const checkStatus = async () => {
@@ -28,14 +31,17 @@ export default function OnboardingPage() {
 
       // Initialize session if not exists and redirect to first step
       if (!session?.sessionId) {
-        initSession(`session-${Date.now()}`, "New Client");
+        initSession(sessionIdParam || `session-${Date.now()}`, "New Client");
       }
 
-      router.push("/onboarding/session/step/1");
+      const resumeStep = currentStep || 1;
+      router.push(`/onboarding/session/step/${resumeStep}${sessionIdParam ? `?sessionId=${sessionIdParam}` : ""}`);
     };
 
-    checkStatus();
-  }, [session, initSession, router]);
+    if (hasHydrated) {
+      checkStatus();
+    }
+  }, [session, initSession, router, currentStep, hasHydrated, sessionIdParam]);
 
   return (
     <div className="min-h-screen bg-[var(--canvas)] flex items-center justify-center">

--- a/src/app/onboarding/session/step/[stepId]/page.tsx
+++ b/src/app/onboarding/session/step/[stepId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, Suspense, lazy } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { OnboardingShell } from "@/components/onboarding/OnboardingShell";
 import { useOnboardingStore } from "@/stores/onboardingStore";
 import { Loader2 } from "lucide-react";
@@ -75,17 +75,24 @@ function StepLoadingFallback() {
 export default function OnboardingStepPage() {
   const params = useParams();
   const router = useRouter();
-  const { initSession, currentStep, session } = useOnboardingStore();
+  const searchParams = useSearchParams();
+  const { initSession, currentStep, setCurrentStep, session, hasHydrated } = useOnboardingStore();
 
   const stepId = parseInt(params.stepId as string);
   const StepComponent = StepComponents[stepId] || StepComponents[1];
+  const sessionIdParam = searchParams.get("sessionId") || searchParams.get("session_id");
 
   useEffect(() => {
     // Initialize session if not already done
+    if (!hasHydrated) return;
     if (!session?.sessionId) {
-      initSession(`session-${Date.now()}`, "New Client");
+      initSession(sessionIdParam || `session-${Date.now()}`, "New Client");
+      return;
     }
-  }, [session, initSession]);
+    if (currentStep !== stepId) {
+      setCurrentStep(stepId);
+    }
+  }, [session, initSession, currentStep, stepId, setCurrentStep, hasHydrated, sessionIdParam]);
 
   // Validate step range (now 24 steps)
   if (stepId < 1 || stepId > 24) {

--- a/src/components/onboarding/OnboardingShell.tsx
+++ b/src/components/onboarding/OnboardingShell.tsx
@@ -296,7 +296,12 @@ export function OnboardingShell({ children, stepId }: OnboardingShellProps) {
                     <div className="absolute bottom-0 left-0 right-0 p-6 bg-gradient-to-t from-[var(--canvas)] via-[var(--canvas)] to-transparent z-20 pointer-events-none">
                         <div className="max-w-3xl mx-auto flex items-center justify-between pointer-events-auto">
                             <SecondaryButton
-                                onClick={() => stepId > 1 && router.push(`/onboarding/session/step/${stepId - 1}`)}
+                                onClick={() => {
+                                    if (stepId <= 1) return;
+                                    const previousStep = stepId - 1;
+                                    setCurrentStep(previousStep);
+                                    router.push(`/onboarding/session/step/${previousStep}`);
+                                }}
                                 disabled={stepId <= 1}
                             >
                                 <ChevronLeft size={16} /> Previous


### PR DESCRIPTION
### Motivation
- Ensure onboarding progress is persisted locally, resumeable across reloads, and reliably synced to the backend per-step without duplicate completion calls.
- Allow external/resume links to restore a specific onboarding session via URL `sessionId`/`session_id` and continue at the last saved step.

### Description
- Added `hasHydrated` to `onboardingStore` and a `setHasHydrated` hook, and set `onRehydrateStorage` to mark hydration when persisted store loads.
- Prevent duplicate backend completion calls by checking previous status before invoking `completeStep` in `updateStepStatus` and added explicit `completeStep` / `updateStep` implementations that sync with the backend.
- Support resume-by-session-id by reading `sessionId`/`session_id` from URL search params and initializing the store with that ID in `src/app/onboarding/page.tsx` and `src/app/onboarding/session/step/[stepId]/page.tsx`.
- Wait for store hydration before initializing or redirecting, and restore/keep `currentStep` in sync when navigating between steps; also update the Previous button to sync `currentStep` before navigation in `OnboardingShell`.

### Testing
- No automated tests were run for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b15a175bc8332b77287c75ef74b3f)