### PR TITLE
Standardize API v1 router prefixes

### DIFF
--- a/backend/api/v1/agents.py
+++ b/backend/api/v1/agents.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 security = HTTPBearer()
 
 # Router
-router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
+router = APIRouter(prefix="/agents", tags=["agents"])
 
 # Global instances - lazy initialized to avoid import-time blocking
 _dispatcher = None

--- a/backend/api/v1/bcm_endpoints.py
+++ b/backend/api/v1/bcm_endpoints.py
@@ -88,7 +88,7 @@ class BCMCleanupResponse(BaseModel):
 
 
 # Create router
-router = APIRouter(prefix="/api/v1/bcm", tags=["bcm"])
+router = APIRouter(prefix="/bcm", tags=["bcm"])
 
 # Global service instance (in production, use dependency injection)
 bcm_service: Optional[BCMStorageOrchestrator] = None

--- a/backend/api/v1/context.py
+++ b/backend/api/v1/context.py
@@ -25,7 +25,7 @@ from ..core.supabase_mgr import get_supabase_admin
 logger = logging.getLogger(__name__)
 
 router = APIRouter(
-    prefix="/api/v1/context", tags=["context"], dependencies=[Depends(get_current_user)]
+    prefix="/context", tags=["context"], dependencies=[Depends(get_current_user)]
 )
 
 

--- a/backend/api/v1/metrics.py
+++ b/backend/api/v1/metrics.py
@@ -48,7 +48,7 @@ from ..core.resources import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/metrics", tags=["metrics"])
+router = APIRouter(prefix="/metrics", tags=["metrics"])
 
 
 @router.get("/global")

--- a/backend/api/v1/minimal_routers.py
+++ b/backend/api/v1/minimal_routers.py
@@ -8,14 +8,14 @@ from typing import Any, Dict
 from fastapi import APIRouter, HTTPException
 
 # Create minimal routers
-health = APIRouter()
-auth = APIRouter()
-users = APIRouter()
-campaigns = APIRouter()
-moves = APIRouter()
-blackbox = APIRouter()
-analytics = APIRouter()
-ocr = APIRouter()
+health = APIRouter(prefix="/health")
+auth = APIRouter(prefix="/auth")
+users = APIRouter(prefix="/users")
+campaigns = APIRouter(prefix="/campaigns")
+moves = APIRouter(prefix="/moves")
+blackbox = APIRouter(prefix="/blackbox")
+analytics = APIRouter(prefix="/analytics")
+ocr = APIRouter(prefix="/ocr")
 
 
 @health.get("/")

--- a/backend/api/v1/onboarding.py
+++ b/backend/api/v1/onboarding.py
@@ -76,7 +76,7 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1
 
 # Create router
-router = APIRouter(prefix="/api/v1/onboarding", tags=["onboarding"])
+router = APIRouter(prefix="/onboarding", tags=["onboarding"])
 
 # Initialize industrial services
 ocr_service = OCRService()

--- a/backend/api/v1/onboarding_enhanced.py
+++ b/backend/api/v1/onboarding_enhanced.py
@@ -67,7 +67,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Create router
-router = APIRouter(prefix="/api/v1/onboarding", tags=["onboarding-enhanced"])
+router = APIRouter(prefix="/onboarding", tags=["onboarding-enhanced"])
 
 # Initialize services
 ocr_service = OCRService()

--- a/backend/api/v1/onboarding_finalize.py
+++ b/backend/api/v1/onboarding_finalize.py
@@ -26,7 +26,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Create router
-router = APIRouter(prefix="/api/v1/onboarding", tags=["onboarding-finalize"])
+router = APIRouter(prefix="/onboarding", tags=["onboarding-finalize"])
 
 # Initialize services
 session_manager = get_onboarding_session_manager()

--- a/backend/api/v1/onboarding_migration.py
+++ b/backend/api/v1/onboarding_migration.py
@@ -28,7 +28,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Create router
-router = APIRouter(prefix="/api/v1/onboarding/migration", tags=["onboarding-migration"])
+router = APIRouter(prefix="/onboarding/migration", tags=["onboarding-migration"])
 
 # Initialize services
 migration_service = OnboardingMigrationService()

--- a/backend/api/v1/onboarding_universal.py
+++ b/backend/api/v1/onboarding_universal.py
@@ -9,7 +9,7 @@ from ..agents.universal.agent import UniversalAgent
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/onboarding-universal", tags=["onboarding-universal"])
+router = APIRouter(prefix="/onboarding-universal", tags=["onboarding-universal"])
 
 # Repositories
 onboarding_repo = OnboardingRepository()

--- a/backend/api/v1/payments_enhanced.py
+++ b/backend/api/v1/payments_enhanced.py
@@ -43,7 +43,7 @@ from ..redis_core.client import get_redis
 logger = logging.getLogger(__name__)
 
 # Create router
