### PR TITLE
feat(frontend): add RaptorFlow Paper Amber brand system

### DIFF
--- a/PR_228_BODY.md
+++ b/PR_228_BODY.md
@@ -1,0 +1,88 @@
+## Summary
+
+This PR creates the central Paper / Amber / Editorial SaaS brand system for RaptorFlow. It is the foundation for the entire frontend renaissance. No product features were added. No API behavior was changed.
+
+## Brand directory created
+
+- `apps/web/src/brand/index.ts` — Barrel export
+- `apps/web/src/brand/tokens.ts` — Canonical colors, typography, radii, shadows, spacing, z-index, semantic states
+- `apps/web/src/brand/copy.ts` — Canonical product copy and positioning
+- `apps/web/src/brand/motion.ts` — Standard motion constants and reduced-motion helper
+- `apps/web/src/brand/routes.ts` — Canonical route metadata and grouped navigation structure
+- `apps/web/src/brand/README.md` — Brand system documentation
+
+## Public asset hub created
+
+- `public/brand/.gitkeep`
+- `public/brand/textures/.gitkeep`
+- `public/brand/logo-full.svg` — Placeholder (amber/ink, no mascot)
+- `public/brand/logo-mark.svg` — Placeholder (abstract geometric mark)
+- `public/brand/favicon.svg` — Placeholder
+
+## Brand components created
+
+- `RaptorFlowLogo.tsx` — Unified logo with asset fallback
+- `RaptorMark.tsx` — Abstract amber/ink geometric mark (no literal bird)
+- `BrandWordmark.tsx` — Serif wordmark
+- `BrandHeader.tsx` — Reusable page header (eyebrow, title, description, status, actions)
+- `PaperTexture.tsx` — Paper texture wrapper
+
+## Window components created
+
+- `RfWindow.tsx` — Paper card/window (default/highlight/quiet/danger variants)
+- `RfWindowHeader.tsx` — Window header
+- `RfWindowBody.tsx` — Window body (comfortable/compact density)
+- `RfWindowGrid.tsx` — Responsive grid (1-4 columns, mobile-first)
+- `RfWindowRail.tsx` — Right rail wrapper
+- `StatusPill.tsx` — Status badge with canonical tones
+- `SignalDot.tsx` — Signal indicator dot with pulse support
+
+## Sidebar branding update
+
+- Replaced generic lightning bolt logo with `RaptorMark` + `BrandWordmark`
+- Updated tagline from "EST. 1989" to "AI-NATIVE MARKETING OS"
+- Kept all existing nav structure and behavior intact
+
+## Dashboard proof-of-concept update
+
+- `apps/web/src/app/(app)/dashboard/page.tsx`
+- Added `BrandHeader` with eyebrow, title, description, and live status pill
+- Replaced ad-hoc grid divs with `RfWindowGrid` for stat cards
+- No API behavior changed, no fake data added
+
+## Commands run with pass/fail table
+
+| Command                        | Result                                                                |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `pnpm typecheck`               | PASS                                                                  |
+| `pnpm lint`                    | PASS                                                                  |
+| `pnpm structural:check`        | PASS (pre-existing WARNs: documented Prisma gaps, unused Rust routes) |
+| `pnpm route-parity:check`      | PASS (pre-existing WARNs: unused Rust routes)                         |
+| `pnpm runtime-authority:check` | PASS (pre-existing WARNs: documented Prisma gaps)                     |
+| `cargo fmt --all --check`      | PASS                                                                  |
+| `cargo check --workspace`      | PASS                                                                  |
+
+## Known limitations
+
+- Logo SVGs are placeholders. Final brand assets should be dropped into `public/brand/`.
+- `RaptorFlowLogo` falls back to `RaptorMark` + `BrandWordmark` if `logo-full.svg` fails to load.
+- `RfWindow` does not yet support collapsible or draggable behavior.
+- `PaperTexture` is a thin wrapper around existing CSS classes.
+
+## Where final assets should be dropped
+
+- `public/brand/logo-full.svg`
+- `public/brand/logo-mark.svg`
+- `public/brand/favicon.svg`
+- `public/brand/apple-touch-icon.png`
+- `public/brand/og-image.png`
+- `public/brand/textures/paper-grain.svg`
+- `public/brand/textures/paper-grain-soft.svg`
+
+## Confirmations
+
+- [x] No product logic changed
+- [x] No fake data added
+- [x] No route behavior changed
+- [x] No force push used
+- [x] No stale PR merge

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -8,6 +8,9 @@ import { useDashboard } from "@/features/dashboard/hooks/useDashboard";
 import { apiFetch } from "@/lib/api";
 import { cn } from "@/lib/cn";
 import { GsapBridge } from "@/components/ui/gsap-bridge";
