### PR TITLE
Add TerminalAdapter for AI Hub contract and migrate API routes off direct orchestrators

### DIFF
--- a/backend/agents/compat.py
+++ b/backend/agents/compat.py
@@ -1,0 +1,80 @@
+"""Temporary compatibility gateways for deprecated direct orchestrator imports."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Literal
+
+from backend.agents.campaign_moves.orchestrator import langgraph_campaign_moves_orchestrator
+from backend.agents.optional.orchestrator import langgraph_optional_orchestrator
+
+
+class CampaignMovesGateway:
+    async def list_campaigns(self, workspace_id: str) -> list[Dict[str, Any]]:
+        return await langgraph_campaign_moves_orchestrator.list_campaigns(workspace_id)
+
+    async def create_campaign(self, workspace_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await langgraph_campaign_moves_orchestrator.create_campaign(workspace_id, payload)
+
+    async def get_campaign(self, workspace_id: str, campaign_id: str) -> Dict[str, Any] | None:
+        return await langgraph_campaign_moves_orchestrator.get_campaign(workspace_id, campaign_id)
+
+    async def update_campaign(
+        self,
+        workspace_id: str,
+        campaign_id: str,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any] | None:
+        return await langgraph_campaign_moves_orchestrator.update_campaign(
+            workspace_id,
+            campaign_id,
+            payload,
+        )
+
+    async def delete_campaign(self, workspace_id: str, campaign_id: str) -> bool:
+        return await langgraph_campaign_moves_orchestrator.delete_campaign(workspace_id, campaign_id)
+
+    async def campaign_moves_bundle(self, workspace_id: str, campaign_id: str) -> Dict[str, Any]:
+        return await langgraph_campaign_moves_orchestrator.campaign_moves_bundle(
+            workspace_id,
+            campaign_id,
+        )
+
+    async def list_moves(self, workspace_id: str) -> list[Dict[str, Any]]:
+        return await langgraph_campaign_moves_orchestrator.list_moves(workspace_id)
+
+    async def create_move(self, workspace_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await langgraph_campaign_moves_orchestrator.create_move(workspace_id, payload)
+
+    async def update_move(
+        self,
+        workspace_id: str,
+        move_id: str,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any] | None:
+        return await langgraph_campaign_moves_orchestrator.update_move(
+            workspace_id,
+            move_id,
+            payload,
+        )
+
+    async def delete_move(self, workspace_id: str, move_id: str) -> bool:
+        return await langgraph_campaign_moves_orchestrator.delete_move(workspace_id, move_id)
+
+
+class OptionalGateway:
+    async def run(
+        self,
+        *,
+        operation: Literal["search", "scraper"],
+        payload: Dict[str, Any],
+        executor: Callable[[], Awaitable[Dict[str, Any]]],
+    ) -> Dict[str, Any]:
+        return await langgraph_optional_orchestrator.run(
+            operation=operation,
+            payload=payload,
+            executor=executor,
+        )
+
+
+campaign_moves_gateway = CampaignMovesGateway()
+optional_gateway = OptionalGateway()

--- a/backend/ai/application/__init__.py
+++ b/backend/ai/application/__init__.py
@@ -1,0 +1,5 @@
+"""AI application service layer."""
+
+from backend.ai.application.terminal_adapter import TerminalAdapter, terminal_adapter
+
+__all__ = ["TerminalAdapter", "terminal_adapter"]

--- a/backend/ai/application/terminal_adapter.py
+++ b/backend/ai/application/terminal_adapter.py
@@ -1,0 +1,233 @@
+"""Terminal adapter for AI and orchestration flows.
+
+Maps terminal-facing payloads into ``TaskRequestV1`` and emits response metadata
+that follows the ``/ai/hub/v1`` run envelope contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional
+from uuid import uuid4
+
+from backend.ai.hub.contracts import TaskRequestV1, ToolPolicy
+from backend.ai.hub.runtime import AIHubRuntime
+from backend.agents.compat import campaign_moves_gateway
+from backend.agents.runtime.profiles import normalize_execution_mode, normalize_intensity
+from backend.services.muse_service import muse_service
+
+
+@dataclass
+class HubEnvelope:
+    run_id: str
+    status: str
+    result: Dict[str, Any]
+    tool_trace_summary: List[Dict[str, Any]]
+    bcm_writes: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "status": self.status,
+            "result": self.result,
+            "tool_trace_summary": self.tool_trace_summary,
+            "bcm_writes": self.bcm_writes,
+        }
+
+
+class TerminalAdapter:
+    """Application service layer for terminal/API payload mediation."""
+
+    def __init__(self, runtime: Optional[AIHubRuntime] = None) -> None:
+        self.runtime = runtime or AIHubRuntime()
+
+    def to_task_request(
+        self,
+        *,
+        workspace_id: str,
+        intent: str,
+        inputs: Optional[Dict[str, Any]] = None,
+        constraints: Optional[Dict[str, Any]] = None,
+        policy_profile: str = "balanced",
+        mode: Optional[str] = None,
+        intensity: Optional[str] = None,
+        max_tokens: int = 900,
+        temperature: float = 0.7,
+        content_type: str = "general",
+        requested_tools: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+    ) -> TaskRequestV1:
+        return TaskRequestV1(
+            workspace_id=workspace_id,
+            intent=intent,
+            inputs=inputs or {},
+            constraints=constraints or {},
+            policy_profile=policy_profile,
+            mode=normalize_execution_mode(mode),
+            intensity=normalize_intensity(intensity),
+            max_tokens=max_tokens,
+            temperature=temperature,
+            content_type=content_type,
+            requested_tools=requested_tools or [],
+            system_prompt=system_prompt,
+            tool_policy=ToolPolicy(),
+        )
+
+    def _build_hub_envelope(
+        self,
+        *,
+        request: TaskRequestV1,
+        result_payload: Dict[str, Any],
+        run_id: Optional[str] = None,
+    ) -> HubEnvelope:
+        resolved_run_id = run_id or str(result_payload.get("trace_id") or uuid4())
+        trace = self.runtime.get_trace(resolved_run_id) if resolved_run_id else {}
+        trace = trace or {}
+        tool_summary: List[Dict[str, Any]] = []
+        for call in trace.get("tool_calls", []):
+            tool_result = call.get("result", {}) if isinstance(call, dict) else {}
+            meta = tool_result.get("_meta", {}) if isinstance(tool_result, dict) else {}
+            tool_summary.append(
+                {
+                    "step_id": call.get("step_id"),
+                    "tool": call.get("tool"),
+                    "duration_ms": meta.get("duration_ms"),
+                    "payload_bytes": meta.get("payload_bytes"),
+                }
+            )
+
+        return HubEnvelope(
+            run_id=resolved_run_id,
+            status=str(result_payload.get("status") or "success"),
+            result=result_payload,
+            tool_trace_summary=tool_summary,
+            bcm_writes={
+                "memory_candidate_id": trace.get("memory_candidate_id"),
+                "event_hint": "task_completed_or_failed",
+                "workspace_id": request.workspace_id,
+            },
+        )
+
+    async def run_optional_module(
+        self,
+        *,
+        workspace_id: str,
+        intent: str,
+        payload: Dict[str, Any],
+        executor: Optional[Callable[[], Awaitable[Dict[str, Any]]]] = None,
+        precomputed_result: Optional[Dict[str, Any]] = None,
+    ) -> HubEnvelope:
+        request = self.to_task_request(
+            workspace_id=workspace_id,
+            intent=intent,
+            inputs=payload,
+            mode=payload.get("execution_mode"),
+            intensity=payload.get("intensity"),
+        )
+        result = precomputed_result if precomputed_result is not None else await executor() if executor else {}
+        status = "success" if result.get("status") != "error" else "failed"
+        return self._build_hub_envelope(
+            request=request,
+            result_payload={"status": status, "result": result},
+            run_id=str(uuid4()),
+        )
+
+    async def generate_muse(
+        self,
+        *,
+        workspace_id: str,
+        task: str,
+        content_type: str,
+        tone: str,
+        target_audience: str,
+        context: Dict[str, Any],
+        max_tokens: int,
+        temperature: float,
+        reasoning_depth: Literal["low", "medium", "high"],
+        intensity: Optional[Literal["low", "medium", "high"]],
+        execution_mode: Optional[Literal["single", "council", "swarm"]],
+    ) -> Dict[str, Any]:
+        request = self.to_task_request(
+            workspace_id=workspace_id,
+            intent="muse.generate",
+            inputs={
+                "task": task,
+                "tone": tone,
+                "target_audience": target_audience,
+                "context": context,
+                "reasoning_depth": reasoning_depth,
+            },
+            mode=execution_mode,
+            intensity=intensity,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            content_type=content_type,
+        )
+        muse_result = await muse_service.generate(
+            workspace_id=workspace_id,
+            task=task,
+            content_type=content_type,
+            tone=tone,
+            target_audience=target_audience,
+            context=context,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            reasoning_depth=reasoning_depth,
+            intensity=intensity,
+            execution_mode=execution_mode,
+        )
+        envelope = self._build_hub_envelope(
+            request=request,
+            result_payload={
+                "status": "success" if muse_result.get("success") else "failed",
+                "result": muse_result,
+            },
+            run_id=str(uuid4()),
+        )
+        return {
+            **muse_result,
+            "hub": envelope.to_dict(),
+        }
+
+    async def list_campaigns(self, workspace_id: str) -> List[Dict[str, Any]]:
+        return await campaign_moves_gateway.list_campaigns(workspace_id)
+
+    async def create_campaign(self, workspace_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await campaign_moves_gateway.create_campaign(workspace_id, payload)
+
+    async def get_campaign(self, workspace_id: str, campaign_id: str) -> Optional[Dict[str, Any]]:
+        return await campaign_moves_gateway.get_campaign(workspace_id, campaign_id)
+
+    async def campaign_moves_bundle(self, workspace_id: str, campaign_id: str) -> Dict[str, Any]:
+        return await campaign_moves_gateway.campaign_moves_bundle(workspace_id, campaign_id)
+
+    async def update_campaign(
+        self,
+        workspace_id: str,
+        campaign_id: str,
+        payload: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        return await campaign_moves_gateway.update_campaign(workspace_id, campaign_id, payload)
+
+    async def delete_campaign(self, workspace_id: str, campaign_id: str) -> bool:
+        return await campaign_moves_gateway.delete_campaign(workspace_id, campaign_id)
+
+    async def list_moves(self, workspace_id: str) -> List[Dict[str, Any]]:
+        return await campaign_moves_gateway.list_moves(workspace_id)
+
+    async def create_move(self, workspace_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await campaign_moves_gateway.create_move(workspace_id, payload)
+
+    async def update_move(
+        self,
+        workspace_id: str,
+        move_id: str,
+        payload: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        return await campaign_moves_gateway.update_move(workspace_id, move_id, payload)
+
+    async def delete_move(self, workspace_id: str, move_id: str) -> bool:
+        return await campaign_moves_gateway.delete_move(workspace_id, move_id)
+
+
+terminal_adapter = TerminalAdapter()

--- a/backend/api/v1/campaigns/routes.py
+++ b/backend/api/v1/campaigns/routes.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from fastapi import APIRouter, Header, HTTPException, Depends, status
 from pydantic import BaseModel, Field
 
-from backend.agents import langgraph_campaign_moves_orchestrator
+from backend.ai.application.terminal_adapter import terminal_adapter
 from backend.api.v1.workspace_guard import (
     enforce_bcm_ready,
     require_workspace_id,
@@ -98,7 +98,7 @@ async def list_campaigns(
     enforce_bcm_ready(workspace_id)
 
     try:
-        campaigns_data = await langgraph_campaign_moves_orchestrator.list_campaigns(
+        campaigns_data = await terminal_adapter.list_campaigns(
             workspace_id
         )
         campaigns = [CampaignOut(**row) for row in campaigns_data]
@@ -123,7 +123,7 @@ async def create_campaign(
     }
 
     try:
-        result = await langgraph_campaign_moves_orchestrator.create_campaign(
+        result = await terminal_adapter.create_campaign(
             workspace_id, insert_row
         )
         return CampaignOut(**result)
@@ -143,7 +143,7 @@ async def get_campaign(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid campaign_id")
 
-    result = await langgraph_campaign_moves_orchestrator.get_campaign(
+    result = await terminal_adapter.get_campaign(
         workspace_id, campaign_id
     )
     if not result:
@@ -164,7 +164,7 @@ async def get_campaign_moves_bundle(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid campaign_id")
 
-    bundle = await langgraph_campaign_moves_orchestrator.campaign_moves_bundle(
+    bundle = await terminal_adapter.campaign_moves_bundle(
         workspace_id,
         campaign_id,
     )
@@ -202,7 +202,7 @@ async def update_campaign(
     if not update_row:
         raise HTTPException(status_code=400, detail="No fields to update")
 
-    result = await langgraph_campaign_moves_orchestrator.update_campaign(
+    result = await terminal_adapter.update_campaign(
         workspace_id,
         campaign_id,
         update_row,
@@ -225,7 +225,7 @@ async def delete_campaign(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid campaign_id")
 
-    deleted = await langgraph_campaign_moves_orchestrator.delete_campaign(
+    deleted = await terminal_adapter.delete_campaign(
         workspace_id,
         campaign_id,
     )

--- a/backend/api/v1/moves/routes.py
+++ b/backend/api/v1/moves/routes.py
@@ -14,7 +14,7 @@ from uuid import UUID
 from fastapi import APIRouter, Header, HTTPException, Depends, status
 from pydantic import BaseModel, Field
 
-from backend.agents import langgraph_campaign_moves_orchestrator
+from backend.ai.application.terminal_adapter import terminal_adapter
 from backend.api.v1.workspace_guard import (
     enforce_bcm_ready,
     require_workspace_id,
@@ -58,7 +58,7 @@ async def list_moves(
     enforce_bcm_ready(workspace_id)
 
     try:
-        moves_data = await langgraph_campaign_moves_orchestrator.list_moves(
+        moves_data = await terminal_adapter.list_moves(
             workspace_id
         )
         # Validate/Convert to Pydantic models to ensure schema compliance
@@ -85,7 +85,7 @@ async def create_move(
     enforce_bcm_ready(workspace_id)
 
     try:
-        result = await langgraph_campaign_moves_orchestrator.create_move(
+        result = await terminal_adapter.create_move(
             workspace_id,
             move.model_dump(),
         )
@@ -126,7 +126,7 @@ async def update_move(
         raise HTTPException(status_code=400, detail="Invalid move_id")
 
     try:
-        result = await langgraph_campaign_moves_orchestrator.update_move(
+        result = await terminal_adapter.update_move(
             workspace_id, move_id, patch.model_dump(exclude_unset=True)
         )
         if not result:
@@ -149,7 +149,7 @@ async def delete_move(
         raise HTTPException(status_code=400, detail="Invalid move_id")
 
     try:
-        deleted = await langgraph_campaign_moves_orchestrator.delete_move(
+        deleted = await terminal_adapter.delete_move(
             workspace_id, move_id
         )
         if not deleted:

--- a/backend/api/v1/muse/routes.py
+++ b/backend/api/v1/muse/routes.py
@@ -16,6 +16,7 @@ from backend.api.v1.workspace_guard import (
     enforce_bcm_ready,
     require_workspace_id,
 )
+from backend.ai.application.terminal_adapter import terminal_adapter
 from backend.services.muse_service import muse_service
 from backend.services.exceptions import ServiceError, ServiceUnavailableError
 from backend.api.dependencies.auth import get_current_user
@@ -69,7 +70,7 @@ async def generate(
     enforce_bcm_ready(workspace_id)
 
     try:
-        result = await muse_service.generate(
+        result = await terminal_adapter.generate_muse(
             workspace_id=workspace_id,
             task=payload.task,
             content_type=payload.content_type,
@@ -88,7 +89,7 @@ async def generate(
             content=result.get("content", ""),
             tokens_used=result.get("tokens_used", 0),
             cost_usd=result.get("cost_usd", 0.0),
-            metadata=result.get("metadata", {}),
+            metadata={**result.get("metadata", {}), "hub": result.get("hub", {})},
         )
     except ServiceUnavailableError as e:
         raise HTTPException(

--- a/backend/api/v1/scraper/routes.py
+++ b/backend/api/v1/scraper/routes.py
@@ -27,7 +27,8 @@ from fastapi.responses import JSONResponse
 from PIL import Image
 from playwright.async_api import async_playwright
 
-from backend.agents import langgraph_optional_orchestrator
+from backend.ai.application.terminal_adapter import terminal_adapter
+from backend.agents.compat import optional_gateway
 from backend.agents.runtime.profiles import (
     intensity_profile,
     normalize_execution_mode,
@@ -561,17 +562,18 @@ async def scrape_endpoint(request: Dict[str, Any], background_tasks: BackgroundT
 
     # Perform scraping through LangGraph optional-module boundary
     try:
-        result = await langgraph_optional_orchestrator.run(
+        payload = {
+            "url": url,
+            "user_id": user_id,
+            "strategy": strategy.value,
+            "legal_basis": legal_basis,
+            "intensity": runtime_intensity,
+            "execution_mode": runtime_execution_mode,
+            "enable_cache": enable_cache,
+        }
+        result = await optional_gateway.run(
             operation="scraper",
-            payload={
-                "url": url,
-                "user_id": user_id,
-                "strategy": strategy.value,
-                "legal_basis": legal_basis,
-                "intensity": runtime_intensity,
-                "execution_mode": runtime_execution_mode,
-                "enable_cache": enable_cache,
-            },
+            payload=payload,
             executor=lambda: unified_scraper.scrape(
                 url,
                 user_id,
@@ -580,9 +582,16 @@ async def scrape_endpoint(request: Dict[str, Any], background_tasks: BackgroundT
                 enable_cache=enable_cache,
             ),
         )
+        hub = await terminal_adapter.run_optional_module(
+            workspace_id="system",
+            intent="scraper.fetch",
+            payload=payload,
+            precomputed_result=result,
+        )
     except ServiceUnavailableError as e:
         raise HTTPException(status_code=503, detail=str(e))
 
+    result["hub"] = hub.to_dict()
     result["intensity"] = runtime_intensity
     result["execution_mode"] = runtime_execution_mode
     result["scraper_profile"] = {

--- a/backend/api/v1/search/routes.py
+++ b/backend/api/v1/search/routes.py
@@ -22,7 +22,8 @@ from bs4 import BeautifulSoup
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
-from backend.agents import langgraph_optional_orchestrator
+from backend.ai.application.terminal_adapter import terminal_adapter
+from backend.agents.compat import optional_gateway
 from backend.agents.runtime.profiles import (
     intensity_profile,
     normalize_execution_mode,
@@ -806,20 +807,28 @@ async def search_endpoint(
         raise HTTPException(status_code=400, detail=f"Invalid engines: {invalid}")
 
     try:
-        result = await langgraph_optional_orchestrator.run(
+        payload = {
+            "q": q,
+            "engines": engine_list,
+            "max_results": max_results,
+            "enable_cache": enable_cache,
+            "intensity": runtime_intensity,
+            "execution_mode": runtime_execution_mode,
+        }
+        result = await optional_gateway.run(
             operation="search",
-            payload={
-                "q": q,
-                "engines": engine_list,
-                "max_results": max_results,
-                "enable_cache": enable_cache,
-                "intensity": runtime_intensity,
-                "execution_mode": runtime_execution_mode,
-            },
+            payload=payload,
             executor=lambda: search_engine.search(
                 q, engine_list, max_results, enable_cache
             ),
         )
+        hub = await terminal_adapter.run_optional_module(
+            workspace_id="system",
+            intent="search.query",
+            payload=payload,
+            precomputed_result=result,
+        )
+        result["hub"] = hub.to_dict()
         result["search_profile"] = {
             "intensity": runtime_intensity,
             "execution_mode": runtime_execution_mode,


### PR DESCRIPTION
### Motivation
- Centralize terminal-facing payload mapping to the AI Hub contract (`TaskRequestV1`) so API routes stop importing orchestrators directly and so responses can include `/ai/hub/v1`-style metadata.
- Preserve existing terminal response shapes while surfacing orchestration/run metadata (`run_id`, `status`, `result`, `tool_trace_summary`, `bcm_writes`) to callers for tracing and UI needs.
- Provide a compatibility layer so the migration off `langgraph_*_orchestrator` can be incremental and non-breaking for existing callers.

### Description
- Added a new application service `TerminalAdapter` at `backend/ai/application/terminal_adapter.py` that builds `TaskRequestV1` payloads and creates a hub envelope (`run_id`, `status`, `result`, `tool_trace_summary`, `bcm_writes`) via `HubEnvelope` and exposes façade methods such as `generate_muse`, `run_optional_module`, and campaign/move gateways.
- Exported the adapter from `backend/ai/application/__init__.py` and instantiated `terminal_adapter` for route usage.
- Introduced temporary compatibility gateways in `backend/agents/compat.py` (`campaign_moves_gateway` and `optional_gateway`) that delegate to the existing `langgraph_*_orchestrator` implementations to avoid breaking callers during migration.
- Refactored API routes to use the adapter/gateways instead of direct orchestrator imports: `backend/api/v1/muse/routes.py` now calls `terminal_adapter.generate_muse`, `backend/api/v1/moves/routes.py` and `backend/api/v1/campaigns/routes.py` call `terminal_adapter` CRUD methods, and `backend/api/v1/search/routes.py` and `backend/api/v1/scraper/routes.py` call `optional_gateway.run` and then `terminal_adapter.run_optional_module` to attach `hub` metadata while preserving original response shapes.

### Testing
- Ran Python bytecode compilation checks via `python -m compileall` on the modified modules/files and confirmed they compiled successfully.
- Performed import-level verification by compiling the new `backend/ai/application` package and the touched route modules, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950d9732a48332aaa1e79538b35ada)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured backend services to use a new application adapter layer for improved modularity and consistency.
  * Enhanced API responses with enriched tracing metadata (run IDs, status, tool traces) across muse, scraper, and search endpoints for better observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->