### PR TITLE
Frontend: inventory buttons + add loading/error states for BlackBox, Muse, Monitoring, System Integration, Campaign Settings

### DIFF
--- a/frontend/FRONTEND_ACTIONS.md
+++ b/frontend/FRONTEND_ACTIONS.md
@@ -1,0 +1,52 @@
+# Frontend Action Inventory
+
+This document inventories click actions in the `/frontend` UI and maps each to a backend endpoint or explains when it is a deliberate client-only action.
+
+## Black Box Engine (`frontend/src/app/(shell)/blackbox/page.tsx`)
+| UI Action | Trigger | Backend Mapping | Notes | 
+| --- | --- | --- | --- |
+| Back | Top-right back button | No-op (client state) | Moves user back in the multi-step flow. | 
+| Select outcome card | Outcome card click | No-op (client state) | Selects an outcome and advances to volatility step. | 
+| Generate Strategy | “Generate Strategy” button | No-op (client-only simulation) | Simulated generation; no backend endpoint wired. | 
+| Discard | “Discard” button | No-op (client state) | Resets in-memory state. | 
+| Accept & Create Move | “Accept & Create Move” button | `POST /api/proxy/api/v1/moves/` | Uses `createMoveFromBlackBox` in `movesStore`. | 
+| Create Another | “Create Another” button | No-op (client state) | Resets in-memory state. | 
+| View Created Move | “View Created Move” button | No-op (client navigation) | Navigates to `/moves?highlight=<id>`; data fetch happens in the Moves page. | 
+
+## Campaign Settings (`frontend/src/components/campaigns/CampaignSettings.tsx`)
+| UI Action | Trigger | Backend Mapping | Notes | 
+| --- | --- | --- | --- |
+| Cancel | “Cancel” button | No-op (client callback) | Delegates to `onClose`. | 
+| Save Changes | “Save Changes” button | `PUT /api/proxy/api/v1/campaigns/:id` | Uses `updateCampaign` from `enhancedCampaignStore`. | 
+| Tabs | General/Notifications/Team/Integrations/Advanced tabs | No-op (client state) | Updates active tab in local state. | 
+
+## System Integration Dashboard (`frontend/src/components/SystemIntegrationDashboard.tsx`)
+| UI Action | Trigger | Backend Mapping | Notes | 
+| --- | --- | --- | --- |
+| Run Integration Test | “Run Integration Test” button | Multiple endpoints: `POST /api/proxy/api/v1/moves/`, `POST /api/proxy/api/v1/daily_wins/generate`, `POST /api/proxy/api/v1/blackbox/generate-strategy`, `POST /api/proxy/api/v1/muse/generate`, `POST /api/proxy/api/v1/agents/:id/execute` (via `executeAgent`), `POST /api/proxy/api/v1/bcm/record-interaction` (via `recordInteraction`) | Executes an end-to-end workflow across stores; errors surfaced in UI. | 
+| Refresh Systems | “Refresh Systems” button | No-op (client reload) | Uses `window.location.reload()` to rerun initialization. | 
+
+## Performance Monitoring (`frontend/src/components/PerformanceMonitoring.tsx`)
+| UI Action | Trigger | Backend Mapping | Notes | 
+| --- | --- | --- | --- |
+| Auto Refresh toggle | “Auto Refresh” button | `GET /api/monitoring/system`, `/agents`, `/workflows`, `/alerts`, `/health` | Toggles polling of monitoring endpoints. | 
+| Export | “Export” button | No-op (client-only download) | Exports current in-memory dataset to JSON; no backend export endpoint wired. | 
+| Settings | “Settings” button | No-op (client-only notice) | Displays a temporary notice; no backend settings endpoint wired. | 
+| Retry Load | “Retry Load” button | `GET /api/monitoring/*` endpoints | Retries monitoring fetches after errors. | 
+
+## Persona Brief Modal (`frontend/src/components/muse/PersonaBriefModal.tsx`)
+| UI Action | Trigger | Backend Mapping | Notes | 
+| --- | --- | --- | --- |
+| Close | “X” button | No-op (client callback) | Calls `onClose`. | 
+| Add Goal | “Add” button | No-op (client state) | Adds a goal to in-memory form state. | 
+| Remove Goal | “X” on a goal pill | No-op (client state) | Removes the goal from in-memory form state. | 
+| Cancel | “Cancel” button | No-op (client callback) | Calls `onClose`. | 
+| Save Brief | “Save Brief” button | No-op (client store) | Persists to local persona store; no backend endpoint wired in this module. | 
+
+## Muse Vertex AI Chat (`frontend/src/components/muse/MuseVertexAIChat.tsx`)
+| UI Action | Trigger | Backend Mapping | Notes | 
+| --- | --- | --- | --- |
+| Blog quick action | “Blog” button | `POST http://localhost:8000/api/v1/muse/generate` | Sends a content generation request to the Muse API. | 
+| Email quick action | “Email” button | `POST http://localhost:8000/api/v1/muse/generate` | Sends a content generation request to the Muse API. | 
+| Prompt shortcut buttons | Suggested prompt buttons | No-op (client state) | Pre-fills the input field. | 
+| Send message | Submit button | `POST http://localhost:8000/api/v1/muse/chat` | Sends a chat request to the Muse API. | 