+import { BrandHeader } from "@/components/brand/BrandHeader";
+import { RfWindow, RfWindowGrid } from "@/components/windows";
+import { StatusPill } from "@/components/windows/StatusPill";
 import {
   BackpackIcon,
   AvatarIcon,
@@ -60,6 +63,13 @@ export default function DashboardPage(): React.ReactElement {
 
   return (
     <GsapBridge stagger className="space-y-8">
+      <BrandHeader
+        eyebrow="Dashboard"
+        title="The Office"
+        description="Your daily briefing and operational overview."
+        status={<StatusPill status="Live" tone="success" />}
+      />
+
       {/* ── Today's Briefing ─────────────────────────────────── */}
       {data?.todayWin ? (
         <div className={cn("gsap-reveal card-elevated p-6 border transition-all", momentumBg(score))}>
@@ -105,7 +115,7 @@ export default function DashboardPage(): React.ReactElement {
       )}
 
       {/* ── Stats Grid ───────────────────────────────────────── */}
-      <div className="gsap-reveal grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+      <RfWindowGrid columns={4} className="gsap-reveal">
         <StatCard
           label="Active campaigns"
           value={data?.stats.activeCampaigns ?? 0}
@@ -149,9 +159,9 @@ export default function DashboardPage(): React.ReactElement {
           }
           icon={HomeIcon}
         />
-      </div>
+      </RfWindowGrid>
 
-      <div className="gsap-reveal grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <RfWindowGrid columns={2} className="gsap-reveal">
         <StatCard
           label="Intel signals"
           value={data?.stats.intelUnread ?? 0}
@@ -170,7 +180,7 @@ export default function DashboardPage(): React.ReactElement {
           alert={(data?.stats.nudgeCount ?? 0) > 0}
           icon={BellIcon}
         />
-      </div>
+      </RfWindowGrid>
 
       {/* ── Activity & Nudges ─────────────────────────────────── */}
       <div className="gsap-reveal grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/apps/web/src/brand/README.md
+++ b/apps/web/src/brand/README.md
@@ -1,0 +1,128 @@
+# RaptorFlow Brand System
+
+## Visual Identity
+
+RaptorFlow uses a **Paper / Amber / Editorial SaaS** identity.
+
+The product should feel like:
+
+- Premium founder operating desk
+- Paper ledger
+- Strategic command journal
+- Warm B2B SaaS
+- Sharp, editorial, senior, operational
+- Calm but powerful
+
+## Asset Drop Locations
+
+Place final assets here:
+
+| Asset                  | Path                                         | Status      |
+| ---------------------- | -------------------------------------------- | ----------- |
+| Full logo              | `public/brand/logo-full.svg`                 | Placeholder |
+| Logo mark              | `public/brand/logo-mark.svg`                 | Placeholder |
+| Favicon                | `public/brand/favicon.svg`                   | Placeholder |
+| Apple touch icon       | `public/brand/apple-touch-icon.png`          | TBD         |
+| OG image               | `public/brand/og-image.png`                  | TBD         |
+| Paper grain (standard) | `public/brand/textures/paper-grain.svg`      | TBD         |
+| Paper grain (soft)     | `public/brand/textures/paper-grain-soft.svg` | TBD         |
+
+## How to Use `RaptorFlowLogo`
+
+```tsx
+import { RaptorFlowLogo } from "@/components/brand";
+
+// Full logo with asset fallback
+<RaptorFlowLogo size="md" variant="full" />
+
+// Mark only
+<RaptorFlowLogo size="sm" variant="mark" />
+
+// Wordmark only
+<RaptorFlowLogo size="lg" variant="wordmark" />
+```
+
+- `size`: `"sm" | "md" | "lg"`
+- `variant`: `"full" | "mark" | "wordmark"`
+- Falls back gracefully if `public/brand/logo-full.svg` is missing.
+
+## How to Use `RfWindow`
+
+```tsx
+import { RfWindow, RfWindowGrid } from "@/components/windows";
+
+<RfWindow
+  eyebrow="Section"
+  title="Window Title"
+  description="Optional description."
+  variant="default"
+  density="comfortable"
+>
+  Content here
+</RfWindow>;
+```
+
+Variants: `default` | `highlight` | `quiet` | `danger`
+Density: `comfortable` | `compact`
+
+Grid wrapper:
+
+```tsx
+<RfWindowGrid columns={3}>
+  <RfWindow>...</RfWindow>
+  <RfWindow>...</RfWindow>
+</RfWindowGrid>
+```
+
+## Color Usage Rules
+
+| Color                     | Usage                                     |
+| ------------------------- | ----------------------------------------- |
+| **Amber**                 | Strategic action, highlight, primary CTAs |
+| **Ink**                   | Primary text, headings, body              |
+| **Paper**                 | Surfaces, backgrounds, cards              |
+| **Crimson / Destructive** | Errors, risk, deletion, danger ONLY       |
+| **Leaf**                  | Success, confirmed, completed             |
+| **Indigo**                | Reserved for Muse                         |
+
+## Typography Rules
+
+| Token                  | Use                                       |
+| ---------------------- | ----------------------------------------- |
+| `font-display` (Serif) | Headlines, display text, hero lines       |
+| `font-sans`            | UI text, body, labels                     |
+| `font-mono`            | Metadata, status, system labels, eyebrows |
+
+## Motion Rules
+
+| Duration | Use                              |
+| -------- | -------------------------------- |
+| 150ms    | Hover states, micro-interactions |
+| 240ms    | Card lifts, transitions          |
+| 700ms    | Page enters, reveals             |
+
+Respect `prefers-reduced-motion`. Do not add heavy animation libraries.
+
+## Accessibility Rules
+
+- All interactive elements have visible focus rings (`outline-color: var(--ring)`).
+- Images have alt text.
+- SignalDot accepts an optional `label` for screen readers.
+- Color is never the sole indicator of state (pair with text/icons).
+
+## Responsive Design Rules
+
+- Mobile-first.
+- `RfWindowGrid` stacks gracefully: 1 col mobile, expands at `sm`/`lg` breakpoints.
+- Sidebar is fixed on desktop, slide-over on mobile.
+
+## What NOT to Do
+
+- Do NOT use dark glass as the default product UI.
+- Do NOT use neon overload.
+- Do NOT use fake hologram vibes.
+- Do NOT use random gradients everywhere.
+- Do NOT use random inline colours.
+- Do NOT use one-off page-specific styling.
+- Do NOT scatter logo usage — use `RaptorFlowLogo` everywhere.
+- Do NOT use a literal bird, mascot, or claw scratches in the mark.

--- a/apps/web/src/brand/copy.ts
+++ b/apps/web/src/brand/copy.ts
@@ -1,0 +1,32 @@
+/**
+ * RaptorFlow Canonical Product Copy
+ *
+ * Single source of truth for product names, taglines, and positioning.
+ * Keep copy tight. No hype paragraphs.
+ */
+
+export const copy = {
+  productName: "RaptorFlow",
+
+  // Section titles
+  officeTitle: "The Office",
+  officeTagline: "Where campaigns become moves.",
+  councilTitle: "Council War Room",
+  campaignsTitle: "Campaigns",
+  contentTitle: "Content Ledger",
+  foundationTitle: "Foundation",
+  museTitle: "Muse",
+  ripplesTitle: "Ripples",
+
+  // Hero / positioning
+  primaryHeroLine: "The office where campaigns become moves.",
+  shortPositioning:
+    "AI-native marketing operating system for founders who need strategy turned into execution.",
+
+  // System labels
+  dailyWinsTitle: "Daily Wins",
+  intelTitle: "Intel",
+  nudgesTitle: "Nudges",
+  uploadsTitle: "Uploads",
+  settingsTitle: "Settings",
+} as const;

--- a/apps/web/src/brand/index.ts
+++ b/apps/web/src/brand/index.ts
@@ -1,0 +1,10 @@
+/**
+ * RaptorFlow Brand System — Barrel Export
+ *
+ * Import from `@/brand` to access canonical tokens, copy, motion, and routes.
+ */
+
+export * from "./tokens";
+export * from "./copy";
+export * from "./motion";
+export * from "./routes";

--- a/apps/web/src/brand/motion.ts
+++ b/apps/web/src/brand/motion.ts
@@ -1,0 +1,48 @@
+/**
+ * RaptorFlow Motion Constants
+ *
+ * Standard motion values aligned with globals.css.
+ * Do not add heavy animation libraries in this phase.
+ * Use existing CSS / Tailwind motion utilities.
+ */
+
+export const motion = {
+  // Durations (ms)
+  fast: 150,
+  medium: 240,
+  slow: 700,
+
+  // Easing curves
+  easeOut: "cubic-bezier(0.16, 1, 0.3, 1)",
+  easeSoft: "cubic-bezier(0.4, 0, 0.2, 1)",
+  easeInOut: "cubic-bezier(0.65, 0, 0.35, 1)",
+
+  // CSS class names for common transitions
+  hoverLift: {
+    transition:
+      "transform 240ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 240ms cubic-bezier(0.4, 0, 0.2, 1)",
+    hoverTransform: "translateY(-2px)",
+  },
+
+  windowEnter: {
+    transition:
+      "opacity 700ms cubic-bezier(0.16, 1, 0.3, 1), transform 700ms cubic-bezier(0.16, 1, 0.3, 1)",
+    initial: { opacity: 0, transform: "translateY(16px)" },
+    final: { opacity: 1, transform: "translateY(0)" },
+  },
+
+  amberPulse: {
+    animation: "amberPulse 2.4s cubic-bezier(0.4, 0, 0.2, 1) infinite",
+  },
+} as const;
+
+/**
+ * Reduced-motion helper.
+ * Returns the given style object only when motion is not reduced.
+ * In component usage, prefer CSS `@media (prefers-reduced-motion: reduce)`.
+ */
+export function withMotion<T extends object>(style: T, reduced?: T): T {
+  if (typeof window === "undefined") return style;
+  const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  return prefersReduced ? (reduced ?? ({} as T)) : style;
+}

--- a/apps/web/src/brand/routes.ts
+++ b/apps/web/src/brand/routes.ts
@@ -1,0 +1,125 @@
+/**
+ * RaptorFlow Canonical Route Metadata
+ *
+ * Single source of truth for app route labels, grouping, and descriptions.
+ * Do not alter Next.js routing behavior here. This is metadata only.
+ */
+
+export interface RouteMeta {
+  href: string;
+  label: string;
+  shortLabel: string;
+  group: "workspace" | "intelligence" | "strategy" | "system";
+  description: string;
+}
+
+export const routes: Record<string, RouteMeta> = {
+  dashboard: {
+    href: "/app/dashboard",
+    label: "Dashboard",
+    shortLabel: "Dash",
+    group: "workspace",
+    description: "Your daily briefing and operational overview.",
+  },
+  office: {
+    href: "/office",
+    label: "The Office",
+    shortLabel: "Office",
+    group: "workspace",
+    description: "Where campaigns become moves.",
+  },
+  campaigns: {
+    href: "/campaigns",
+    label: "Campaigns",
+    shortLabel: "Campaigns",
+    group: "strategy",
+    description: "Active marketing campaigns and moves.",
+  },
+  council: {
+    href: "/council",
+    label: "Council",
+    shortLabel: "Council",
+    group: "strategy",
+    description: "Strategic council war room sessions.",
+  },
+  muse: {
+    href: "/muse",
+    label: "Muse",
+    shortLabel: "Muse",
+    group: "strategy",
+    description: "AI creative partner and ideation.",
+  },
+  content: {
+    href: "/content",
+    label: "Content",
+    shortLabel: "Content",
+    group: "strategy",
+    description: "Content ledger and editorial pipeline.",
+  },
+  foundation: {
+    href: "/foundation",
+    label: "Foundation",
+    shortLabel: "Foundation",
+    group: "system",
+    description: "Brand positioning and foundation data.",
+  },
+  intel: {
+    href: "/intel",
+    label: "Intel",
+    shortLabel: "Intel",
+    group: "intelligence",
+    description: "Market signals and intelligence feed.",
+  },
+  nudges: {
+    href: "/nudges",
+    label: "Nudges",
+    shortLabel: "Nudges",
+    group: "intelligence",
+    description: "Actionable nudges and alerts.",
+  },
+  ripples: {
+    href: "/ripples",
+    label: "Ripples",
+    shortLabel: "Ripples",
+    group: "intelligence",
+    description: "Impact tracking and ripple effects.",
+  },
+  uploads: {
+    href: "/uploads",
+    label: "Uploads",
+    shortLabel: "Uploads",
+    group: "workspace",
+    description: "File uploads and asset management.",
+  },
+  settings: {
+    href: "/settings",
+    label: "Settings",
+    shortLabel: "Settings",
+    group: "system",
+    description: "Account and workspace settings.",
+  },
+} as const;
+
+/** Ordered groups for navigation rendering. */
+export const routeGroups = [
+  {
+    key: "workspace" as const,
+    label: "Workspace",
+    routes: [routes.dashboard, routes.office, routes.uploads],
+  },
+  {
+    key: "intelligence" as const,
+    label: "Intelligence",
+    routes: [routes.intel, routes.nudges, routes.ripples],
+  },
+  {
+    key: "strategy" as const,
+    label: "Strategy",
+    routes: [routes.campaigns, routes.council, routes.muse, routes.content],
+  },
+  {
+    key: "system" as const,
+    label: "System",
+    routes: [routes.foundation, routes.settings],
+  },
+];

--- a/apps/web/src/brand/tokens.ts
+++ b/apps/web/src/brand/tokens.ts
@@ -1,0 +1,131 @@
+/**
+ * RaptorFlow Brand Tokens
+ *
+ * TypeScript mirrors of the CSS design system defined in globals.css.
+ * Do not create a parallel theme that fights the CSS. These are canonical
+ * references for use in components when JS-level access is needed.
+ */
+
+export const colors = {
+  // Paper surfaces
+  paper50: "#faf7f1",
+  paper100: "#fbf8f2",
+  paper150: "#f5f1e8",
+  paper200: "#efe9dc",
+  paper300: "#e6dfce",
+  paper400: "#c9c0ab",
+
+  // Ink scale
+  ink900: "#2a2622",
+  ink700: "#4a433c",
+  ink500: "#7a7268",
+  ink400: "#9c9384",
+  ink300: "#bab0a0",
+
+  // Amber primary
+  amber: "#d97757",
+  amberHover: "#c26645",
+  amberWash: "#fbe9de",
+  amberStroke: "#e89878",
+
+  // Semantic
+  leaf: "#5c8a5a",
+  leafWash: "#e8f0e5",
+  indigoMuse: "#5b5fb8",
+  indigoWash: "#e8e9f4",
+  destructive: "#c44a3f",
+  destructiveWash: "#fbeae7",
+
+  // Pod colors
+  podCreative: "#8b6fc2",
+  podDigital: "#4f87b8",
+  podStrategy: "#b8556b",
+  podSupport: "#c26f4a",
+  podStrategist: "#4a433c",
+} as const;
+
+export const typography = {
+  display: '"Instrument Serif", "DM Serif Display", ui-serif, serif',
+  sans: '"DM Sans", "Inter", ui-sans-serif, system-ui, sans-serif',
+  mono: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace',
+} as const;
+
+export const radii = {
+  xs: "4px",
+  sm: "6px",
+  md: "10px",
+  lg: "12px",
+  xl: "16px",
+  "2xl": "20px",
+  pill: "9999px",
+} as const;
+
+export const shadows = {
+  xs: "0 1px 2px rgba(42, 38, 34, 0.04)",
+  sm: "0 1px 2px rgba(42, 38, 34, 0.05), 0 1px 3px rgba(42, 38, 34, 0.04)",
+  md: "0 2px 4px rgba(42, 38, 34, 0.04), 0 4px 12px rgba(42, 38, 34, 0.06)",
+  lg: "0 4px 8px rgba(42, 38, 34, 0.04), 0 12px 32px rgba(42, 38, 34, 0.08)",
+  amber: "0 0 0 3px rgba(217, 119, 87, 0.15), 0 6px 18px -6px rgba(217, 119, 87, 0.3)",
+  inset: "inset 0 1px 0 rgba(255, 255, 255, 0.6)",
+} as const;
+
+export const spacing = {
+  px: "1px",
+  0.5: "0.125rem",
+  1: "0.25rem",
+  1.5: "0.375rem",
+  2: "0.5rem",
+  2.5: "0.625rem",
+  3: "0.75rem",
+  3.5: "0.875rem",
+  4: "1rem",
+  5: "1.25rem",
+  6: "1.5rem",
+  7: "1.75rem",
+  8: "2rem",
+  9: "2.25rem",
+  10: "2.5rem",
+  12: "3rem",
+  14: "3.5rem",
+  16: "4rem",
+  20: "5rem",
+  24: "6rem",
+  28: "7rem",
+  32: "8rem",
+} as const;
+
+export const zIndex = {
+  base: 0,
+  dropdown: 50,
+  sticky: 100,
+  fixed: 200,
+  overlay: 300,
+  modal: 400,
+  popover: 500,
+  toast: 600,
+  tooltip: 700,
+} as const;
+
+export const semantic = {
+  // Surfaces
+  background: colors.paper100,
+  card: "#ffffff",
+  sidebar: colors.paper50,
+  muted: colors.paper150,
+
+  // Text
+  foreground: colors.ink900,
+  primaryText: colors.ink900,
+  secondaryText: colors.ink700,
+  mutedText: colors.ink500,
+  hintText: colors.ink400,
+
+  // Action
+  primary: colors.amber,
+  primaryHover: colors.amberHover,
+  ring: colors.amber,
+
+  // Borders
+  border: colors.paper300,
+  borderStrong: colors.paper400,
+} as const;

--- a/apps/web/src/components/brand/BrandHeader.tsx
+++ b/apps/web/src/components/brand/BrandHeader.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface BrandHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  status?: React.ReactNode;
+  actions?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function BrandHeader({
+  eyebrow,
+  title,
+  description,
+  status,
+  actions,
+  children,
+  className,
+}: BrandHeaderProps) {
+  return (
+    <div className={cn("mb-8", className)}>
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          {eyebrow && (
+            <div className="flex items-center gap-3 mb-3">
+              <span className="eyebrow">{eyebrow}</span>
+              <span className="h-px flex-1 bg-[var(--border)]" />
+            </div>
+          )}
+          <h1 className="h1">{title}</h1>
+          {description && <p className="body-muted mt-2 max-w-xl">{description}</p>}
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {status && <div>{status}</div>}
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </div>
+      </div>
+      {children && <div className="mt-6">{children}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/brand/BrandWordmark.tsx
+++ b/apps/web/src/components/brand/BrandWordmark.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface BrandWordmarkProps {
+  size?: number;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function BrandWordmark({
+  size = 120,
+  className,
+  "aria-label": ariaLabel = "RaptorFlow",
+}: BrandWordmarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size * 0.25}
+      viewBox="0 0 200 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("shrink-0", className)}
+      aria-label={ariaLabel}
+      role="img"
+    >
+      <text
+        x="0"
+        y="28"
+        fontFamily="'Instrument Serif', 'DM Serif Display', ui-serif, serif"
+        fontSize="28"
+        fill="currentColor"
+        letterSpacing="-0.02em"
+        className="text-[#2a2622]"
+      >
+        RaptorFlow
+      </text>
+      <circle cx="188" cy="20" r="5" fill="#d97757" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/brand/PaperTexture.tsx
+++ b/apps/web/src/components/brand/PaperTexture.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface PaperTextureProps {
+  children: React.ReactNode;
+  intensity?: "none" | "soft" | "standard";
+  className?: string;
+}
+
+export function PaperTexture({ children, intensity = "soft", className }: PaperTextureProps) {
+  const textureClass = intensity === "none" ? "" : intensity === "soft" ? "paper-soft" : "paper";
+
+  return <div className={cn(textureClass, className)}>{children}</div>;
+}

--- a/apps/web/src/components/brand/RaptorFlowLogo.tsx
+++ b/apps/web/src/components/brand/RaptorFlowLogo.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+import { cn } from "@/lib/cn";
+import { RaptorMark } from "./RaptorMark";
+import { BrandWordmark } from "./BrandWordmark";
+
+export type LogoSize = "sm" | "md" | "lg";
+export type LogoVariant = "full" | "mark" | "wordmark";
+
+interface RaptorFlowLogoProps {
+  size?: LogoSize;
+  variant?: LogoVariant;
+  className?: string;
+}
+
+const sizeMap: Record<LogoSize, { mark: number; wordmark: number }> = {
+  sm: { mark: 24, wordmark: 80 },
+  md: { mark: 32, wordmark: 120 },
+  lg: { mark: 40, wordmark: 160 },
+};
+
+export function RaptorFlowLogo({ size = "md", variant = "full", className }: RaptorFlowLogoProps) {
+  const { mark: markSize, wordmark: wordmarkSize } = sizeMap[size];
+
+  if (variant === "mark") {
+    return <RaptorMark size={markSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  if (variant === "wordmark") {
+    return <BrandWordmark size={wordmarkSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  // variant === "full": try SVG asset first, fallback to mark + wordmark
+  const [assetError, setAssetError] = React.useState(false);
+
+  if (!assetError) {
+    return (
+      <Image
+        src="/brand/logo-full.svg"
+        alt="RaptorFlow"
+        width={wordmarkSize + markSize + 8}
+        height={markSize}
+        className={cn("h-auto", className)}
+        onError={() => setAssetError(true)}
+        priority
+      />
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <RaptorMark size={markSize} />
+      <BrandWordmark size={wordmarkSize} />
+    </div>
+  );
+}

--- a/apps/web/src/components/brand/RaptorFlowLogo.tsx
+++ b/apps/web/src/components/brand/RaptorFlowLogo.tsx
@@ -21,18 +21,15 @@ const sizeMap: Record<LogoSize, { mark: number; wordmark: number }> = {
   lg: { mark: 40, wordmark: 160 },
 };
 
-export function RaptorFlowLogo({ size = "md", variant = "full", className }: RaptorFlowLogoProps) {
-  const { mark: markSize, wordmark: wordmarkSize } = sizeMap[size];
-
-  if (variant === "mark") {
-    return <RaptorMark size={markSize} className={className} aria-label="RaptorFlow" />;
-  }
-
-  if (variant === "wordmark") {
-    return <BrandWordmark size={wordmarkSize} className={className} aria-label="RaptorFlow" />;
-  }
-
-  // variant === "full": try SVG asset first, fallback to mark + wordmark
+function FullRaptorFlowLogo({
+  markSize,
+  wordmarkSize,
+  className,
+}: {
+  markSize: number;
+  wordmarkSize: number;
+  className?: string;
+}) {
   const [assetError, setAssetError] = React.useState(false);
 
   if (!assetError) {
@@ -54,5 +51,21 @@ export function RaptorFlowLogo({ size = "md", variant = "full", className }: Rap
       <RaptorMark size={markSize} />
       <BrandWordmark size={wordmarkSize} />
     </div>
+  );
+}
+
+export function RaptorFlowLogo({ size = "md", variant = "full", className }: RaptorFlowLogoProps) {
+  const { mark: markSize, wordmark: wordmarkSize } = sizeMap[size];
+
+  if (variant === "mark") {
+    return <RaptorMark size={markSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  if (variant === "wordmark") {
+    return <BrandWordmark size={wordmarkSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  return (
+    <FullRaptorFlowLogo markSize={markSize} wordmarkSize={wordmarkSize} className={className} />
   );
 }

--- a/apps/web/src/components/brand/RaptorMark.tsx
+++ b/apps/web/src/components/brand/RaptorMark.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RaptorMarkProps {
+  size?: number;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function RaptorMark({
+  size = 32,
+  className,
+  "aria-label": ariaLabel = "RaptorFlow",
+}: RaptorMarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("shrink-0", className)}
+      aria-label={ariaLabel}
+      role="img"
+    >
+      <rect
+        x="2"
+        y="2"
+        width="28"
+        height="28"
+        rx="6"
+        fill="currentColor"
+        className="text-[#2a2622]"
+      />
+      <path d="M16 8L24 16L16 24L8 16Z" fill="#d97757" />
+      <circle cx="16" cy="16" r="3" fill="#fbf8f2" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/brand/index.ts
+++ b/apps/web/src/components/brand/index.ts
@@ -1,0 +1,5 @@
+export { RaptorFlowLogo } from "./RaptorFlowLogo";
+export { RaptorMark } from "./RaptorMark";
+export { BrandWordmark } from "./BrandWordmark";
+export { BrandHeader } from "./BrandHeader";
+export { PaperTexture } from "./PaperTexture";

--- a/apps/web/src/components/layout/shell-sidebar.tsx
+++ b/apps/web/src/components/layout/shell-sidebar.tsx
@@ -19,10 +19,11 @@ import {
   FileTextIcon,
   GearIcon,
   UploadIcon,
-  LightningBoltIcon,
   MixerHorizontalIcon,
 } from "@radix-ui/react-icons";
 import { cn } from "@/lib/cn";
+import { RaptorMark } from "@/components/brand/RaptorMark";
+import { BrandWordmark } from "@/components/brand/BrandWordmark";
 import { OfficeMiniStrip } from "@/components/office/office-mini-strip";
 import { NotificationPanel } from "@/components/layout/notification-panel";
 import { useOfficeStore } from "@/state/office-store";
@@ -134,15 +135,11 @@ export function ShellSidebar({ identity }: { identity: { userId: string; orgId: 
       >
         <div className="h-16 px-6 flex items-center justify-between border-b border-[var(--sidebar-border)] relative">
           <div className="flex items-center gap-3">
-            <div className="w-7 h-7 bg-[var(--primary)] flex items-center justify-center rounded-[var(--radius)] transition-transform duration-300 hover:scale-105">
-              <LightningBoltIcon className="w-4 h-4 text-white" />
-            </div>
+            <RaptorMark size={28} className="text-[var(--ink-900)]" />
             <div className="flex flex-col">
-              <span className="text-sm font-bold text-[var(--ink-900)] tracking-tight leading-none">
-                RaptorFlow
-              </span>
+              <BrandWordmark size={90} className="text-[var(--ink-900)]" />
               <span className="text-[9px] font-mono text-[var(--ink-400)] uppercase tracking-widest mt-0.5">
-                EST. 1989
+                AI-NATIVE MARKETING OS
               </span>
             </div>
           </div>

--- a/apps/web/src/components/windows/RfWindow.tsx
+++ b/apps/web/src/components/windows/RfWindow.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { RfWindowHeader } from "./RfWindowHeader";
+import { RfWindowBody } from "./RfWindowBody";
+
+export type WindowVariant = "default" | "highlight" | "quiet" | "danger";
+export type WindowDensity = "comfortable" | "compact";
+
+interface RfWindowProps {
+  title?: string;
+  eyebrow?: string;
+  description?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  variant?: WindowVariant;
+  density?: WindowDensity;
+}
+
+const variantMap: Record<WindowVariant, string> = {
+  default: "paper-card",
+  highlight: "card-highlight",
+  quiet: "bg-[var(--paper-150)] border border-[var(--border)] rounded-[var(--radius-lg)]",
+  danger:
+    "bg-[var(--destructive-wash)] border border-[var(--destructive)]/20 rounded-[var(--radius-lg)]",
+};
+
+export function RfWindow({
+  title,
+  eyebrow,
+  description,
+  actions,
+  children,
+  className,
+  variant = "default",
+  density = "comfortable",
+}: RfWindowProps) {
+  const hasHeader = title || eyebrow || description || actions;
+
+  return (
+    <div
+      className={cn(
+        variantMap[variant],
+        "overflow-hidden transition-all duration-[240ms]",
+        className,
+      )}
+    >
+      {hasHeader && (
+        <RfWindowHeader
+          eyebrow={eyebrow}
+          title={title}
+          description={description}
+          actions={actions}
+        />
+      )}
+      <RfWindowBody density={density}>{children}</RfWindowBody>
+    </div>
+  );
+}

--- a/apps/web/src/components/windows/RfWindowBody.tsx
+++ b/apps/web/src/components/windows/RfWindowBody.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import type { WindowDensity } from "./RfWindow";
+
+interface RfWindowBodyProps {
+  children: React.ReactNode;
+  className?: string;
+  density?: WindowDensity;
+}
+
+export function RfWindowBody({ children, className, density = "comfortable" }: RfWindowBodyProps) {
+  return <div className={cn(density === "comfortable" ? "p-6" : "p-4", className)}>{children}</div>;
+}

--- a/apps/web/src/components/windows/RfWindowGrid.tsx
+++ b/apps/web/src/components/windows/RfWindowGrid.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RfWindowGridProps {
+  children: React.ReactNode;
+  columns?: 1 | 2 | 3 | 4;
+  className?: string;
+}
+
+const colMap: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+  4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+};
+
+export function RfWindowGrid({ children, columns = 2, className }: RfWindowGridProps) {
+  return <div className={cn("grid gap-4", colMap[columns], className)}>{children}</div>;
+}

--- a/apps/web/src/components/windows/RfWindowHeader.tsx
+++ b/apps/web/src/components/windows/RfWindowHeader.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RfWindowHeaderProps {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function RfWindowHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: RfWindowHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "px-6 pt-5 pb-0 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3",
+        className,
+      )}
+    >
+      <div className="flex-1 min-w-0">
+        {eyebrow && <span className="eyebrow block mb-1.5">{eyebrow}</span>}
+        {title && <h3 className="h3">{title}</h3>}
+        {description && <p className="body-muted mt-1">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/windows/RfWindowRail.tsx
+++ b/apps/web/src/components/windows/RfWindowRail.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RfWindowRailProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function RfWindowRail({ children, className }: RfWindowRailProps) {
+  return (
+    <aside className={cn("w-full lg:w-80 xl:w-96 shrink-0 paper-card p-5 h-fit", className)}>
+      {children}
+    </aside>
+  );
+}

--- a/apps/web/src/components/windows/SignalDot.tsx
+++ b/apps/web/src/components/windows/SignalDot.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type SignalTone = "amber" | "success" | "danger" | "neutral";
+
+interface SignalDotProps {
+  tone?: SignalTone;
+  pulse?: boolean;
+  label?: string;
+  className?: string;
+}
+
+const toneMap: Record<SignalTone, string> = {
+  amber: "bg-[var(--primary)] shadow-[0_0_0_3px_rgba(217,119,87,0.18)]",
+  success: "bg-[var(--leaf-confirm)] shadow-[0_0_0_3px_rgba(92,138,90,0.18)]",
+  danger: "bg-[var(--destructive)] shadow-[0_0_0_3px_rgba(196,74,63,0.18)]",
+  neutral: "bg-[var(--ink-400)] shadow-none",
+};
+
+export function SignalDot({ tone = "amber", pulse = false, label, className }: SignalDotProps) {
+  return (
+    <span className={cn("inline-flex items-center gap-2", className)}>
+      <span
+        className={cn(
+          "inline-block w-2 h-2 rounded-full",
+          toneMap[tone],
+          pulse && "animate-[amberPulse_2.4s_cubic-bezier(0.4,0,0.2,1)_infinite]",
+        )}
+        aria-hidden={!label}
+        aria-label={label}
+      />
+      {label && <span className="text-[11px] text-[var(--ink-500)]">{label}</span>}
+    </span>
+  );
+}

--- a/apps/web/src/components/windows/StatusPill.tsx
+++ b/apps/web/src/components/windows/StatusPill.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type StatusTone = "neutral" | "success" | "warning" | "danger" | "amber" | "muse";
+
+interface StatusPillProps {
+  status: string;
+  tone?: StatusTone;
+  className?: string;
+}
+
+const toneMap: Record<StatusTone, string> = {
+  neutral: "bg-[var(--paper-200)] text-[var(--ink-700)] border-[var(--paper-300)]",
+  success: "bg-[var(--leaf-wash)] text-[var(--leaf)] border-[var(--leaf)]/20",
+  warning: "bg-[var(--amber-wash)] text-[var(--primary)] border-[var(--amber-stroke)]/30",
+  danger: "bg-[var(--destructive-wash)] text-[var(--destructive)] border-[var(--destructive)]/20",
+  amber: "bg-[var(--amber-wash)] text-[var(--primary)] border-[var(--amber-stroke)]/30",
+  muse: "bg-[var(--indigo-wash)] text-[var(--indigo-muse)] border-[var(--indigo-muse)]/20",
+};
+
+export function StatusPill({ status, tone = "neutral", className }: StatusPillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium border",
+        toneMap[tone],
+        className,
+      )}
+    >
+      {status}
+    </span>
+  );
+}

--- a/apps/web/src/components/windows/index.ts
+++ b/apps/web/src/components/windows/index.ts
@@ -1,0 +1,7 @@
+export { RfWindow } from "./RfWindow";
+export { RfWindowHeader } from "./RfWindowHeader";
+export { RfWindowBody } from "./RfWindowBody";
+export { RfWindowGrid } from "./RfWindowGrid";
+export { RfWindowRail } from "./RfWindowRail";
+export { StatusPill } from "./StatusPill";
+export { SignalDot } from "./SignalDot";

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -23,5 +23,4 @@ raptorflow-config = { path = "../config" }
 raptorflow-contracts = { path = "../contracts" }
 raptorflow-eel = { path = "../eel" }
 raptorflow-prl = { path = "../prl" }
-<<<<<<< HEAD
 raptorflow-aws = { path = "../aws" }

--- a/docs/frontend-phase-1-brand-system.md
+++ b/docs/frontend-phase-1-brand-system.md
@@ -1,0 +1,90 @@
+# Frontend Phase 1 — RaptorFlow Brand System
+
+## Summary
+
+This phase creates the central Paper / Amber / Editorial SaaS brand system for RaptorFlow. It is the foundation for the entire frontend renaissance. No product features were added. No API behavior was changed.
+
+## Files Created
+
+### Brand Directory
+
+- `apps/web/src/brand/index.ts` — Barrel export
+- `apps/web/src/brand/tokens.ts` — Canonical colors, typography, radii, shadows, spacing, z-index, semantic states
+- `apps/web/src/brand/copy.ts` — Canonical product copy and positioning
+- `apps/web/src/brand/motion.ts` — Standard motion constants and reduced-motion helper
+- `apps/web/src/brand/routes.ts` — Canonical route metadata and grouped navigation structure
+- `apps/web/src/brand/README.md` — Brand system documentation
+
+### Public Asset Hub
+
+- `public/brand/.gitkeep`
+- `public/brand/textures/.gitkeep`
+- `public/brand/logo-full.svg` — Placeholder
+- `public/brand/logo-mark.svg` — Placeholder
+- `public/brand/favicon.svg` — Placeholder
+
+### Brand Components
+
+- `apps/web/src/components/brand/RaptorFlowLogo.tsx` — Unified logo component with asset fallback
+- `apps/web/src/components/brand/RaptorMark.tsx` — Abstract amber/ink geometric mark
+- `apps/web/src/components/brand/BrandWordmark.tsx` — Serif wordmark
+- `apps/web/src/components/brand/BrandHeader.tsx` — Reusable page header
+- `apps/web/src/components/brand/PaperTexture.tsx` — Paper texture wrapper
+- `apps/web/src/components/brand/index.ts` — Barrel export
+
+### Window Components
+
+- `apps/web/src/components/windows/RfWindow.tsx` — Paper card/window
+- `apps/web/src/components/windows/RfWindowHeader.tsx` — Window header
+- `apps/web/src/components/windows/RfWindowBody.tsx` — Window body
+- `apps/web/src/components/windows/RfWindowGrid.tsx` — Responsive grid
+- `apps/web/src/components/windows/RfWindowRail.tsx` — Right rail wrapper
+- `apps/web/src/components/windows/StatusPill.tsx` — Status badge
+- `apps/web/src/components/windows/SignalDot.tsx` — Signal indicator dot
+- `apps/web/src/components/windows/index.ts` — Barrel export
+
+### Modified Files
+
+- `apps/web/src/components/layout/shell-sidebar.tsx` — Replaced generic lightning logo with `RaptorMark` + `BrandWordmark`
+- `apps/web/src/app/(app)/dashboard/page.tsx` — Added `BrandHeader`, `RfWindowGrid`, `StatusPill` as proof of concept
+
+## How Later Phases Should Use This
+
+1. **Import from `@/brand`** for tokens, copy, motion, and route metadata.
+2. **Use `RaptorFlowLogo`** instead of inline logo fragments.
+3. **Wrap page content with `RfWindow`** and `RfWindowGrid` instead of ad-hoc card divs.
+4. **Use `BrandHeader`** for consistent page headers.
+5. **Reference `globals.css`** for the canonical CSS design system; use `tokens.ts` only when JS-level access is required.
+
+## Known Limitations
+
+- Logo SVGs are placeholders. Final brand assets should be dropped into `public/brand/`.
+- `RaptorFlowLogo` falls back to `RaptorMark` + `BrandWordmark` if `logo-full.svg` fails to load.
+- `RfWindow` does not yet support collapsible or draggable behavior.
+- `PaperTexture` is a thin wrapper around existing CSS classes.
+
+## Next Phase Recommendation
+
+**Phase 2: Page-by-Page Brand Application**
+
+Transform each major page (Office, Campaigns, Content, Billing, Landing) to use the brand system consistently. Replace ad-hoc card styles with `RfWindow`, standardize headers with `BrandHeader`, and eliminate one-off color usage.
+
+## Commands Run
+
+| Command                        | Result                                                                |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `pnpm typecheck`               | PASS                                                                  |
+| `pnpm lint`                    | PASS                                                                  |
+| `pnpm structural:check`        | PASS (pre-existing WARNs: documented Prisma gaps, unused Rust routes) |
+| `pnpm route-parity:check`      | PASS (pre-existing WARNs: unused Rust routes)                         |
+| `pnpm runtime-authority:check` | PASS (pre-existing WARNs: documented Prisma gaps)                     |
+| `cargo fmt --all --check`      | PASS                                                                  |
+| `cargo check --workspace`      | PASS                                                                  |
+
+## Confirmations
+
+- No product logic changed.
+- No fake data added.
+- No route behavior changed.
+- No force push used.
+- No stale PR merge.

--- a/public/brand/favicon.svg
+++ b/public/brand/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- PLACEHOLDER: Replace with final RaptorFlow favicon -->
+  <rect width="32" height="32" rx="6" fill="#faf7f1"/>
+  <path d="M16 6L26 16L16 26L6 16Z" fill="#d97757"/>
+  <circle cx="16" cy="16" r="2.5" fill="#2a2622"/>
+</svg>

--- a/public/brand/logo-full.svg
+++ b/public/brand/logo-full.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" fill="none">
+  <!-- PLACEHOLDER: Replace with final RaptorFlow wordmark -->
+  <text x="0" y="28" font-family="'Instrument Serif', 'DM Serif Display', ui-serif, serif" font-size="28" fill="#2a2622" letter-spacing="-0.02em">RaptorFlow</text>
+  <circle cx="188" cy="20" r="6" fill="#d97757"/>
+</svg>

--- a/public/brand/logo-mark.svg
+++ b/public/brand/logo-mark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- PLACEHOLDER: Replace with final RaptorFlow mark -->
+  <!-- Abstract strategic mark: amber diamond with ink inner shape -->
+  <rect x="2" y="2" width="28" height="28" rx="6" fill="#2a2622"/>
+  <path d="M16 8L24 16L16 24L8 16Z" fill="#d97757"/>
+  <circle cx="16" cy="16" r="3" fill="#fbf8f2"/>
+</svg>


### PR DESCRIPTION
## Summary

This PR creates the central Paper / Amber / Editorial SaaS brand system for RaptorFlow. It is the foundation for the entire frontend renaissance. No product features were added. No API behavior was changed.

## Brand directory created

- `apps/web/src/brand/index.ts` — Barrel export
- `apps/web/src/brand/tokens.ts` — Canonical colors, typography, radii, shadows, spacing, z-index, semantic states
- `apps/web/src/brand/copy.ts` — Canonical product copy and positioning
- `apps/web/src/brand/motion.ts` — Standard motion constants and reduced-motion helper
- `apps/web/src/brand/routes.ts` — Canonical route metadata and grouped navigation structure
- `apps/web/src/brand/README.md` — Brand system documentation

## Public asset hub created

- `public/brand/.gitkeep`
- `public/brand/textures/.gitkeep`
- `public/brand/logo-full.svg` — Placeholder (amber/ink, no mascot)
- `public/brand/logo-mark.svg` — Placeholder (abstract geometric mark)
- `public/brand/favicon.svg` — Placeholder

## Brand components created

- `RaptorFlowLogo.tsx` — Unified logo with asset fallback
- `RaptorMark.tsx` — Abstract amber/ink geometric mark (no literal bird)
- `BrandWordmark.tsx` — Serif wordmark
- `BrandHeader.tsx` — Reusable page header (eyebrow, title, description, status, actions)
- `PaperTexture.tsx` — Paper texture wrapper

## Window components created

- `RfWindow.tsx` — Paper card/window (default/highlight/quiet/danger variants)
- `RfWindowHeader.tsx` — Window header
- `RfWindowBody.tsx` — Window body (comfortable/compact density)
- `RfWindowGrid.tsx` — Responsive grid (1-4 columns, mobile-first)
- `RfWindowRail.tsx` — Right rail wrapper
- `StatusPill.tsx` — Status badge with canonical tones
- `SignalDot.tsx` — Signal indicator dot with pulse support

## Sidebar branding update

- Replaced generic lightning bolt logo with `RaptorMark` + `BrandWordmark`
- Updated tagline from "EST. 1989" to "AI-NATIVE MARKETING OS"
- Kept all existing nav structure and behavior intact

## Dashboard proof-of-concept update

- `apps/web/src/app/(app)/dashboard/page.tsx`
- Added `BrandHeader` with eyebrow, title, description, and live status pill
- Replaced ad-hoc grid divs with `RfWindowGrid` for stat cards
- No API behavior changed, no fake data added

## Commands run with pass/fail table

| Command                        | Result                                                                |
| ------------------------------ | --------------------------------------------------------------------- |
| `pnpm typecheck`               | PASS                                                                  |
| `pnpm lint`                    | PASS                                                                  |
| `pnpm structural:check`        | PASS (pre-existing WARNs: documented Prisma gaps, unused Rust routes) |
| `pnpm route-parity:check`      | PASS (pre-existing WARNs: unused Rust routes)                         |
| `pnpm runtime-authority:check` | PASS (pre-existing WARNs: documented Prisma gaps)                     |
| `cargo fmt --all --check`      | PASS                                                                  |
| `cargo check --workspace`      | PASS                                                                  |

## Known limitations

- Logo SVGs are placeholders. Final brand assets should be dropped into `public/brand/`.
- `RaptorFlowLogo` falls back to `RaptorMark` + `BrandWordmark` if `logo-full.svg` fails to load.
- `RfWindow` does not yet support collapsible or draggable behavior.
- `PaperTexture` is a thin wrapper around existing CSS classes.

## Where final assets should be dropped

- `public/brand/logo-full.svg`
- `public/brand/logo-mark.svg`
- `public/brand/favicon.svg`
- `public/brand/apple-touch-icon.png`
- `public/brand/og-image.png`
- `public/brand/textures/paper-grain.svg`
- `public/brand/textures/paper-grain-soft.svg`

## Confirmations

- [x] No product logic changed
- [x] No fake data added
- [x] No route behavior changed
- [x] No force push used
- [x] No stale PR merge
