### PR TITLE
Home: Consolidate auth flow and add landing hero for unauthenticated users

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,19 +1,21 @@
 'use client';
 
-import { useEffect } from 'react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { isAuthenticated } from '../lib/auth-helpers';
 import SystemIntegrationDashboard from '../components/SystemIntegrationDashboard';
 
 export default function Home() {
-  // Redirect to login if not authenticated
+  const [authChecked, setAuthChecked] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
+
   useEffect(() => {
-    if (!isAuthenticated()) {
-      window.location.href = '/login';
-    }
+    const authed = isAuthenticated();
+    setAuthenticated(authed);
+    setAuthChecked(true);
   }, []);
 
-  // Show loading while checking auth
-  if (!isAuthenticated()) {
+  if (!authChecked) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
         <div className="text-center">
@@ -24,23 +26,34 @@ export default function Home() {
     );
   }
 
-  return (
-    <main>
-      <SystemIntegrationDashboard />
-    </main>
-  );
-}
-      window.location.href = '/login';
-    }
-  }, []);
-
-  // Show loading while checking auth
-  if (!isAuthenticated()) {
+  if (!authenticated) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <h2 className="text-xl font-semibold text-gray-800">Checking authentication...</h2>
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+        <div className="mx-auto flex min-h-screen max-w-6xl flex-col items-center justify-center px-6 py-16 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-700">
+            Raptorflow System Integrations
+          </p>
+          <h1 className="mt-4 text-4xl font-bold text-slate-900 sm:text-5xl">
+            Connect every system. Orchestrate every workflow.
+          </h1>
+          <p className="mt-5 max-w-2xl text-lg text-slate-600">
+            Sign in to launch your unified integration dashboard, monitor pipelines, and automate
+            your business operations from one control plane.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Link
+              href="/login"
+              className="rounded-full bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-200 transition hover:bg-blue-700"
+            >
+              Log in
+            </Link>
+            <Link
+              href="/signup"
+              className="rounded-full border border-blue-200 bg-white px-6 py-3 text-sm font-semibold text-blue-700 shadow-sm transition hover:border-blue-300 hover:text-blue-800"
+            >
+              Create an account
+            </Link>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
### Motivation
- Remove a duplicated trailing auth block and centralize the authentication check to avoid inconsistent behavior in `frontend/src/app/page.tsx`.
- Replace a hard `window.location.href` redirect for unauthenticated users with a friendly landing UI to improve UX and provide clear CTAs.
- Ensure the `SystemIntegrationDashboard` is only rendered after the authentication check completes to prevent flashing protected UI.

### Description
- Consolidated the auth check into a single stateful flow using `useState` and `useEffect` in `frontend/src/app/page.tsx` and removed the duplicated/stray block.
- Replaced the unconditional `window.location.href = '/login'` redirect with a hero landing UI that includes CTA `Link`s to `/login` and `/signup` for unauthenticated users.
- Added an `authChecked` state so the app shows a loading view while verifying auth and only renders `SystemIntegrationDashboard` after the check passes.
- Kept the authenticated branch pointing to `SystemIntegrationDashboard` and gated its rendering until `authChecked` is `true` and `authenticated` is `true`.

### Testing
- Attempted to start the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, but it failed because the `next` binary was not found (dev server did not start).
- No automated test suite was executed as part of this change due to the unavailable dev runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c4e8e1ee08332a444b0b343698693)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added landing page with sign-in and sign-up call-to-action options for unauthenticated users

* **Refactor**
  * Improved authentication flow with state-driven approach for a more reliable user experience
  * Enhanced loading state management to align with authentication verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->