--- a/frontend/src/components/SystemIntegrationDashboard.tsx
+++ b/frontend/src/components/SystemIntegrationDashboard.tsx
@@ -22,6 +22,10 @@ interface SystemStatus {
 export default function SystemIntegrationDashboard() {
   const [systemStatuses, setSystemStatuses] = useState<Record<string, SystemStatus>>({});
   const [isInitializing, setIsInitializing] = useState(true);
+  const [initError, setInitError] = useState<string | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [testSuccess, setTestSuccess] = useState<string | null>(null);
+  const [isTesting, setIsTesting] = useState(false);
 
   // Store hooks
   const movesStore = useMovesStore();
@@ -42,72 +46,82 @@ export default function SystemIntegrationDashboard() {
 
       if (!workspaceId || !userId) {
         console.error('Authentication required for system initialization');
+        setInitError('Authentication required. Please sign in to load system status.');
         setIsInitializing(false);
         return;
       }
 
+      setInitError(null);
       const systems: Record<string, SystemStatus> = {};
 
-      // Initialize each system
-      try {
-        // Moves System
-        setSystemStatuses(prev => ({ ...prev, moves: { name: 'Moves', status: 'loading', lastCheck: new Date().toISOString() } }));
+      const updateStatus = (key: string, status: SystemStatus) => {
+        systems[key] = status;
+        setSystemStatuses(prev => ({ ...prev, [key]: status }));
+      };
+
+      const initializeSystem = async (
+        key: string,
+        name: string,
+        action: () => Promise<any>
+      ) => {
+        updateStatus(key, { name, status: 'loading', lastCheck: new Date().toISOString() });
+        try {
+          const data = await action();
+          updateStatus(key, { name, status: 'connected', lastCheck: new Date().toISOString(), data });
+        } catch (error) {
+          console.error(`System initialization error (${name}):`, error);
+          updateStatus(key, { name, status: 'error', lastCheck: new Date().toISOString() });
+          setInitError(prev => prev ?? 'Some systems failed to initialize. Check connectivity and retry.');
+        }
+      };
+
+      await initializeSystem('moves', 'Moves', async () => {
         await movesStore.fetchMoves();
-        systems.moves = { name: 'Moves', status: 'connected', lastCheck: new Date().toISOString(), data: movesStore.moves };
+        return movesStore.moves;
+      });
 
-        // Campaigns System
-        setSystemStatuses(prev => ({ ...prev, campaigns: { name: 'Campaigns', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('campaigns', 'Campaigns', async () => {
         await campaignsStore.fetchCampaigns();
-        systems.campaigns = { name: 'Campaigns', status: 'connected', lastCheck: new Date().toISOString(), data: campaignsStore.campaigns };
+        return campaignsStore.campaigns;
+      });
 
-        // Daily Wins System
-        setSystemStatuses(prev => ({ ...prev, dailyWins: { name: 'Daily Wins', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('dailyWins', 'Daily Wins', async () => {
         await dailyWinsStore.fetchWins(workspaceId, userId);
-        systems.dailyWins = { name: 'Daily Wins', status: 'connected', lastCheck: new Date().toISOString(), data: dailyWinsStore.wins };
+        return dailyWinsStore.wins;
+      });
 
-        // Blackbox System
-        setSystemStatuses(prev => ({ ...prev, blackbox: { name: 'Blackbox', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('blackbox', 'Blackbox', async () => {
         await blackboxStore.fetchStrategies(workspaceId, userId);
-        systems.blackbox = { name: 'Blackbox', status: 'connected', lastCheck: new Date().toISOString(), data: blackboxStore.strategies };
+        return blackboxStore.strategies;
+      });
 
-        // Muse System
-        setSystemStatuses(prev => ({ ...prev, muse: { name: 'Muse', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('muse', 'Muse', async () => {
         await museStore.fetchAssets(workspaceId, userId);
-        systems.muse = { name: 'Muse', status: 'connected', lastCheck: new Date().toISOString(), data: museStore.assets };
+        return museStore.assets;
+      });
 
-        // BCM System
-        setSystemStatuses(prev => ({ ...prev, bcm: { name: 'BCM', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('bcm', 'BCM', async () => {
         await bcmStore.fetchContext(workspaceId);
         await bcmStore.fetchEvolution(workspaceId);
-        systems.bcm = { name: 'BCM', status: 'connected', lastCheck: new Date().toISOString(), data: bcmStore.context };
+        return bcmStore.context;
+      });
 
-        // Tools System
-        setSystemStatuses(prev => ({ ...prev, tools: { name: 'Tools', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('tools', 'Tools', async () => {
         await toolsStore.fetchAvailableTools();
         await toolsStore.fetchServicesStatus();
-        systems.tools = { name: 'Tools', status: 'connected', lastCheck: new Date().toISOString(), data: toolsStore.tools };
+        return toolsStore.tools;
+      });
 
-        // Agents System
-        setSystemStatuses(prev => ({ ...prev, agents: { name: 'Agents', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('agents', 'Agents', async () => {
         await agentsStore.fetchAvailableAgents();
-        systems.agents = { name: 'Agents', status: 'connected', lastCheck: new Date().toISOString(), data: agentsStore.agents };
+        return agentsStore.agents;
+      });
 
-        // Analytics System
-        setSystemStatuses(prev => ({ ...prev, analytics: { name: 'Analytics', status: 'loading', lastCheck: new Date().toISOString() } }));
+      await initializeSystem('analytics', 'Analytics', async () => {
         await analyticsStore.fetchDashboard();
-        systems.analytics = { name: 'Analytics', status: 'connected', lastCheck: new Date().toISOString(), data: analyticsStore.dashboard };
+        return analyticsStore.dashboard;
+      });
 
-      } catch (error) {
-        console.error('System initialization error:', error);
-        // Mark failed systems as error
-        Object.keys(systems).forEach(key => {
-          if (!systems[key].data) {
-            systems[key] = { ...systems[key], status: 'error' as const };
-          }
-        });
-      }
-
-      setSystemStatuses(systems);
       setIsInitializing(false);
     };
 
@@ -120,9 +134,13 @@ export default function SystemIntegrationDashboard() {
     const userId = getCurrentUserId();
 
     if (!workspaceId || !userId) {
-      alert('Please authenticate first');
+      setTestError('Please authenticate first.');
       return;
     }
+
+    setIsTesting(true);
+    setTestError(null);
+    setTestSuccess(null);
 
     try {
       // Test 1: Create a Move
@@ -179,11 +197,13 @@ export default function SystemIntegrationDashboard() {
         }
       });
 
-      alert('✅ Integration test completed successfully! All systems are working together.');
+      setTestSuccess('✅ Integration test completed successfully! All systems are working together.');
 
     } catch (error) {
       console.error('Integration test failed:', error);
-      alert('❌ Integration test failed. Check console for details.');
+      setTestError('❌ Integration test failed. Check console for details.');
+    } finally {
+      setIsTesting(false);
     }
   };
 
@@ -223,6 +243,21 @@ export default function SystemIntegrationDashboard() {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">🚀 Raptorflow System Integration</h1>
           <p className="text-gray-600">Complete integration of all systems with BCM, tools, and agents</p>
+          {initError && (
+            <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+              {initError}
+            </div>
+          )}
+          {testError && (
+            <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+              {testError}
+            </div>
+          )}
+          {testSuccess && (
+            <div className="mt-3 rounded-lg border border-green-200 bg-green-50 px-4 py-2 text-sm text-green-700">
+              {testSuccess}
+            </div>
+          )}
         </div>
 
         {/* System Status Grid */}
@@ -384,9 +419,10 @@ export default function SystemIntegrationDashboard() {
         <div className="flex flex-wrap gap-4 justify-center">
           <button
             onClick={testIntegration}
-            className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors"
+            disabled={isTesting}
+            className="bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            🧪 Run Integration Test
+            {isTesting ? '🧪 Running Integration Test...' : '🧪 Run Integration Test'}
           </button>
           <button
             onClick={() => window.location.reload()}

--- a/frontend/src/components/campaigns/CampaignSettings.tsx
+++ b/frontend/src/components/campaigns/CampaignSettings.tsx
@@ -75,6 +75,7 @@ export function CampaignSettings({ campaignId, onSave, onClose }: CampaignSettin
   const [activeTab, setActiveTab] = useState<'general' | 'notifications' | 'team' | 'integrations' | 'advanced'>('general');
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Settings state
   const [generalSettings, setGeneralSettings] = useState({
@@ -164,6 +165,7 @@ export function CampaignSettings({ campaignId, onSave, onClose }: CampaignSettin
   // Handle save
   const handleSave = async () => {
     setIsSaving(true);
+    setSaveError(null);
     try {
       await updateCampaign({
         id: campaign.id,
@@ -172,6 +174,9 @@ export function CampaignSettings({ campaignId, onSave, onClose }: CampaignSettin
       });
       setHasChanges(false);
       onSave?.();
+    } catch (error) {
+      console.error('Failed to save campaign settings:', error);
+      setSaveError('Unable to save changes right now. Please try again.');
     } finally {
       setIsSaving(false);
     }
@@ -233,6 +238,12 @@ export function CampaignSettings({ campaignId, onSave, onClose }: CampaignSettin
             <div className="flex items-center gap-2 text-sm text-[var(--warning)]">
               <Info size={16} />
               Unsaved changes
+            </div>
+          )}
+          {saveError && (
+            <div className="flex items-center gap-2 text-sm text-[var(--error)]">
+              <AlertTriangle size={16} />
+              {saveError}
             </div>
           )}
 


### PR DESCRIPTION
### Motivation
- Provide an explicit inventory mapping of frontend buttons/actions to backend endpoints or to intentional client-only behavior for easier maintenance and QA.
- Harden UX by adding missing handlers and clear loading/disabled states for long-running actions (strategy generation, move creation, integration tests, monitoring refresh/export, campaign save) so users get feedback and errors are surfaced.
- Improve robustness of system initialization and integration test flows by surfacing per-system errors and preventing duplicate actions while requests are in-flight.

### Description
- Added `frontend/FRONTEND_ACTIONS.md` to document all major UI actions and their backend mappings or deliberate client-only behavior.
- Black Box page (`frontend/src/app/(shell)/blackbox/page.tsx`) now uses `isGenerating` and `actionError`, reads `createMoveFromBlackBox` and `isLoading` from `movesStore`, performs async generation/create flows with try/catch, and disables buttons and shows inline feedback while operations run or when they fail.
- Campaign settings (`frontend/src/components/campaigns/CampaignSettings.tsx`) now tracks `saveError`, shows an error banner in the header, and sets `isSaving` with proper try/catch around `updateCampaign` calls.
- Performance monitoring (`frontend/src/components/PerformanceMonitoring.tsx`) gains robust fetch parsing (`parseResponse`), better error handling (`loadError`), silent auto-refresh polling, an export-to-JSON client action, a temporary settings notice, and last-updated timestamp and UI feedback for refreshing/exporting operations.
- System integration dashboard (`frontend/src/components/SystemIntegrationDashboard.tsx`) initializes each subsystem independently with per-system loading/connected/error states, surfaces an `initError` summary if systems fail, and wraps the integration test flow with `isTesting`, `testError`, and `testSuccess` feedback while disabling the test button during execution.
- Muse chat (`frontend/src/components/muse/MuseVertexAIChat.tsx`) now tracks `errorMessage`, validates responses (shows API errors when response is not OK), and surfaces network/API error messages in the UI for both chat and generation requests.

### Testing
- No automated tests were executed as part of this change; changes were implemented and committed but runtime verification was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b1c4cda288332b64238750d0ab5cc)