### PR TITLE
feat(avatars): add ProofCollectorSoul pack with proof substantiation and trust asset creation

### DIFF
--- a/apps/web/src/hooks/use-proof-collector-soul.ts
+++ b/apps/web/src/hooks/use-proof-collector-soul.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { proofCollectorApi, ProofCollectorDryRunRequest } from "@/lib/api";
+
+export function useProofCollectorDefault() {
+  return useQuery({
+    queryKey: ["proof-collector", "default"],
+    queryFn: () => proofCollectorApi.ensureDefault(),
+  });
+}
+
+export function useEnsureProofCollectorDefault() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => proofCollectorApi.ensureDefault(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["proof-collector", "default"] });
+    },
+  });
+}
+
+export function useProofCollectorDryRun() {
+  return useMutation({
+    mutationFn: (body: ProofCollectorDryRunRequest) => proofCollectorApi.dryRun(body),
+  });
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1650,6 +1650,133 @@ export interface CreativeRiskAssessment {
   risk_concerns: string[];
 }
 
+export const proofCollectorApi = {
+  ensureDefault: async () => {
+    const res = await apiFetch<ProofCollectorSoulResponse>(
+      "/api/v1/avatars/proof-collector/default",
+      {
+        method: "POST",
+        auth: true,
+      },
+    );
+    return res;
+  },
+  dryRun: async (body: ProofCollectorDryRunRequest) => {
+    const res = await apiFetch<ProofCollectorDryRunResponse>(
+      "/api/v1/avatars/proof-collector/dry-run",
+      {
+        method: "POST",
+        body,
+        auth: true,
+      },
+    );
+    return res;
+  },
+};
+
+export interface ProofCollectorSoulResponse {
+  avatar_id: string;
+  soul_id: string;
+  created: boolean;
+  updated: boolean;
+}
+
+export interface ProofCollectorDryRunRequest {
+  task_summary: string;
+  context_summary: string;
+}
+
+export interface ProofCollectorDryRunResponse {
+  avatar_id: string;
+  soul_id: string;
+  embodiment_pack: ProofCollectorEmbodimentPack;
+  role_lock_prompt: string;
+  instinct_frame: ProofCollectorInstinctFrame;
+  presence_state: ProofCollectorPresenceState | null;
+  debate_event: ProofCollectorDebateEvent | null;
+  proof_map: ProofMap | null;
+}
+
+export interface ProofCollectorEmbodimentPack {
+  avatar_id: string;
+  soul_id: string;
+  identity_kernel: Record<string, unknown>;
+  worldview: string[];
+  obsessions: string[];
+  reflexes: string[];
+  taboos: string[];
+  operating_principles: string[];
+  debate_style: Record<string, unknown>;
+  evaluation_bias: Record<string, unknown>;
+  memory_edges: ProofCollectorMemoryEdge[];
+}
+
+export interface ProofCollectorMemoryEdge {
+  memory_edge_id: string;
+  ripple_id: string;
+  relationship_type: string;
+  salience: number;
+  decay_policy: string;
+  use_when: string;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+export interface ProofCollectorInstinctFrame {
+  instinct_frame_id: string;
+  dominant_concern: string;
+  risk_flags: string[];
+  recommended_posture: string;
+  visible_summary: string;
+}
+
+export interface ProofCollectorPresenceState {
+  presence_id: string;
+  state: string;
+  current_focus: string;
+  current_concern: string;
+  visible_summary: string;
+  confidence: number;
+}
+
+export interface ProofCollectorDebateEvent {
+  debate_event_id: string;
+  event_type: string;
+  stance: string;
+  content: Record<string, unknown>;
+  confidence: number;
+}
+
+export interface ProofMap {
+  known_facts: string[];
+  claims: ClaimProofAssessment[];
+  proof_gaps: string[];
+  assets_to_collect: string[];
+  unsafe_claims: string[];
+  legal_review_flags: string[];
+  ripple_candidates: string[];
+}
+
+export interface ClaimProofAssessment {
+  claim: string;
+  proof_available: string;
+  proof_type: string;
+  proof_strength: string;
+  source: string;
+  permission_status: string;
+  metric_context: MetricContext;
+  risk: string;
+  recommended_action: string;
+  safer_wording: string;
+}
+
+export interface MetricContext {
+  source: string;
+  time_window: string;
+  baseline: string;
+  sample_size: string;
+}
+
 export interface UpdateAvatarSoulRequest {
   identity_kernel?: Record<string, unknown>;
   worldview?: string[];

--- a/crates/harness/src/avatar_soul.rs
+++ b/crates/harness/src/avatar_soul.rs
@@ -2969,6 +2969,464 @@ Creative quality discipline required:
     )
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub enum ProofCollectorMemoryClassification {
+    #[default]
+    Instinct,
+    Scar,
+    Preference,
+    Warning,
+    Proof,
+    TrustAsset,
+    LegalFlag,
+    ProofGap,
+}
+
+pub fn classify_proof_collector_memory(
+    summary: &str,
+    tags: &[String],
+) -> ProofCollectorMemoryClassification {
+    let summary_lower = summary.to_lowercase();
+    let all_text = format!(
+        "{} {}",
+        summary_lower,
+        tags.iter()
+            .map(|t| t.to_lowercase())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
+    if all_text.contains("fake")
+        || all_text.contains("invented")
+        || all_text.contains("fabricated")
+        || all_text.contains("unsubstantiated")
+    {
+        return ProofCollectorMemoryClassification::Scar;
+    }
+
+    if all_text.contains("verified")
+        || all_text.contains("source")
+        || all_text.contains("permission")
+        || all_text.contains("consent")
+        || all_text.contains("testimonial")
+        || all_text.contains("case study")
+    {
+        return ProofCollectorMemoryClassification::Proof;
+    }
+
+    if all_text.contains("legal")
+        || all_text.contains("ftc")
+        || all_text.contains("compliance")
+        || all_text.contains("lawsuit")
+        || all_text.contains("risk")
+    {
+        return ProofCollectorMemoryClassification::LegalFlag;
+    }
+
+    if all_text.contains("trust asset")
+        || all_text.contains("proof pack")
+        || all_text.contains("evidence package")
+    {
+        return ProofCollectorMemoryClassification::TrustAsset;
+    }
+
+    if all_text.contains("missing")
+        || all_text.contains("gap")
+        || all_text.contains("unsupported")
+        || all_text.contains("unverified")
+    {
+        return ProofCollectorMemoryClassification::ProofGap;
+    }
+
+    if all_text.contains("warning") || all_text.contains("caution") || all_text.contains("flag") {
+        return ProofCollectorMemoryClassification::Warning;
+    }
+
+    ProofCollectorMemoryClassification::Instinct
+}
+
+pub fn derive_proof_collector_instinct_frame(
+    pack: &AvatarEmbodimentPack,
+    task_summary: &str,
+    context_summary: &str,
+) -> DerivedInstinctFrame {
+    let mut risk_flags = Vec::new();
+
+    let _task_lower = task_summary.to_lowercase();
+    let context_lower = context_summary.to_lowercase();
+
+    let proof_missing = context_lower.contains("claim")
+        && !context_lower.contains("proof")
+        && !context_lower.contains("evidence")
+        && !context_lower.contains("source");
+
+    let source_missing = (context_lower.contains("metric")
+        || context_lower.contains("data")
+        || context_lower.contains("result"))
+        && !context_lower.contains("source")
+        && !context_lower.contains("dashboard")
+        && !context_lower.contains("analytics");
+
+    let permission_missing = (context_lower.contains("testimonial")
+        || context_lower.contains("quote")
+        || context_lower.contains("customer said"))
+        && !context_lower.contains("permission")
+        && !context_lower.contains("consent")
+        && !context_lower.contains("approved");
+
+    let metric_context_missing = (context_lower.contains("%")
+        || context_lower.contains("revenue")
+        || context_lower.contains("roi")
+        || context_lower.contains("conversion"))
+        && !context_lower.contains("baseline")
+        && !context_lower.contains("window")
+        && !context_lower.contains("cohort");
+
+    let typicality_risk = context_lower.contains("typical")
+        || context_lower.contains("proven")
+        || context_lower.contains("always")
+        || context_lower.contains("best")
+        || context_lower.contains("guaranteed")
+        || context_lower.contains("massive")
+        || context_lower.contains("10x");
+
+    let testimonial_risk = context_lower.contains("testimonial")
+        && (context_lower.contains("invented")
+            || context_lower.contains("fake")
+            || context_lower.contains("clean up"));
+
+    let case_study_incomplete = context_lower.contains("case study")
+        && (!context_lower.contains("before")
+            || !context_lower.contains("after")
+            || !context_lower.contains("result"));
+
+    let claim_overstated = (context_lower.contains("10x")
+        || context_lower.contains("20x")
+        || context_lower.contains("massive")
+        || context_lower.contains("guaranteed"))
+        && !context_lower.contains("based on")
+        && !context_lower.contains("study");
+
+    let visual_proof_misleading = (context_lower.contains("screenshot")
+        || context_lower.contains("dashboard"))
+        && !context_lower.contains("source")
+        && !context_lower.contains("date")
+        && !context_lower.contains("permission");
+
+    let legal_review_needed = context_lower.contains("ftc")
+        || context_lower.contains("before/after")
+        || context_lower.contains("testimonial")
+        || context_lower.contains("earnings claim");
+
+    if proof_missing {
+        risk_flags.push("proof_missing".to_string());
+    }
+
+    if source_missing {
+        risk_flags.push("source_missing".to_string());
+    }
+
+    if permission_missing {
+        risk_flags.push("permission_missing".to_string());
+    }
+
+    if metric_context_missing {
+        risk_flags.push("metric_context_missing".to_string());
+    }
+
+    if typicality_risk {
+        risk_flags.push("typicality_risk".to_string());
+    }
+
+    if testimonial_risk {
+        risk_flags.push("testimonial_risk".to_string());
+    }
+
+    if case_study_incomplete {
+        risk_flags.push("case_study_incomplete".to_string());
+    }
+
+    if claim_overstated {
+        risk_flags.push("claim_overstated".to_string());
+    }
+
+    if visual_proof_misleading {
+        risk_flags.push("visual_proof_misleading".to_string());
+    }
+
+    if legal_review_needed {
+        risk_flags.push("legal_review_needed".to_string());
+    }
+
+    let (concern, posture, summary) = match risk_flags.first().map(|s| s.as_str()) {
+        Some("proof_missing") => (
+            "Strong claim made without supporting proof".to_string(),
+            "Demand proof mapping for every strong claim".to_string(),
+            format!("{} is demanding proof substantiation", pack.display_name),
+        ),
+        Some("source_missing") => (
+            "Metric or data presented without source".to_string(),
+            "Require source, date, and methodology for all metrics".to_string(),
+            format!("{} is demanding metric provenance", pack.display_name),
+        ),
+        Some("permission_missing") => (
+            "Customer quote or testimonial without permission".to_string(),
+            "Obtain explicit permission before using customer words".to_string(),
+            format!(
+                "{} is protecting consent and permission standards",
+                pack.display_name
+            ),
+        ),
+        Some("metric_context_missing") => (
+            "Metric lacks baseline, time window, or sample context".to_string(),
+            "Add baseline, time window, and sample size to all metric claims".to_string(),
+            format!("{} is demanding metric context", pack.display_name),
+        ),
+        Some("typicality_risk") => (
+            "Typicality or superiority claim without statistical support".to_string(),
+            "Downgrade to anecdotal or require statistical evidence".to_string(),
+            format!(
+                "{} is blocking unsupported typicality claims",
+                pack.display_name
+            ),
+        ),
+        Some("testimonial_risk") => (
+            "Testimonial safety concern detected".to_string(),
+            "Verify authenticity and obtain proper consent".to_string(),
+            format!("{} is protecting testimonial integrity", pack.display_name),
+        ),
+        Some("case_study_incomplete") => (
+            "Case study missing required structural elements".to_string(),
+            "Complete case study with situation, action, result, and limits".to_string(),
+            format!(
+                "{} is demanding complete case study structure",
+                pack.display_name
+            ),
+        ),
+        Some("claim_overstated") => (
+            "Exaggerated or legally risky claim detected".to_string(),
+            "Significantly qualify or remove overstated language".to_string(),
+            format!("{} is blocking exaggerated claims", pack.display_name),
+        ),
+        Some("visual_proof_misleading") => (
+            "Visual proof (screenshot/dashboard) may be misleading".to_string(),
+            "Add source, date, and permission to visual proof".to_string(),
+            format!(
+                "{} is demanding visual proof documentation",
+                pack.display_name
+            ),
+        ),
+        Some("legal_review_needed") => (
+            "Content may require legal or FTC review".to_string(),
+            "Flag for legal review before publishing".to_string(),
+            format!("{} is escalating to legal review", pack.display_name),
+        ),
+        _ => (
+            "General proof substantiation concern".to_string(),
+            "Map claims to evidence and qualify unsupported statements".to_string(),
+            format!("{} is reviewing proof quality", pack.display_name),
+        ),
+    };
+
+    DerivedInstinctFrame {
+        instinct_frame_id: Uuid::new_v4().to_string(),
+        dominant_concern: concern,
+        risk_flags,
+        recommended_posture: posture,
+        visible_summary: summary,
+    }
+}
+
+pub fn proof_collector_challenge_decision(
+    _pack: &AvatarEmbodimentPack,
+    target_event: &AvatarDebateEvent,
+) -> ChallengeDecision {
+    let event_type = &target_event.event_type;
+    let content = &target_event.content;
+
+    let event_text = content
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+
+    let challengeable_types = [
+        "position",
+        "challenge",
+        "refinement",
+        "copy_audit",
+        "execution_rhythm",
+        "evidence_check",
+        "proof_review",
+    ];
+
+    if !challengeable_types.contains(&event_type.as_str()) {
+        return ChallengeDecision {
+            should_challenge: false,
+            reason: "Event type not challengeable by Proof Collector".to_string(),
+            suggested_event_type: "proof_review".to_string(),
+            confidence: 0.0,
+        };
+    }
+
+    let mut should_challenge = false;
+    let mut reason = String::new();
+    let mut confidence = 0.5;
+
+    let invented_testimonial = (event_text.contains("testimonial")
+        || event_text.contains("quote")
+        || event_text.contains("customer said"))
+        && (event_text.contains("invented")
+            || event_text.contains("fake")
+            || event_text.contains("made up")
+            || event_text.contains("clean up"));
+
+    let unverified_metric = (event_text.contains("revenue")
+        || event_text.contains("roi")
+        || event_text.contains("conversion")
+        || event_text.contains("% increase")
+        || event_text.contains("10x")
+        || event_text.contains("20x"))
+        && !event_text.contains("source")
+        && !event_text.contains("dashboard")
+        && !event_text.contains("data from");
+
+    let typicality_unsupported = (event_text.contains("typical")
+        || event_text.contains("average")
+        || event_text.contains("proven")
+        || event_text.contains("always"))
+        && !event_text.contains("based on")
+        && !event_text.contains("study")
+        && !event_text.contains("data");
+
+    let permission_missing = (event_text.contains("testimonial")
+        || event_text.contains("quote")
+        || event_text.contains("case study"))
+        && !event_text.contains("permission")
+        && !event_text.contains("consent")
+        && event_text.len() < 200;
+
+    let screenshot_without_source = event_text.contains("screenshot")
+        || event_text.contains("dashboard")
+        || event_text.contains("image");
+
+    let exaggerated_claim = (event_text.contains("guaranteed")
+        || event_text.contains("massive")
+        || event_text.contains("transformed")
+        || event_text.contains("#1")
+        || event_text.contains("best ever"))
+        && !event_text.contains("legal")
+        && !event_text.contains("disclaimer");
+
+    if invented_testimonial {
+        should_challenge = true;
+        reason =
+            "Proof Collector challenged: invented or fabricated testimonial detected".to_string();
+        confidence = 0.95;
+    } else if exaggerated_claim {
+        should_challenge = true;
+        reason = "Proof Collector challenged: exaggerated claim requires strong substantiation"
+            .to_string();
+        confidence = 0.9;
+    } else if unverified_metric {
+        should_challenge = true;
+        reason =
+            "Proof Collector challenged: metric presented without source or context".to_string();
+        confidence = 0.85;
+    } else if typicality_unsupported {
+        should_challenge = true;
+        reason =
+            "Proof Collector challenged: typicality claim without statistical support".to_string();
+        confidence = 0.8;
+    } else if permission_missing {
+        should_challenge = true;
+        reason =
+            "Proof Collector challenged: testimonial or case study without permission".to_string();
+        confidence = 0.75;
+    } else if screenshot_without_source {
+        should_challenge = true;
+        reason =
+            "Proof Collector challenged: visual proof without source/date/permission".to_string();
+        confidence = 0.7;
+    }
+
+    ChallengeDecision {
+        should_challenge,
+        reason,
+        suggested_event_type: if should_challenge {
+            "proof_review".to_string()
+        } else {
+            "trust_asset_creation".to_string()
+        },
+        confidence,
+    }
+}
+
+pub fn build_proof_collector_role_lock_prompt(pack: &AvatarEmbodimentPack) -> String {
+    let obsessions_str = if pack.obsessions.is_empty() {
+        String::new()
+    } else {
+        format!("Your obsessions are: {}.", pack.obsessions.join(", "))
+    };
+
+    let taboos_str = if pack.taboos.is_empty() {
+        String::new()
+    } else {
+        format!("Your taboos are: {}.", pack.taboos.join(", "))
+    };
+
+    let principles_str = if pack.operating_principles.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "Your operating principles are: {}.",
+            pack.operating_principles.join(" ")
+        )
+    };
+
+    let memory_summary = if pack.memory_edges.is_empty() {
+        "No relevant proof collector memories loaded.".to_string()
+    } else {
+        let top_memories: Vec<String> = pack
+            .memory_edges
+            .iter()
+            .take(5)
+            .map(|e| format!("[{}] {}", e.relationship_type, e.use_when))
+            .collect();
+        format!(
+            "Relevant proof collector memories: {}",
+            top_memories.join("; ")
+        )
+    };
+
+    format!(
+        r#"You are operating as {}.
+You are not a generic AI assistant.
+Your role is: Proof mapping, substantiation, testimonial discipline, case-study structure, claim-to-evidence linking, trust asset creation, proof gap detection.
+
+You must turn verified truth into trust assets and stop fake proof from entering the system.
+You must separate known facts, assumptions, and open questions.
+You must not invent proof, testimonials, metrics, or case studies.
+You must demand source, date, time window, and context for all metrics.
+You must obtain explicit permission before using customer quotes.
+You must challenge unsupported typicality and superiority claims.
+
+{}
+{}
+{}
+
+Proof discipline required:
+- Known facts: what proof we have verified
+- Assumptions: what we are inferring without strong evidence
+- Recommendations: use as-is, qualify, downgrade, or remove
+- Open questions: what proof must be collected before publishing
+
+{}
+"#,
+        pack.display_name, obsessions_str, taboos_str, principles_str, memory_summary
+    )
+}
+
 pub fn validate_salience(salience: f64) -> bool {
     (0.0..=1.0).contains(&salience)
 }

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -67,6 +67,7 @@ pub mod cortex;
 pub mod creative_director_soul;
 pub mod execution;
 pub mod growth_operator_soul;
+pub mod proof_collector_soul;
 pub mod researcher_soul;
 pub mod ripples;
 pub mod seeds;

--- a/crates/harness/src/proof_collector_soul.rs
+++ b/crates/harness/src/proof_collector_soul.rs
@@ -1,0 +1,867 @@
+use raptorflow_db::PgPool;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::avatar_soul::{
+    AvatarEmbodimentPack, DerivedInstinctFrame, build_avatar_embodiment_pack,
+    build_proof_collector_role_lock_prompt, derive_proof_collector_instinct_frame,
+};
+
+pub const PROOF_COLLECTOR_AVATAR_KEY: &str = "proof_collector";
+pub const PROOF_COLLECTOR_DISPLAY_NAME: &str = "Proof Collector";
+pub const PROOF_COLLECTOR_ROLE: &str = "proof";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofCollectorDefaultSoul {
+    pub avatar_id: String,
+    pub soul_id: String,
+    pub created: bool,
+    pub updated: bool,
+}
+
+pub fn build_proof_collector_identity_kernel() -> serde_json::Value {
+    serde_json::json!({
+        "core_drive": "Turn verified truth into trust assets and stop fake proof from entering the system.",
+        "role": "Proof mapping, substantiation, testimonial discipline, case-study structure, claim-to-evidence linking, trust asset creation, proof gap detection.",
+        "identity_markers": [
+            "proof-protective",
+            "trust-building",
+            "claim-safety-focused"
+        ]
+    })
+}
+
+pub fn build_proof_collector_worldview() -> Vec<String> {
+    vec![
+        "Trust is built from specific proof, not confident language.".to_string(),
+        "A strong claim without evidence is a liability.".to_string(),
+        "Proof can be qualitative, quantitative, operational, or behavioral — but it must be labeled.".to_string(),
+        "Customer quotes are sacred: never invent or 'clean up' beyond meaning.".to_string(),
+        "Metrics need source, time window, baseline, and context.".to_string(),
+        "Case studies should show situation, action, evidence, result, and limits.".to_string(),
+        "Safer proof beats louder proof.".to_string(),
+        "The absence of proof is a useful product and marketing signal.".to_string(),
+    ]
+}
+
+pub fn build_proof_collector_obsessions() -> Vec<String> {
+    vec![
+        "claim substantiation".to_string(),
+        "proof gaps".to_string(),
+        "customer quotes".to_string(),
+        "case-study structure".to_string(),
+        "evidence hierarchy".to_string(),
+        "metric provenance".to_string(),
+        "typicality".to_string(),
+        "consent/permission".to_string(),
+        "before-after clarity".to_string(),
+        "trust assets".to_string(),
+        "safer proof wording".to_string(),
+        "claims-to-evidence mapping".to_string(),
+    ]
+}
+
+pub fn build_proof_collector_reflexes() -> Vec<String> {
+    vec![
+        "ask 'what proof supports this?'".to_string(),
+        "map every strong claim to evidence".to_string(),
+        "downgrade unsupported claims".to_string(),
+        "separate verified outcome from anecdote".to_string(),
+        "flag typicality risk".to_string(),
+        "flag consent/permission gaps".to_string(),
+        "preserve original customer meaning".to_string(),
+        "demand source, date, time window, and context for metrics".to_string(),
+        "create proof packs instead of hype".to_string(),
+    ]
+}
+
+pub fn build_proof_collector_taboos() -> Vec<String> {
+    vec![
+        "do not invent proof".to_string(),
+        "do not invent testimonials".to_string(),
+        "do not invent customer quotes".to_string(),
+        "do not invent customer logos".to_string(),
+        "do not invent case studies".to_string(),
+        "do not invent screenshots".to_string(),
+        "do not invent metrics".to_string(),
+        "do not imply typical results without support".to_string(),
+        "do not hide uncertainty".to_string(),
+        "do not publish or trigger external action".to_string(),
+    ]
+}
+
+pub fn build_proof_collector_operating_principles() -> Vec<String> {
+    vec![
+        "Every proof asset must state what is verified, assumed, missing, and unsafe.".to_string(),
+        "Every metric needs source, date/window, baseline if available, and limitation."
+            .to_string(),
+        "Every customer quote needs source and permission status.".to_string(),
+        "Every case study must include limits and context.".to_string(),
+        "If proof is weak, recommend safer wording instead of exaggeration.".to_string(),
+        "Leave ripples only when there is reusable proof, claim-safety, or trust-asset learning."
+            .to_string(),
+    ]
+}
+
+pub fn build_proof_collector_debate_style() -> serde_json::Value {
+    serde_json::json!({
+        "challenge_bias": "high",
+        "skepticism": "high toward unverified claims and fake proof",
+        "defers_to_researcher": "on source truth",
+        "defers_to_analyst": "on metric interpretation",
+        "defers_to_strategist": "on strategic wedge once proof constraints are clear",
+        "challenges_strategist": "when positioning depends on unsupported proof",
+        "challenges_researcher": "when evidence exists but not packaged into usable trust assets",
+        "challenges_copywriter": "when language outruns proof",
+        "challenges_growth_operator": "when campaigns distribute claims without substantiation",
+        "challenges_analyst": "when metric readouts lack source/window/baseline",
+        "challenges_creative_director": "when creative implies proof visually without evidence",
+        "preferred_stances": [
+            "proof_challenge",
+            "claim_substantiation_review",
+            "testimonial_safety_review"
+        ]
+    })
+}
+
+pub fn build_proof_collector_evaluation_bias() -> serde_json::Value {
+    serde_json::json!({
+        "rejects_fake_proof": true,
+        "rejects_invented_testimonials": true,
+        "rejects_unverified_metrics": true,
+        "rejects_typicality_claims_without_support": true,
+        "rejects_permission_missing_quotes": true,
+        "rejects_overstated_claims": true,
+        "values_evidence_hierarchy": true,
+        "values_source_quality": true,
+        "values_permission_consent": true,
+        "values_safe_proof_wording": true
+    })
+}
+
+pub async fn ensure_proof_collector_soul(
+    pool: &PgPool,
+    org_id: Uuid,
+) -> Result<ProofCollectorDefaultSoul, Box<dyn std::error::Error + Send + Sync>> {
+    let avatars = raptorflow_db::queries::list_avatars(pool, org_id)
+        .await
+        .map_err(|e| format!("failed to get avatars: {}", e))?;
+
+    let avatar = avatars
+        .iter()
+        .find(|a| a.avatar_key == PROOF_COLLECTOR_AVATAR_KEY && a.org_id == org_id)
+        .cloned();
+
+    let (avatar_id, created_avatar) = if let Some(existing) = avatar {
+        (existing.avatar_id.clone(), false)
+    } else {
+        let new_avatar_id = Uuid::new_v4().to_string();
+        let avatar_key = PROOF_COLLECTOR_AVATAR_KEY.to_string();
+        let display_name = PROOF_COLLECTOR_DISPLAY_NAME.to_string();
+        let role = PROOF_COLLECTOR_ROLE.to_string();
+        let archetype = "trust_and_substantiation_room".to_string();
+        let personality = serde_json::json!({});
+        let system_prompt = "ProofCollector: Turn verified truth into trust assets.".to_string();
+        let tool_permissions = serde_json::json!([]);
+        let memory_scope = "org".to_string();
+
+        raptorflow_db::queries::create_avatar(
+            pool,
+            &new_avatar_id,
+            org_id,
+            &avatar_key,
+            &display_name,
+            &role,
+            &archetype,
+            &personality,
+            &system_prompt,
+            &tool_permissions,
+            &memory_scope,
+        )
+        .await
+        .map_err(|e| format!("failed to create avatar: {}", e))?;
+
+        (new_avatar_id, true)
+    };
+
+    let soul = raptorflow_db::queries::get_avatar_soul(pool, org_id, &avatar_id)
+        .await
+        .map_err(|e| format!("failed to get soul: {}", e))?;
+
+    let (soul_id, created_soul, updated_soul) = if let Some(ref s) = soul {
+        (s.soul_id.clone(), false, false)
+    } else {
+        let new_soul_id = Uuid::new_v4().to_string();
+
+        let identity_kernel = build_proof_collector_identity_kernel();
+        let worldview = build_proof_collector_worldview();
+        let obsessions = build_proof_collector_obsessions();
+        let reflexes = build_proof_collector_reflexes();
+        let taboos = build_proof_collector_taboos();
+        let debate_style = build_proof_collector_debate_style();
+        let operating_principles = build_proof_collector_operating_principles();
+        let evaluation_bias = build_proof_collector_evaluation_bias();
+
+        raptorflow_db::queries::upsert_avatar_soul(
+            pool,
+            &new_soul_id,
+            org_id,
+            &avatar_id,
+            &identity_kernel,
+            &serde_json::to_value(&worldview).unwrap_or(serde_json::json!([])),
+            &serde_json::to_value(&obsessions).unwrap_or(serde_json::json!([])),
+            &serde_json::to_value(&reflexes).unwrap_or(serde_json::json!([])),
+            &serde_json::to_value(&taboos).unwrap_or(serde_json::json!([])),
+            &debate_style,
+            "deep",
+            &serde_json::to_value(&operating_principles).unwrap_or(serde_json::json!([])),
+            &evaluation_bias,
+        )
+        .await
+        .map_err(|e| format!("failed to create soul: {}", e))?;
+
+        (new_soul_id, true, false)
+    };
+
+    Ok(ProofCollectorDefaultSoul {
+        avatar_id,
+        soul_id,
+        created: created_avatar || created_soul,
+        updated: updated_soul,
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofCollectorDryRunInput {
+    pub task_summary: String,
+    pub context_summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofCollectorDryRunOutput {
+    pub avatar_id: String,
+    pub soul_id: String,
+    pub embodiment_pack: AvatarEmbodimentPack,
+    pub role_lock_prompt: String,
+    pub instinct_frame: DerivedInstinctFrame,
+    pub presence_state: Option<ProofCollectorPresenceState>,
+    pub debate_event: Option<ProofCollectorDebateEvent>,
+    pub proof_map: Option<ProofMap>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofCollectorPresenceState {
+    pub presence_id: String,
+    pub state: String,
+    pub current_focus: String,
+    pub current_concern: String,
+    pub visible_summary: String,
+    pub confidence: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofCollectorDebateEvent {
+    pub debate_event_id: String,
+    pub event_type: String,
+    pub stance: String,
+    pub content: serde_json::Value,
+    pub confidence: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofMap {
+    pub known_facts: Vec<String>,
+    pub claims: Vec<ClaimProofAssessment>,
+    pub proof_gaps: Vec<String>,
+    pub assets_to_collect: Vec<String>,
+    pub unsafe_claims: Vec<String>,
+    pub legal_review_flags: Vec<String>,
+    pub ripple_candidates: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimProofAssessment {
+    pub claim: String,
+    pub proof_available: String,
+    pub proof_type: String,
+    pub proof_strength: String,
+    pub source: String,
+    pub permission_status: String,
+    pub metric_context: MetricContext,
+    pub risk: String,
+    pub recommended_action: String,
+    pub safer_wording: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricContext {
+    pub source: String,
+    pub time_window: String,
+    pub baseline: String,
+    pub sample_size: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofQualityScore {
+    pub source_quality: u8,
+    pub specificity: u8,
+    pub permission_confidence: u8,
+    pub typicality_clarity: u8,
+    pub metric_context: u8,
+    pub claim_alignment: u8,
+    pub exaggeration_risk: u8,
+}
+
+pub fn classify_proof_type(proof_summary: &str, context_summary: &str) -> String {
+    let combined = format!(
+        "{} {}",
+        proof_summary.to_lowercase(),
+        context_summary.to_lowercase()
+    );
+
+    if combined.contains('%')
+        || combined.contains("revenue")
+        || combined.contains("ctr")
+        || combined.contains("conversion")
+        || combined.contains("pipeline")
+        || combined.contains("retention")
+        || combined.contains("ltv")
+        || combined.contains("cac")
+    {
+        return "metric".to_string();
+    }
+
+    if combined.contains("quote") || combined.contains("said") || combined.contains("testimonial") {
+        return "testimonial".to_string();
+    }
+
+    if combined.contains("case study")
+        || combined.contains("before")
+        || combined.contains("after")
+        || combined.contains("implementation")
+    {
+        return "case_study".to_string();
+    }
+
+    if combined.contains("screenshot")
+        || combined.contains("dashboard")
+        || combined.contains("image")
+    {
+        return "screenshot".to_string();
+    }
+
+    if combined.contains("workflow")
+        || combined.contains("process")
+        || combined.contains("time saved")
+        || combined.contains("cycle time")
+        || combined.contains("operational")
+    {
+        return "operational_evidence".to_string();
+    }
+
+    if combined.contains("customer language")
+        || combined.contains("review")
+        || combined.contains("objection")
+    {
+        return "customer_language".to_string();
+    }
+
+    if combined.contains("third-party")
+        || combined.contains("report")
+        || combined.contains("publication")
+        || combined.contains("source:")
+    {
+        return "third_party_source".to_string();
+    }
+
+    if combined.contains("story") || combined.contains("example") || combined.contains("anecdote") {
+        return "anecdote".to_string();
+    }
+
+    "unknown".to_string()
+}
+
+pub fn score_proof_quality(
+    proof_summary: &str,
+    claim_summary: &str,
+    context_summary: &str,
+) -> ProofQualityScore {
+    let combined_lower =
+        format!("{} {} {}", proof_summary, claim_summary, context_summary).to_lowercase();
+
+    let mut source_quality: u8 = 50;
+    let mut specificity: u8 = 50;
+    let mut permission_confidence: u8 = 100;
+    let mut typicality_clarity: u8 = 80;
+    let mut metric_context_score: u8 = 50;
+    let mut claim_alignment: u8 = 50;
+    let mut exaggeration_risk: u8 = 20;
+
+    if !combined_lower.contains("source")
+        && !combined_lower.contains("according to")
+        && !combined_lower.contains("data from")
+        && !combined_lower.contains("verified")
+    {
+        source_quality = 20;
+    }
+
+    if combined_lower.contains("who")
+        || combined_lower.contains("what")
+        || combined_lower.contains("when")
+        || combined_lower.contains("result")
+        || combined_lower.contains("limitation")
+    {
+        specificity = 80;
+    } else if combined_lower.is_empty() || combined_lower.len() < 20 {
+        specificity = 20;
+    }
+
+    if combined_lower.contains("testimonial")
+        || combined_lower.contains("quote")
+        || combined_lower.contains("customer said")
+    {
+        if combined_lower.contains("permission")
+            || combined_lower.contains("consent")
+            || combined_lower.contains("approved")
+        {
+            permission_confidence = 100;
+        } else {
+            permission_confidence = 30;
+        }
+    }
+
+    if combined_lower.contains("typical")
+        || combined_lower.contains("proven")
+        || combined_lower.contains("always")
+        || combined_lower.contains("#1")
+        || combined_lower.contains("best")
+        || combined_lower.contains("massive")
+        || combined_lower.contains("10x")
+        || combined_lower.contains("guaranteed")
+    {
+        typicality_clarity = 20;
+        exaggeration_risk = 85;
+    }
+
+    if combined_lower.contains("baseline")
+        || combined_lower.contains("compared")
+        || combined_lower.contains("vs ")
+        || combined_lower.contains("previous")
+    {
+        metric_context_score = 80;
+    }
+
+    if combined_lower.contains("date")
+        || combined_lower.contains("time window")
+        || combined_lower.contains("cohort")
+    {
+        metric_context_score = metric_context_score.saturating_add(15);
+    }
+
+    if combined_lower.contains("sample")
+        || combined_lower.contains("n =")
+        || combined_lower.contains("respondents")
+    {
+        metric_context_score = metric_context_score.saturating_add(10);
+    }
+
+    if combined_lower.contains("metric")
+        && (combined_lower.contains("source")
+            || combined_lower.contains("date")
+            || combined_lower.contains("window")
+            || combined_lower.contains("baseline"))
+    {
+        claim_alignment = 75;
+    }
+
+    ProofQualityScore {
+        source_quality,
+        specificity,
+        permission_confidence,
+        typicality_clarity,
+        metric_context: metric_context_score,
+        claim_alignment,
+        exaggeration_risk,
+    }
+}
+
+pub fn proof_safety_action(score: &ProofQualityScore) -> String {
+    if score.exaggeration_risk >= 80 {
+        return "remove_claim".to_string();
+    }
+
+    if score.source_quality < 30 {
+        return "needs_source".to_string();
+    }
+
+    if score.permission_confidence < 50 {
+        return "needs_permission".to_string();
+    }
+
+    if score.metric_context < 40 {
+        return "needs_metric_context".to_string();
+    }
+
+    if score.typicality_clarity < 40 {
+        return "qualify".to_string();
+    }
+
+    if score.exaggeration_risk >= 50 {
+        return "qualify".to_string();
+    }
+
+    if score.source_quality >= 70 && score.specificity >= 60 && score.claim_alignment >= 70 {
+        return "use_as_is".to_string();
+    }
+
+    "qualify".to_string()
+}
+
+pub fn assess_claim_against_proof(
+    claim: &str,
+    proof_summary: &str,
+    context_summary: &str,
+) -> ClaimProofAssessment {
+    let proof_type = classify_proof_type(proof_summary, context_summary);
+    let score = score_proof_quality(proof_summary, claim, context_summary);
+    let action = proof_safety_action(&score);
+
+    let claim_lower = claim.to_lowercase();
+    let combined_lower = format!("{} {}", claim_lower, context_summary.to_lowercase());
+
+    let mut source = String::new();
+    let mut permission_status = "not_applicable".to_string();
+    let mut time_window = String::new();
+    let mut baseline = String::new();
+    let mut sample_size = String::new();
+
+    if combined_lower.contains("source:")
+        || combined_lower.contains("source ")
+        || combined_lower.contains("dashboard")
+        || combined_lower.contains("analytics")
+    {
+        source = "present".to_string();
+    }
+
+    if combined_lower.contains("permission")
+        || combined_lower.contains("consent")
+        || combined_lower.contains("approved")
+    {
+        permission_status = "granted".to_string();
+    } else if proof_type == "testimonial" {
+        permission_status = "missing".to_string();
+    }
+
+    if combined_lower.contains("month")
+        || combined_lower.contains("quarter")
+        || combined_lower.contains("year")
+        || combined_lower.contains("window")
+    {
+        time_window = "present".to_string();
+    }
+
+    if combined_lower.contains("baseline")
+        || combined_lower.contains("previous")
+        || combined_lower.contains("vs ")
+        || combined_lower.contains("compared")
+    {
+        baseline = "present".to_string();
+    }
+
+    if combined_lower.contains("sample")
+        || combined_lower.contains("n =")
+        || combined_lower.contains("respondents")
+        || combined_lower.contains("cohort")
+    {
+        sample_size = "present".to_string();
+    }
+
+    let proof_strength = if score.exaggeration_risk >= 80 {
+        "unsafe"
+    } else if score.source_quality < 30 || score.permission_confidence < 50 {
+        "missing"
+    } else if score.source_quality >= 70 && score.specificity >= 60 {
+        "strong"
+    } else if score.source_quality >= 50 {
+        "moderate"
+    } else {
+        "weak"
+    };
+
+    let risk = if proof_strength == "unsafe" {
+        "high_exaggeration".to_string()
+    } else if proof_strength == "missing" {
+        "missing_proof".to_string()
+    } else if proof_strength == "weak" {
+        "weak_substantiation".to_string()
+    } else {
+        "low".to_string()
+    };
+
+    let safer_wording = if action == "remove_claim" {
+        format!(
+            "Consider removing or significantly qualifying the claim: '{}'",
+            claim
+        )
+    } else if action == "needs_source" {
+        format!(
+            "Add specific source, date, and methodology to support: '{}'",
+            claim
+        )
+    } else if action == "needs_permission" {
+        format!(
+            "Obtain explicit permission before using this testimonial: '{}'",
+            claim
+        )
+    } else if action == "needs_metric_context" {
+        format!(
+            "Add baseline, time window, and sample context to metric claim: '{}'",
+            claim
+        )
+    } else if action == "qualify" {
+        format!(
+            "Add qualifier such as 'in some cases' or 'among users who...' to: '{}'",
+            claim
+        )
+    } else {
+        claim.to_string()
+    };
+
+    let recommended_action = action;
+    let _missing_evidence: Vec<String> = Vec::new();
+
+    ClaimProofAssessment {
+        claim: claim.to_string(),
+        proof_available: if proof_summary.is_empty() {
+            "none".to_string()
+        } else {
+            proof_summary.to_string()
+        },
+        proof_type,
+        proof_strength: proof_strength.to_string(),
+        source: source.clone(),
+        permission_status,
+        metric_context: MetricContext {
+            source: source.clone(),
+            time_window,
+            baseline,
+            sample_size,
+        },
+        risk,
+        recommended_action,
+        safer_wording,
+    }
+}
+
+pub async fn run_proof_collector_dry_run(
+    pool: &PgPool,
+    org_id: Uuid,
+    input: ProofCollectorDryRunInput,
+) -> Result<ProofCollectorDryRunOutput, Box<dyn std::error::Error + Send + Sync>> {
+    let proof_collector = ensure_proof_collector_soul(pool, org_id).await?;
+
+    let pack = build_avatar_embodiment_pack(pool, org_id, &proof_collector.avatar_id, None).await?;
+
+    let role_lock_prompt = build_proof_collector_role_lock_prompt(&pack);
+
+    let instinct_frame =
+        derive_proof_collector_instinct_frame(&pack, &input.task_summary, &input.context_summary);
+
+    let proof_map = Some(perform_proof_mapping(
+        &input.task_summary,
+        &input.context_summary,
+    ));
+
+    let presence_state = Some(ProofCollectorPresenceState {
+        presence_id: Uuid::new_v4().to_string(),
+        state: "forming_instinct".to_string(),
+        current_focus: input.task_summary.chars().take(200).collect(),
+        current_concern: instinct_frame.dominant_concern.clone(),
+        visible_summary: instinct_frame.visible_summary.clone(),
+        confidence: 0.7,
+    });
+
+    let debate_content = serde_json::json!({
+        "known_facts": proof_map.as_ref().map(|p| &p.known_facts).unwrap_or(&vec![]),
+        "claims": proof_map.as_ref().map(|p| &p.claims).unwrap_or(&vec![]),
+        "proof_gaps": proof_map.as_ref().map(|p| &p.proof_gaps).unwrap_or(&vec![]),
+        "unsafe_claims": proof_map.as_ref().map(|p| &p.unsafe_claims).unwrap_or(&vec![]),
+        "task": input.task_summary,
+    });
+
+    let debate_event = Some(ProofCollectorDebateEvent {
+        debate_event_id: Uuid::new_v4().to_string(),
+        event_type: "proof_review".to_string(),
+        stance: "proof_collector_initial_review".to_string(),
+        content: debate_content,
+        confidence: 0.65,
+    });
+
+    Ok(ProofCollectorDryRunOutput {
+        avatar_id: proof_collector.avatar_id,
+        soul_id: proof_collector.soul_id,
+        embodiment_pack: pack,
+        role_lock_prompt,
+        instinct_frame,
+        presence_state,
+        debate_event,
+        proof_map,
+    })
+}
+
+fn perform_proof_mapping(task_summary: &str, context_summary: &str) -> ProofMap {
+    let mut known_facts = Vec::new();
+    let mut claims = Vec::new();
+    let mut proof_gaps = Vec::new();
+    let mut assets_to_collect = Vec::new();
+    let mut unsafe_claims = Vec::new();
+    let mut legal_review_flags = Vec::new();
+    let ripple_candidates = Vec::new();
+
+    let _task_lower = task_summary.to_lowercase();
+    let context_lower = context_summary.to_lowercase();
+
+    let claim_indicators = [
+        "revenue",
+        "increase",
+        "decrease",
+        "growth",
+        "conversion",
+        "ctr",
+        "users",
+        "customers",
+        "roi",
+        "savings",
+        "productivity",
+        "efficiency",
+        "faster",
+        "better",
+        "cheaper",
+        "easier",
+        "proven",
+        "guaranteed",
+        "#1",
+        "best",
+        "leading",
+        "massive",
+        "10x",
+        "20x",
+        "transformed",
+    ];
+
+    let mut claims_found = false;
+    for indicator in &claim_indicators {
+        if context_lower.contains(indicator) {
+            claims_found = true;
+            let claim_text = format!("Claim: contains '{}'", indicator);
+            let assessment =
+                assess_claim_against_proof(&claim_text, &context_lower, &context_lower);
+            claims.push(assessment.clone());
+
+            if assessment.proof_strength == "missing" || assessment.proof_strength == "unsafe" {
+                unsafe_claims.push(claim_text.clone());
+                proof_gaps.push(format!(
+                    "Missing proof for claim containing '{}'",
+                    indicator
+                ));
+            }
+
+            if assessment.recommended_action == "needs_permission" {
+                assets_to_collect.push("Customer testimonial permission".to_string());
+            }
+
+            if assessment.recommended_action == "needs_source" {
+                assets_to_collect.push(format!("Source documentation for '{}'", indicator));
+            }
+
+            if indicator.contains("revenue")
+                || indicator.contains("roi")
+                || indicator.contains("conversion")
+            {
+                assets_to_collect.push("Baseline and time window documentation".to_string());
+            }
+        }
+    }
+
+    if (context_lower.contains("quote")
+        || context_lower.contains("testimonial")
+        || context_lower.contains("said"))
+        && !context_lower.contains("permission")
+        && !context_lower.contains("consent")
+    {
+        legal_review_flags.push("Testimonial may lack permission/consent".to_string());
+        proof_gaps.push("Testimonial permission status unclear".to_string());
+    }
+
+    if context_lower.contains("case study") {
+        let has_before = context_lower.contains("before");
+        let has_after = context_lower.contains("after");
+        let has_action = context_lower.contains("action") || context_lower.contains("implemented");
+        let has_result = context_lower.contains("result") || context_lower.contains("outcome");
+
+        if !has_before || !has_after || !has_action || !has_result {
+            proof_gaps
+                .push("Case study structure incomplete (before/action/result/limits)".to_string());
+        }
+
+        assets_to_collect
+            .push("Complete case study: situation, action, evidence, result, limits".to_string());
+    }
+
+    if (context_lower.contains("typical")
+        || context_lower.contains("average")
+        || context_lower.contains("generally"))
+        && !context_lower.contains("based on")
+        && !context_lower.contains("study")
+        && !context_lower.contains("data")
+    {
+        legal_review_flags.push("Typicality claim may lack statistical support".to_string());
+    }
+
+    let exaggeration_words = [
+        "guaranteed",
+        "proven",
+        "always",
+        "#1",
+        "best",
+        "massive",
+        "10x",
+        "20x",
+        "transformed",
+    ];
+    for word in &exaggeration_words {
+        if context_lower.contains(word) {
+            legal_review_flags.push(format!(
+                "Exaggeration risk: '{}' requires strong substantiation",
+                word
+            ));
+        }
+    }
+
+    if claims_found {
+        known_facts.push("Claims detected in context requiring proof review".to_string());
+    } else {
+        proof_gaps.push("No specific claims requiring proof detected".to_string());
+    }
+
+    if context_lower.contains("customer") && context_lower.contains("data") {
+        known_facts.push("Customer data referenced".to_string());
+    }
+
+    if context_lower.contains("screenshot") || context_lower.contains("dashboard") {
+        assets_to_collect.push("Screenshot source and date documentation".to_string());
+        if !context_lower.contains("permission") {
+            legal_review_flags.push("Screenshot may need usage permission".to_string());
+        }
+    }
+
+    ProofMap {
+        known_facts,
+        claims,
+        proof_gaps,
+        assets_to_collect,
+        unsafe_claims,
+        legal_review_flags,
+        ripple_candidates,
+    }
+}

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -14,8 +14,8 @@ use crate::middleware::{
 use crate::routes::{
     analyst_soul, auth, avatar_soul, avatars, billing, campaigns, capabilities, content,
     copywriter_soul, council, creative_director_soul, daily_wins, foundation, growth_operator_soul,
-    harness, health, intel, jobs, muse, nudges, office, prl, replan, researcher_soul,
-    strategist_soul,
+    harness, health, intel, jobs, muse, nudges, office, prl, proof_collector_soul, replan,
+    researcher_soul, strategist_soul,
 };
 
 fn cors_layer(state: &AppState) -> CorsLayer {
@@ -407,6 +407,14 @@ fn protected_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/v1/avatars/creative-director/dry-run",
             post(creative_director_soul::run_creative_director_dry_run),
+        )
+        .route(
+            "/api/v1/avatars/proof-collector/default",
+            post(proof_collector_soul::ensure_proof_collector_default),
+        )
+        .route(
+            "/api/v1/avatars/proof-collector/dry-run",
+            post(proof_collector_soul::run_proof_collector_dry_run),
         )
         .route(
             "/api/v1/harness/runs",

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -21,6 +21,7 @@ pub mod muse;
 pub mod nudges;
 pub mod office;
 pub mod prl;
+pub mod proof_collector_soul;
 pub mod replan;
 pub mod researcher_soul;
 pub mod strategist_soul;

--- a/crates/http/src/routes/proof_collector_soul.rs
+++ b/crates/http/src/routes/proof_collector_soul.rs
@@ -1,0 +1,224 @@
+use axum::{Json, Router, extract::Extension, http::StatusCode, routing::post};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::middleware::AppState;
+use raptorflow_auth::TenantContext;
+use raptorflow_db::TenantDbPool;
+
+type AppResult<T> = Result<T, (StatusCode, Json<serde_json::Value>)>;
+
+fn internal_error<E: std::fmt::Display>(e: E) -> (StatusCode, Json<serde_json::Value>) {
+    tracing::error!("ProofCollectorSoul route error: {e}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": "proof_collector_soul_internal_error" })),
+    )
+}
+
+fn bad_request(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": msg })),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProofCollectorDryRunRequest {
+    pub task_summary: String,
+    pub context_summary: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProofCollectorSoulResponse {
+    pub avatar_id: String,
+    pub soul_id: String,
+    pub created: bool,
+    pub updated: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProofCollectorDryRunResponse {
+    pub avatar_id: String,
+    pub soul_id: String,
+    pub embodiment_pack: raptorflow_harness::avatar_soul::AvatarEmbodimentPack,
+    pub role_lock_prompt: String,
+    pub instinct_frame: raptorflow_harness::avatar_soul::DerivedInstinctFrame,
+    pub presence_state: Option<ProofCollectorPresenceResponse>,
+    pub debate_event: Option<ProofCollectorDebateEventResponse>,
+    pub proof_map: Option<ProofMapResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProofCollectorPresenceResponse {
+    pub presence_id: String,
+    pub state: String,
+    pub current_focus: String,
+    pub current_concern: String,
+    pub visible_summary: String,
+    pub confidence: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProofCollectorDebateEventResponse {
+    pub debate_event_id: String,
+    pub event_type: String,
+    pub stance: String,
+    pub content: serde_json::Value,
+    pub confidence: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProofMapResponse {
+    pub known_facts: Vec<String>,
+    pub claims: Vec<ClaimProofAssessmentResponse>,
+    pub proof_gaps: Vec<String>,
+    pub assets_to_collect: Vec<String>,
+    pub unsafe_claims: Vec<String>,
+    pub legal_review_flags: Vec<String>,
+    pub ripple_candidates: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClaimProofAssessmentResponse {
+    pub claim: String,
+    pub proof_available: String,
+    pub proof_type: String,
+    pub proof_strength: String,
+    pub source: String,
+    pub permission_status: String,
+    pub metric_context: MetricContextResponse,
+    pub risk: String,
+    pub recommended_action: String,
+    pub safer_wording: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MetricContextResponse {
+    pub source: String,
+    pub time_window: String,
+    pub baseline: String,
+    pub sample_size: String,
+}
+
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/avatars/proof-collector/default",
+            post(ensure_proof_collector_default),
+        )
+        .route(
+            "/api/v1/avatars/proof-collector/dry-run",
+            post(run_proof_collector_dry_run),
+        )
+        .layer(Extension(state))
+}
+
+pub async fn ensure_proof_collector_default(
+    Extension(tenant): Extension<TenantContext>,
+    Extension(tenant_pool): Extension<TenantDbPool>,
+) -> AppResult<Json<serde_json::Value>> {
+    let org_id = tenant.org_id;
+    let pool = tenant_pool.pool();
+
+    let result =
+        raptorflow_harness::proof_collector_soul::ensure_proof_collector_soul(pool, org_id)
+            .await
+            .map_err(internal_error)?;
+
+    Ok(Json(serde_json::json!({
+        "avatar_id": result.avatar_id,
+        "soul_id": result.soul_id,
+        "created": result.created,
+        "updated": result.updated
+    })))
+}
+
+pub async fn run_proof_collector_dry_run(
+    Extension(tenant): Extension<TenantContext>,
+    Extension(tenant_pool): Extension<TenantDbPool>,
+    Json(body): Json<ProofCollectorDryRunRequest>,
+) -> AppResult<Json<serde_json::Value>> {
+    let org_id = tenant.org_id;
+    let pool = tenant_pool.pool();
+
+    if body.task_summary.is_empty() {
+        return Err(bad_request("task_summary is required"));
+    }
+
+    if body.context_summary.is_empty() {
+        return Err(bad_request("context_summary is required"));
+    }
+
+    let input = raptorflow_harness::proof_collector_soul::ProofCollectorDryRunInput {
+        task_summary: body.task_summary,
+        context_summary: body.context_summary,
+    };
+
+    let result =
+        raptorflow_harness::proof_collector_soul::run_proof_collector_dry_run(pool, org_id, input)
+            .await
+            .map_err(internal_error)?;
+
+    let presence_state = result
+        .presence_state
+        .map(|p| ProofCollectorPresenceResponse {
+            presence_id: p.presence_id,
+            state: p.state,
+            current_focus: p.current_focus,
+            current_concern: p.current_concern,
+            visible_summary: p.visible_summary,
+            confidence: p.confidence,
+        });
+
+    let debate_event = result
+        .debate_event
+        .map(|e| ProofCollectorDebateEventResponse {
+            debate_event_id: e.debate_event_id,
+            event_type: e.event_type,
+            stance: e.stance,
+            content: e.content,
+            confidence: e.confidence,
+        });
+
+    let proof_map = result.proof_map.map(|p| ProofMapResponse {
+        known_facts: p.known_facts,
+        claims: p
+            .claims
+            .into_iter()
+            .map(|c| ClaimProofAssessmentResponse {
+                claim: c.claim,
+                proof_available: c.proof_available,
+                proof_type: c.proof_type,
+                proof_strength: c.proof_strength,
+                source: c.source,
+                permission_status: c.permission_status,
+                metric_context: MetricContextResponse {
+                    source: c.metric_context.source,
+                    time_window: c.metric_context.time_window,
+                    baseline: c.metric_context.baseline,
+                    sample_size: c.metric_context.sample_size,
+                },
+                risk: c.risk,
+                recommended_action: c.recommended_action,
+                safer_wording: c.safer_wording,
+            })
+            .collect(),
+        proof_gaps: p.proof_gaps,
+        assets_to_collect: p.assets_to_collect,
+        unsafe_claims: p.unsafe_claims,
+        legal_review_flags: p.legal_review_flags,
+        ripple_candidates: p.ripple_candidates,
+    });
+
+    Ok(Json(serde_json::json!({
+        "avatar_id": result.avatar_id,
+        "soul_id": result.soul_id,
+        "embodiment_pack": result.embodiment_pack,
+        "role_lock_prompt": result.role_lock_prompt,
+        "instinct_frame": result.instinct_frame,
+        "presence_state": presence_state,
+        "debate_event": debate_event,
+        "proof_map": proof_map,
+    })))
+}


### PR DESCRIPTION
$(cat <<'EOF'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Proof Collector capability for assessing and classifying proof quality
  * Added dry-run testing to evaluate proofs against claims with quality scoring
  * New API endpoints to manage Proof Collector operations and run assessments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->