-router = APIRouter(prefix="/api/v1/payments", tags=["payments_enhanced"])
+router = APIRouter(prefix="/payments", tags=["payments_enhanced"])
 
 # Security
 security = HTTPBearer(auto_error=False)

--- a/backend/api/v1/rate_limit.py
+++ b/backend/api/v1/rate_limit.py
@@ -13,7 +13,7 @@ from ..core.rate_limiter import get_rate_limit_stats, get_rate_limiter
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/rate-limit", tags=["rate-limiting"])
+router = APIRouter(prefix="/rate-limit", tags=["rate-limiting"])
 
 
 @router.get("/status")

--- a/backend/api/v1/sessions.py
+++ b/backend/api/v1/sessions.py
@@ -23,7 +23,7 @@ from ..core.sessions import get_session_manager as get_redis_session_manager
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1/sessions", tags=["sessions"])
+router = APIRouter(prefix="/sessions", tags=["sessions"])
 
 
 # Dependency for authentication

--- a/backend/api/v1/usage.py
+++ b/backend/api/v1/usage.py
@@ -14,7 +14,7 @@ except ImportError:
     vertex_ai_client = None
 from ..core.auth import get_current_user
 
-router = APIRouter(prefix="/api/v1/usage", tags=["usage"])
+router = APIRouter(prefix="/usage", tags=["usage"])
 
 from ..core.supabase_mgr import get_supabase_client
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -117,14 +117,14 @@ async def health_check():
 
 
 # Include API routers
-app.include_router(health.router, prefix="/api/v1/health", tags=["health"])
-app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
-app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
-app.include_router(campaigns.router, prefix="/api/v1/campaigns", tags=["campaigns"])
-app.include_router(moves.router, prefix="/api/v1/moves", tags=["moves"])
-app.include_router(blackbox.router, prefix="/api/v1/blackbox", tags=["blackbox"])
-app.include_router(analytics.router, prefix="/api/v1/analytics", tags=["analytics"])
-app.include_router(ocr.router, prefix="/api/v1/ocr", tags=["ocr"])
+app.include_router(health.router, prefix="/api/v1", tags=["health"])
+app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
+app.include_router(users.router, prefix="/api/v1", tags=["users"])
+app.include_router(campaigns.router, prefix="/api/v1", tags=["campaigns"])
+app.include_router(moves.router, prefix="/api/v1", tags=["moves"])
+app.include_router(blackbox.router, prefix="/api/v1", tags=["blackbox"])
+app.include_router(analytics.router, prefix="/api/v1", tags=["analytics"])
+app.include_router(ocr.router, prefix="/api/v1", tags=["ocr"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/main.py
+++ b/backend/main.py
@@ -345,34 +345,34 @@ if os.getenv("ENABLE_RATE_LIMITING", "true").lower() == "true":
     app.add_middleware(rate_limit_middleware)
 
 # Include all API routers
-app.include_router(agents.router, prefix="/api/v1/agents", tags=["agents"])
-app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
-app.include_router(workspaces.router, prefix="/api/v1/workspaces", tags=["workspaces"])
-app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
-app.include_router(foundation.router, prefix="/api/v1/foundation", tags=["foundation"])
-app.include_router(icps.router, prefix="/api/v1/icps", tags=["icps"])
-app.include_router(council.router, prefix="/api/v1/council", tags=["council"])
-app.include_router(moves.router, prefix="/api/v1/moves", tags=["moves"])
+app.include_router(agents.router, prefix="/api/v1", tags=["agents"])
+app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
+app.include_router(workspaces.router, prefix="/api/v1", tags=["workspaces"])
+app.include_router(users.router, prefix="/api/v1", tags=["users"])
+app.include_router(foundation.router, prefix="/api/v1", tags=["foundation"])
+app.include_router(icps.router, prefix="/api/v1", tags=["icps"])
+app.include_router(council.router, prefix="/api/v1", tags=["council"])
+app.include_router(moves.router, prefix="/api/v1", tags=["moves"])
 app.include_router(muse_vertex_ai.router, prefix="/api/v1", tags=["muse"])
-app.include_router(onboarding.router, prefix="/api/v1/onboarding", tags=["onboarding"])
+app.include_router(onboarding.router, prefix="/api/v1", tags=["onboarding"])
 app.include_router(onboarding_v2.router, prefix="/api/v1", tags=["onboarding-v2"])
 app.include_router(
     onboarding_universal.router,
-    prefix="/api/v1/onboarding-universal",
+    prefix="/api/v1",
     tags=["onboarding-universal"],
 )
-app.include_router(analytics.router, prefix="/api/v1/analytics", tags=["analytics"])
+app.include_router(analytics.router, prefix="/api/v1", tags=["analytics"])
 app.include_router(
-    analytics_v2.router, prefix="/api/v1/analytics-v2", tags=["analytics"]
+    analytics_v2.router, prefix="/api/v1", tags=["analytics"]
 )
-app.include_router(memory.router, prefix="/api/v1/memory", tags=["memory"])
-app.include_router(graph.router, prefix="/api/v1/graph", tags=["graph"])
-app.include_router(sessions.router, prefix="/api/v1/sessions", tags=["sessions"])
+app.include_router(memory.router, prefix="/api/v1", tags=["memory"])
+app.include_router(graph.router, prefix="/api/v1", tags=["graph"])
+app.include_router(sessions.router, prefix="/api/v1", tags=["sessions"])
 # app.include_router(episodes.router, prefix="/api/v1/episodes", tags=["episodes"])
-app.include_router(approvals.router, prefix="/api/v1/approvals", tags=["approvals"])
-app.include_router(metrics.router, prefix="/api/v1/metrics", tags=["metrics"])
+app.include_router(approvals.router, prefix="/api/v1", tags=["approvals"])
+app.include_router(metrics.router, prefix="/api/v1", tags=["metrics"])
 app.include_router(
-    health_comprehensive.router, prefix="/api/v1/health", tags=["health"]
+    health_comprehensive.router, prefix="/api/v1", tags=["health"]
 )
 # Add configuration management router
 app.include_router(config.router, prefix="/api/v1", tags=["configuration"])
@@ -392,20 +392,20 @@ app.include_router(payments_v2.router, tags=["payments-v2"])  # Official PhonePe
 # Add AI proxy router
 app.include_router(ai_proxy.router, prefix="/api/v1", tags=["ai-proxy"])
 # Add usage tracking router
-app.include_router(usage.router, tags=["usage"])
+app.include_router(usage.router, prefix="/api/v1", tags=["usage"])
 # Add enhanced storage management router
 app.include_router(storage.router, prefix="/api/v1", tags=["storage"])
 app.include_router(
-    context.router, prefix="/api/v1/context", tags=["context"]
+    context.router, prefix="/api/v1", tags=["context"]
 )  # New context router
-app.include_router(evolution.router, prefix="/api/v1/evolution", tags=["evolution"])
+app.include_router(evolution.router, prefix="/api/v1", tags=["evolution"])
 app.include_router(ocr.router, prefix="/api/v1", tags=["ocr"])
-app.include_router(search.router, prefix="/api/v1/search", tags=["search"])
-app.include_router(titan.router, prefix="/api/v1/titan", tags=["titan"])
+app.include_router(search.router, prefix="/api/v1", tags=["search"])
+app.include_router(titan.router, prefix="/api/v1", tags=["titan"])
 # Add missing system routers
-app.include_router(campaigns.router, prefix="/api/v1/campaigns", tags=["campaigns"])
-app.include_router(daily_wins.router, prefix="/api/v1/daily_wins", tags=["daily_wins"])
-app.include_router(blackbox.router, prefix="/api/v1/blackbox", tags=["blackbox"])
+app.include_router(campaigns.router, prefix="/api/v1", tags=["campaigns"])
+app.include_router(daily_wins.router, prefix="/api/v1", tags=["daily_wins"])
+app.include_router(blackbox.router, prefix="/api/v1", tags=["blackbox"])
 app.include_router(
     business_contexts.router,
     prefix="/api/v1",

--- a/backend/services/sota_ocr/api.py
+++ b/backend/services/sota_ocr/api.py
@@ -88,7 +88,7 @@ class SystemStatusResponse(BaseModel):
 
 
 # Router setup
-router = APIRouter(prefix="/api/v1/ocr", tags=["OCR"])
+router = APIRouter(prefix="/ocr", tags=["OCR"])
 logger = logging.getLogger(__name__)
 
 # Global service instance


### PR DESCRIPTION
### Motivation
- Unify routing convention so each router defines a resource-level prefix (e.g. `/auth`, `/agents`, `/onboarding`) and the main app mounts those routers under a single versioned prefix (`/api/v1`).
- Remove duplicated embedding of `/api/v1` inside many routers to avoid double-prefixing and make route composition predictable.

### Description
- Converted many routers to resource-level prefixes by removing embedded `/api/v1` from router definitions (examples: `backend/api/v1/agents.py`, `onboarding*.py`, `sessions.py`, `metrics.py`, `usage.py`, `bcm_endpoints.py`, `rate_limit.py`, `payments_enhanced.py`, `backend/services/sota_ocr/api.py`, `context.py`, etc.).
- Updated the primary application files `backend/main.py` and `backend/app.py` to mount routers under the common prefix `prefix="/api/v1"` so endpoints become `/api/v1/<resource>/*`.
- Adjusted `backend/api/v1/minimal_routers.py` to define resource prefixes there (e.g. `prefix="/auth"`, `prefix="/health"`) so the minimal app similarly mounts them under `/api/v1`.
- Preserved the auth router resource (`router = APIRouter(prefix="/auth")`) and confirmed it remains mounted at `/api/v1/auth` so frontend requests like `POST /api/v1/auth/login` and `POST /api/v1/auth/signup` continue to work.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c509028248332a2476099a9b78665)