### PR TITLE
feat(frontend): integrate RaptorFlow app shell and page frame

### DIFF
--- a/PR_228_BODY.md
+++ b/PR_228_BODY.md
@@ -1,0 +1,88 @@
+## Summary
+
+This PR creates the central Paper / Amber / Editorial SaaS brand system for RaptorFlow. It is the foundation for the entire frontend renaissance. No product features were added. No API behavior was changed.
+
+## Brand directory created
+
+- `apps/web/src/brand/index.ts` — Barrel export
+- `apps/web/src/brand/tokens.ts` — Canonical colors, typography, radii, shadows, spacing, z-index, semantic states
+- `apps/web/src/brand/copy.ts` — Canonical product copy and positioning
+- `apps/web/src/brand/motion.ts` — Standard motion constants and reduced-motion helper
+- `apps/web/src/brand/routes.ts` — Canonical route metadata and grouped navigation structure
+- `apps/web/src/brand/README.md` — Brand system documentation
+
+## Public asset hub created
+
+- `public/brand/.gitkeep`
+- `public/brand/textures/.gitkeep`
+- `public/brand/logo-full.svg` — Placeholder (amber/ink, no mascot)
+- `public/brand/logo-mark.svg` — Placeholder (abstract geometric mark)
+- `public/brand/favicon.svg` — Placeholder
+
+## Brand components created
+
+- `RaptorFlowLogo.tsx` — Unified logo with asset fallback
+- `RaptorMark.tsx` — Abstract amber/ink geometric mark (no literal bird)
+- `BrandWordmark.tsx` — Serif wordmark
+- `BrandHeader.tsx` — Reusable page header (eyebrow, title, description, status, actions)
+- `PaperTexture.tsx` — Paper texture wrapper
+
+## Window components created
+
+- `RfWindow.tsx` — Paper card/window (default/highlight/quiet/danger variants)
+- `RfWindowHeader.tsx` — Window header
+- `RfWindowBody.tsx` — Window body (comfortable/compact density)
+- `RfWindowGrid.tsx` — Responsive grid (1-4 columns, mobile-first)
+- `RfWindowRail.tsx` — Right rail wrapper
+- `StatusPill.tsx` — Status badge with canonical tones
+- `SignalDot.tsx` — Signal indicator dot with pulse support
+
+## Sidebar branding update
+
+- Replaced generic lightning bolt logo with `RaptorMark` + `BrandWordmark`
+- Updated tagline from "EST. 1989" to "AI-NATIVE MARKETING OS"
+- Kept all existing nav structure and behavior intact
+
+## Dashboard proof-of-concept update
+
+- `apps/web/src/app/(app)/dashboard/page.tsx`
+- Added `BrandHeader` with eyebrow, title, description, and live status pill
+- Replaced ad-hoc grid divs with `RfWindowGrid` for stat cards
+- No API behavior changed, no fake data added
+
+## Commands run with pass/fail table
+
+| Command                        | Result                                                                |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `pnpm typecheck`               | PASS                                                                  |
+| `pnpm lint`                    | PASS                                                                  |
+| `pnpm structural:check`        | PASS (pre-existing WARNs: documented Prisma gaps, unused Rust routes) |
+| `pnpm route-parity:check`      | PASS (pre-existing WARNs: unused Rust routes)                         |
+| `pnpm runtime-authority:check` | PASS (pre-existing WARNs: documented Prisma gaps)                     |
+| `cargo fmt --all --check`      | PASS                                                                  |
+| `cargo check --workspace`      | PASS                                                                  |
+
+## Known limitations
+
+- Logo SVGs are placeholders. Final brand assets should be dropped into `public/brand/`.
+- `RaptorFlowLogo` falls back to `RaptorMark` + `BrandWordmark` if `logo-full.svg` fails to load.
+- `RfWindow` does not yet support collapsible or draggable behavior.
+- `PaperTexture` is a thin wrapper around existing CSS classes.
+
+## Where final assets should be dropped
+
+- `public/brand/logo-full.svg`
+- `public/brand/logo-mark.svg`
+- `public/brand/favicon.svg`
+- `public/brand/apple-touch-icon.png`
+- `public/brand/og-image.png`
+- `public/brand/textures/paper-grain.svg`
+- `public/brand/textures/paper-grain-soft.svg`
+
+## Confirmations
+
+- [x] No product logic changed
+- [x] No fake data added
+- [x] No route behavior changed
+- [x] No force push used
+- [x] No stale PR merge

--- a/apps/web/src/app/(app)/content/page.tsx
+++ b/apps/web/src/app/(app)/content/page.tsx
@@ -6,80 +6,85 @@ import { GsapBridge } from "@/components/ui/gsap-bridge";
 import { DownloadIcon, MixerHorizontalIcon, ViewGridIcon } from "@radix-ui/react-icons";
 import { contentApi } from "@/lib/api";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EmptyState } from "@/components/ui/empty-state";
 import { FileText } from "lucide-react";
 import { renderGeneratedContent } from "@/components/content/renderer-registry";
+import { AppPageFrame } from "@/components/layout/AppPageFrame";
+import { AppEmptyState } from "@/components/layout/AppEmptyState";
+import { AppLoadingState } from "@/components/layout/AppLoadingState";
+import { AppErrorState } from "@/components/layout/AppErrorState";
+import { AppPageSection } from "@/components/layout/AppPageSection";
+import { StatusPill } from "@/components/windows/StatusPill";
 
 export default function ContentPage(): React.ReactElement {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["content"],
     queryFn: () => contentApi.list(),
   });
 
-  return (
-    <div className="min-h-[calc(100vh-theme(spacing.16))] bg-[var(--background)] p-8 md:p-12 font-body">
-      <GsapBridge stagger={true} className="mx-auto max-w-[1400px]">
-        {/* Header */}
-        <div className="gsap-reveal flex items-end justify-between border-b-2 border-[var(--foreground)] pb-8 mb-12">
-          <div>
-            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.25em] text-[var(--muted-foreground)] mb-2">
-              Content Engine
-            </p>
-            <h1 className="font-[family-name:var(--font-display)] text-5xl">Content</h1>
-          </div>
-          <div className="flex gap-3">
-            <button disabled className="border border-[var(--border)] bg-transparent px-4 h-10 font-mono text-[10px] uppercase tracking-widest text-[var(--muted-foreground)] flex items-center gap-2 opacity-40 cursor-not-allowed">
-              <MixerHorizontalIcon className="h-3.5 w-3.5" /> Filter
-            </button>
-            <button disabled className="border border-[var(--border)] bg-transparent px-4 h-10 font-mono text-[10px] uppercase tracking-widest text-[var(--muted-foreground)] flex items-center gap-2 opacity-40 cursor-not-allowed">
-              <ViewGridIcon className="h-3.5 w-3.5" /> Grid
-            </button>
-            <button disabled className="border border-[var(--border)] bg-transparent px-4 h-10 font-mono text-[10px] uppercase tracking-widest text-[var(--muted-foreground)] flex items-center gap-2 opacity-40 cursor-not-allowed">
-              <DownloadIcon className="h-3.5 w-3.5" /> Export All
-            </button>
-          </div>
-        </div>
+  if (isLoading) {
+    return (
+      <AppPageFrame eyebrow="Content Engine" title="Content Ledger">
+        <AppLoadingState label="Loading content archive..." />
+      </AppPageFrame>
+    );
+  }
 
-        <div className="gsap-reveal space-y-4">
-          {isLoading ? (
-            <>
-              <Skeleton className="h-28 w-full rounded-none" />
-              <Skeleton className="h-28 w-full rounded-none" />
-              <Skeleton className="h-28 w-full rounded-none" />
-            </>
-          ) : (data?.length ?? 0) === 0 ? (
-            <EmptyState
-              icon={FileText}
-              title="Content Archive Empty"
-              description="No generated content has been persisted yet. Generate content from campaigns or the council."
-            />
-          ) : (
-            data?.map((item) => (
-              <div key={item.contentId} className="border border-[var(--border)] bg-[var(--card)] p-6">
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <p className="font-mono text-[10px] uppercase tracking-widest text-[#D97757] mb-2">
-                      {item.contentType}
-                    </p>
-                    <h2 className="font-[family-name:var(--font-display)] text-2xl leading-tight">
-                      {String(item.body.headline ?? item.body.title ?? item.contentType)}
-                    </h2>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-mono text-[9px] uppercase tracking-widest text-[var(--muted-foreground)]">
-                      {item.status}
-                    </p>
-                    <p className="font-mono text-[9px] text-[var(--muted-foreground)] mt-1">
-                      {new Date(item.createdAt).toLocaleString()}
-                    </p>
-                  </div>
+  if (error) {
+    return (
+      <AppPageFrame eyebrow="Content Engine" title="Content Ledger">
+        <AppErrorState
+          title="Failed to load content"
+          description={error.message}
+        />
+      </AppPageFrame>
+    );
+  }
+
+  const hasContent = (data?.length ?? 0) > 0;
+
+  return (
+    <AppPageFrame
+      eyebrow="Content Engine"
+      title="Content Ledger"
+      description="Generated content from campaigns and council sessions."
+      actions={
+        <>
+          <button disabled className="btn-secondary opacity-40 cursor-not-allowed">
+            <MixerHorizontalIcon className="w-3.5 h-3.5" /> Filter
+          </button>
+          <button disabled className="btn-secondary opacity-40 cursor-not-allowed">
+            <DownloadIcon className="w-3.5 h-3.5" /> Export
+          </button>
+        </>
+      }
+    >
+      <GsapBridge stagger={true} className="space-y-4">
+        {!hasContent ? (
+          <AppEmptyState
+            icon={<FileText className="w-6 h-6 text-[var(--ink-400)]" />}
+            title="Content Archive Empty"
+            description="No generated content has been persisted yet. Generate content from campaigns or the council."
+          />
+        ) : (
+          data?.map((item) => (
+            <AppPageSection
+              key={item.contentId}
+              eyebrow={item.contentType}
+              title={String(item.body.headline ?? item.body.title ?? item.contentType)}
+              actions={<StatusPill status={item.status} tone="neutral" />}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1">
+                  {renderGeneratedContent(item.contentType, item.body)}
                 </div>
-                {renderGeneratedContent(item.contentType, item.body)}
+                <span className="mono-label shrink-0">
+                  {new Date(item.createdAt).toLocaleString()}
+                </span>
               </div>
-            ))
-          )}
-        </div>
+            </AppPageSection>
+          ))
+        )}
       </GsapBridge>
-    </div>
+    </AppPageFrame>
   );
 }

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -8,6 +8,9 @@ import { useDashboard } from "@/features/dashboard/hooks/useDashboard";
 import { apiFetch } from "@/lib/api";
 import { cn } from "@/lib/cn";
 import { GsapBridge } from "@/components/ui/gsap-bridge";
+import { BrandHeader } from "@/components/brand/BrandHeader";
+import { RfWindow, RfWindowGrid } from "@/components/windows";
+import { StatusPill } from "@/components/windows/StatusPill";
 import {
   BackpackIcon,
   AvatarIcon,
@@ -60,6 +63,13 @@ export default function DashboardPage(): React.ReactElement {
 
   return (
     <GsapBridge stagger className="space-y-8">
+      <BrandHeader
+        eyebrow="Dashboard"
+        title="The Office"
+        description="Your daily briefing and operational overview."
+        status={<StatusPill status="Live" tone="success" />}
+      />
+
       {/* ── Today's Briefing ─────────────────────────────────── */}
       {data?.todayWin ? (
         <div className={cn("gsap-reveal card-elevated p-6 border transition-all", momentumBg(score))}>
@@ -105,7 +115,7 @@ export default function DashboardPage(): React.ReactElement {
       )}
 
       {/* ── Stats Grid ───────────────────────────────────────── */}
-      <div className="gsap-reveal grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+      <RfWindowGrid columns={4} className="gsap-reveal">
         <StatCard
           label="Active campaigns"
           value={data?.stats.activeCampaigns ?? 0}
@@ -149,9 +159,9 @@ export default function DashboardPage(): React.ReactElement {
           }
           icon={HomeIcon}
         />
-      </div>
+      </RfWindowGrid>
 
-      <div className="gsap-reveal grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <RfWindowGrid columns={2} className="gsap-reveal">
         <StatCard
           label="Intel signals"
           value={data?.stats.intelUnread ?? 0}
@@ -170,7 +180,7 @@ export default function DashboardPage(): React.ReactElement {
           alert={(data?.stats.nudgeCount ?? 0) > 0}
           icon={BellIcon}
         />
-      </div>
+      </RfWindowGrid>
 
       {/* ── Activity & Nudges ─────────────────────────────────── */}
       <div className="gsap-reveal grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/apps/web/src/app/(app)/ripples/page.tsx
+++ b/apps/web/src/app/(app)/ripples/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRipples, useCreateRipple, useDeleteRipple, useRealizeRipple, useRunDecay } from "@/hooks/use-prl";
 import { AGENTS } from "@/lib/agents";
 import { AgentPill } from "@/components/ui/agent-portrait";
@@ -12,34 +12,40 @@ import {
   TrashIcon,
   ReloadIcon,
 } from "@radix-ui/react-icons";
-import { EmptyState } from "@/components/ui/empty-state";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Activity } from "lucide-react";
+import { AppPageFrame } from "@/components/layout/AppPageFrame";
+import { AppPageSection } from "@/components/layout/AppPageSection";
+import { AppEmptyState } from "@/components/layout/AppEmptyState";
+import { AppLoadingState } from "@/components/layout/AppLoadingState";
+import { AppErrorState } from "@/components/layout/AppErrorState";
+import { AppPageToolbar } from "@/components/layout/AppPageToolbar";
+import { StatusPill } from "@/components/windows/StatusPill";
+import { SignalDot } from "@/components/windows/SignalDot";
+import { cn } from "@/lib/cn";
 
 /* ─── Protection band config ────────────────────────────────────── */
-const BAND_CONFIG: Record<string, { label: string; color: string; bg: string }> = {
-  protected:  { label: "PROTECTED",  color: "var(--indigo-muse)",      bg: "var(--indigo-muse-dim, rgba(99,102,241,0.08))" },
-  important:  { label: "IMPORTANT",  color: "var(--amber-war)",         bg: "var(--amber-war-dim,  rgba(196,128,30,0.08))"  },
-  normal:     { label: "NORMAL",     color: "var(--leaf-confirm)",      bg: "var(--leaf-confirm-dim, rgba(34,197,94,0.06))" },
-  disposable: { label: "DISPOSABLE", color: "var(--signal-red)",        bg: "var(--signal-red-dim, rgba(220,38,38,0.07))"   },
+const BAND_CONFIG: Record<string, { label: string; tone: "neutral" | "success" | "warning" | "danger" | "amber" | "muse" }> = {
+  protected:  { label: "PROTECTED",  tone: "muse" },
+  important:  { label: "IMPORTANT",  tone: "amber" },
+  normal:     { label: "NORMAL",     tone: "success" },
+  disposable: { label: "DISPOSABLE", tone: "danger" },
 };
 
 /* ─── Confidence bar ────────────────────────────────────────────── */
 function ConfidenceBar({ value }: { value: number }): React.ReactElement {
   const pct = Math.round(value * 100);
-  const color = pct >= 75 ? "var(--leaf-confirm)" : pct >= 40 ? "var(--amber-war)" : "var(--signal-red)";
+  const color = pct >= 75 ? "var(--leaf-confirm)" : pct >= 40 ? "var(--primary)" : "var(--destructive)";
   return (
     <div>
       <div className="flex items-center justify-between mb-1">
-        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 8, textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--muted-foreground)" }}>
-          Confidence
-        </span>
-        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, color }}>
-          {pct}%
-        </span>
+        <span className="mono-label">Confidence</span>
+        <span className="font-mono text-[9px] font-bold" style={{ color }}>{pct}%</span>
       </div>
-      <div style={{ height: 3, background: "var(--muted)", overflow: "hidden" }}>
-        <div style={{ height: "100%", width: `${pct}%`, background: color, transition: "width 0.6s ease" }} />
+      <div className="h-[3px] bg-[var(--paper-200)] overflow-hidden rounded-full">
+        <div
+          className="h-full rounded-full transition-all duration-700"
+          style={{ width: `${pct}%`, background: color }}
+        />
       </div>
     </div>
   );
@@ -56,118 +62,47 @@ function RippleCard({ ripple, onRealize, onDelete }: {
   const dateStr = new Date(ripple.createdAt).toLocaleDateString("en-IN", { day: "numeric", month: "short" });
 
   return (
-    <div
-      className="flex border border-[var(--border)] overflow-hidden"
-      style={{ background: "var(--card)" }}
+    <AppPageSection
+      eyebrow={`LEVEL ${ripple.hierarchyLevel || 1}`}
+      title={ripple.summaryText}
+      actions={<StatusPill status={band.label} tone={band.tone} />}
+      variant="quiet"
     >
-      {/* Left band */}
-      <div className="w-1 shrink-0" style={{ background: band.color }} />
-
-      {/* Content */}
-      <div className="flex-1 p-5">
-        {/* Header row */}
-        <div className="flex items-start justify-between mb-3 gap-3">
-          <div className="flex gap-2">
-            <span
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 8,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.14em",
-                border: `1px solid ${band.color}`,
-                color: band.color,
-                padding: "2px 6px",
-                background: band.bg,
-                whiteSpace: "nowrap",
-              }}
-            >
-              LEVEL {ripple.hierarchyLevel || 1}
-            </span>
-            {ripple.memoryClass && (
-              <span
-                style={{
-                  fontFamily: "'JetBrains Mono', monospace",
-                  fontSize: 8,
-                  fontWeight: 700,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.14em",
-                  border: `1px solid var(--border)`,
-                  color: "var(--muted-foreground)",
-                  padding: "2px 6px",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {ripple.memoryClass}
-              </span>
-            )}
-          </div>
-          <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 8, color: "var(--muted-foreground)", whiteSpace: "nowrap" }}>
-            {dateStr}
-          </span>
-        </div>
-
-        {/* Core claim */}
-        <h3
-          style={{
-            fontFamily: "'DM Serif Display', serif",
-            fontSize: 17,
-            lineHeight: 1.3,
-            color: "var(--foreground)",
-            margin: 0,
-            marginBottom: 8,
-          }}
-        >
-          {ripple.summaryText}
-        </h3>
-
-        {/* Reasoning */}
+      <div className="space-y-4">
         {ripple.rawText && (
-          <p
-            className="mb-4 line-clamp-2"
-            style={{ fontFamily: "'Inter', sans-serif", fontSize: 11, lineHeight: 1.6, color: "var(--muted-foreground)" }}
-          >
-            {ripple.rawText}
-          </p>
+          <p className="text-xs text-[var(--ink-500)] line-clamp-2">{ripple.rawText}</p>
         )}
 
-        {/* Confidence bar */}
-        <div className="mb-4">
-          <ConfidenceBar value={ripple.confidence} />
-        </div>
+        <ConfidenceBar value={ripple.confidence} />
 
-        {/* Footer */}
-        <div className="flex items-center justify-between mt-auto pt-2 border-t border-[var(--border)]">
+        <div className="flex items-center justify-between pt-3 border-t border-[var(--border)]">
           {sourceAgent ? (
             <AgentPill agent={sourceAgent} size={16} />
-          ) : ripple.sourceAgent ? (
-            <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 8, color: "var(--muted-foreground)" }}>
-              {ripple.sourceAgent}
-            </span>
           ) : (
-            <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 8, color: "var(--muted-foreground)" }}>
-              System Generated
-            </span>
+            <span className="mono-label">{ripple.sourceAgent || "System Generated"}</span>
           )}
-          <div className="flex gap-1">
-            <button
-              onClick={onRealize}
-              className="flex h-7 w-7 items-center justify-center border border-[var(--border)] hover:border-[var(--amber-war)] hover:text-[var(--amber-war)] transition-all"
-              title="Realize ripple"
-            >
-              <LightningBoltIcon className="h-3 w-3" />
-            </button>
-            <button
-              onClick={onDelete}
-              className="flex h-7 w-7 items-center justify-center border border-[var(--border)] hover:border-[var(--signal-red)] hover:text-[var(--signal-red)] transition-all"
-              title="Delete ripple"
-            >
-              <TrashIcon className="h-3 w-3" />
-            </button>
+          <div className="flex items-center gap-2">
+            <span className="mono-label">{dateStr}</span>
+            <div className="flex gap-1">
+              <button
+                onClick={onRealize}
+                className="flex h-7 w-7 items-center justify-center rounded-[var(--radius)] border border-[var(--border)] hover:border-[var(--primary)] hover:text-[var(--primary)] transition-all"
+                title="Realize ripple"
+              >
+                <LightningBoltIcon className="h-3 w-3" />
+              </button>
+              <button
+                onClick={onDelete}
+                className="flex h-7 w-7 items-center justify-center rounded-[var(--radius)] border border-[var(--border)] hover:border-[var(--destructive)] hover:text-[var(--destructive)] transition-all"
+                title="Delete ripple"
+              >
+                <TrashIcon className="h-3 w-3" />
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </AppPageSection>
   );
 }
 
@@ -179,7 +114,7 @@ function NewRipplePanel({ onClose, onCreate }: {
   const [claim, setClaim] = useState("");
   const [reasoning, setReasoning] = useState("");
 
-  useEffect(() => {
+  React.useEffect(() => {
     const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
@@ -187,26 +122,20 @@ function NewRipplePanel({ onClose, onCreate }: {
 
   return (
     <>
-      <div className="fixed inset-0 z-40" style={{ background: "rgba(16,14,15,0.2)" }} onClick={onClose} />
-      <div
-        className="fixed right-0 top-0 bottom-0 z-50 flex flex-col border-l-2 border-[var(--foreground)]"
-        style={{ width: 400, background: "var(--background)" }}
-      >
-        <div className="flex items-center justify-between p-5 border-b-2 border-[var(--foreground)]">
-          <h2 style={{ fontFamily: "'DM Serif Display', serif", fontSize: 24, margin: 0 }}>New Ripple</h2>
-          <button onClick={onClose} className="p-1 hover:bg-[var(--accent)] transition-colors">
+      <div className="fixed inset-0 z-40 bg-[var(--ink-900)]/20" onClick={onClose} />
+      <div className="fixed right-0 top-0 bottom-0 z-50 flex flex-col border-l border-[var(--border)] bg-[var(--background)] w-full max-w-md">
+        <div className="flex items-center justify-between p-5 border-b border-[var(--border)]">
+          <h2 className="h2">New Ripple</h2>
+          <button onClick={onClose} className="p-1 hover:bg-[var(--paper-150)] rounded-[var(--radius)] transition-colors">
             <Cross2Icon className="h-4 w-4" />
           </button>
         </div>
 
         <div className="flex-1 overflow-y-auto p-5 space-y-5">
           <div>
-            <label style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.16em", color: "var(--muted-foreground)", display: "block", marginBottom: 8 }}>
-              Core Claim *
-            </label>
+            <label className="mono-label block mb-2">Core Claim *</label>
             <textarea
-              className="w-full bg-transparent border border-[var(--border)] focus:border-[var(--foreground)] focus:outline-none p-3 resize-none"
-              style={{ fontFamily: "'DM Serif Display', serif", fontSize: 16, color: "var(--foreground)", minHeight: 80 }}
+              className="w-full bg-transparent border border-[var(--border)] focus:border-[var(--primary)] focus:outline-none p-3 resize-none rounded-[var(--radius)] font-display text-base"
               placeholder="State the strategic claim..."
               value={claim}
               onChange={(e) => setClaim(e.target.value)}
@@ -214,12 +143,9 @@ function NewRipplePanel({ onClose, onCreate }: {
             />
           </div>
           <div>
-            <label style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.16em", color: "var(--muted-foreground)", display: "block", marginBottom: 8 }}>
-              Key Reasoning
-            </label>
+            <label className="mono-label block mb-2">Key Reasoning</label>
             <textarea
-              className="w-full bg-transparent border border-[var(--border)] focus:border-[var(--foreground)] focus:outline-none p-3 resize-none"
-              style={{ fontFamily: "'Inter', sans-serif", fontSize: 13, color: "var(--foreground)", minHeight: 100 }}
+              className="w-full bg-transparent border border-[var(--border)] focus:border-[var(--primary)] focus:outline-none p-3 resize-none rounded-[var(--radius)] text-sm"
               placeholder="Why does this claim matter? What evidence supports it?"
               value={reasoning}
               onChange={(e) => setReasoning(e.target.value)}
@@ -228,19 +154,14 @@ function NewRipplePanel({ onClose, onCreate }: {
           </div>
         </div>
 
-        <div className="p-5 border-t-2 border-[var(--foreground)] flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 py-3 border border-[var(--border)] hover:border-[var(--foreground)] transition-all"
-            style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.14em" }}
-          >
+        <div className="p-5 border-t border-[var(--border)] flex gap-3">
+          <button onClick={onClose} className="btn-secondary flex-1">
             Cancel
           </button>
           <button
             onClick={() => { if (claim.trim()) onCreate({ coreClaim: claim, keyReasoning: reasoning }); }}
             disabled={!claim.trim()}
-            className="flex-1 py-3 hover:opacity-80 disabled:opacity-30 transition-all"
-            style={{ background: "var(--foreground)", color: "var(--background)", fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.14em" }}
+            className="btn-primary flex-1 disabled:opacity-30"
           >
             Create Ripple
           </button>
@@ -276,115 +197,92 @@ export default function RipplesPage(): React.ReactElement {
     }, { onSuccess: () => setShowPanel(false) });
   };
 
-  return (
-    <div className="flex flex-col gap-8 py-2">
+  if (isLoading) {
+    return (
+      <AppPageFrame eyebrow="PRL" title="Memory Ripples">
+        <AppLoadingState label="Loading ripples..." />
+      </AppPageFrame>
+    );
+  }
 
-      {/* ── Header ──────────────────────────────────────── */}
-      <header className="flex items-end justify-between border-b-2 border-[var(--foreground)] pb-6">
-        <div>
-          <p style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.2em", color: "var(--muted-foreground)", marginBottom: 8 }}>
-            PRL — Propagated Rationality Log
-          </p>
-          <h1 style={{ fontFamily: "'DM Serif Display', serif", fontSize: 40, lineHeight: 1, margin: 0 }}>
-            Memory Ripples
-          </h1>
-          <p className="mt-2" style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, color: "var(--muted-foreground)", textTransform: "uppercase", letterSpacing: "0.14em" }}>
-            {displayRipples.length} tracked claims
-          </p>
-        </div>
-        <div className="flex gap-2">
+  if (error) {
+    return (
+      <AppPageFrame eyebrow="PRL" title="Memory Ripples">
+        <AppErrorState
+          title="Failed to load ripples"
+          description={error.message}
+        />
+      </AppPageFrame>
+    );
+  }
+
+  return (
+    <AppPageFrame
+      eyebrow="PRL — Propagated Rationality Log"
+      title="Memory Ripples"
+      description={`${displayRipples.length} tracked claims`}
+      actions={
+        <>
           <button
             onClick={() => runDecay.mutate()}
             disabled={runDecay.isPending}
-            className="flex h-10 items-center gap-2 px-4 border border-[var(--border)] hover:border-[var(--foreground)] transition-all"
-            style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.12em", color: "var(--muted-foreground)" }}
+            className="btn-secondary"
           >
-            <ReloadIcon className={`h-3 w-3 ${runDecay.isPending ? "animate-spin" : ""}`} />
+            <ReloadIcon className={cn("h-3 w-3", runDecay.isPending && "animate-spin")} />
             Run Decay
           </button>
-          <button
-            onClick={() => setShowPanel(true)}
-            className="flex h-10 items-center gap-2 px-4 hover:opacity-80 transition-opacity"
-            style={{ background: "var(--foreground)", color: "var(--background)", fontFamily: "'JetBrains Mono', monospace", fontSize: 9, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.12em" }}
-          >
+          <button onClick={() => setShowPanel(true)} className="btn-primary">
             <PlusIcon className="h-3.5 w-3.5" />
             New Ripple
           </button>
-        </div>
-      </header>
-
-      {/* ── Band Filter ──────────────────────────────────── */}
-      <div className="flex gap-0.5 flex-wrap">
+        </>
+      }
+    >
+      <AppPageToolbar>
         {(["all", "protected", "important", "normal", "disposable"] as BandFilter[]).map((b) => {
-          const conf = b !== "all" ? BAND_CONFIG[b] : null;
           const isActive = filter === b;
           return (
             <button
               key={b}
               onClick={() => setFilter(b)}
-              className="px-4 py-2 border transition-all"
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 9,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.12em",
-                background: isActive ? (conf?.color ?? "var(--foreground)") : "transparent",
-                color: isActive ? "var(--background)" : conf?.color ?? "var(--muted-foreground)",
-                borderColor: isActive ? (conf?.color ?? "var(--foreground)") : "var(--border)",
-              }}
+              className={cn(
+                "px-4 py-2 rounded-[var(--radius)] text-[11px] font-mono uppercase tracking-widest transition-all border",
+                isActive
+                  ? "bg-[var(--ink-900)] text-white border-[var(--ink-900)]"
+                  : "bg-transparent text-[var(--ink-500)] border-[var(--border)] hover:border-[var(--ink-400)]",
+              )}
             >
               {b}
             </button>
           );
         })}
-      </div>
-
-      {/* ── Grid ─────────────────────────────────────────── */}
-      {isLoading && (
-        <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <Skeleton key={i} className="h-48 w-full" />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <div className="border border-[var(--signal-red)] p-5" style={{ background: "var(--signal-red-dim, rgba(220,38,38,0.06))" }}>
-          <p style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: 10, color: "var(--signal-red)" }}>
-            FAILED TO LOAD: {error.message}
-          </p>
-        </div>
-      )}
+      </AppPageToolbar>
 
       {!isLoading && filtered.length === 0 && !error && (
-        <EmptyState
-          icon={Activity}
+        <AppEmptyState
+          icon={<Activity className="w-6 h-6 text-[var(--ink-400)]" />}
           title={filter === "all" ? "No ripples yet" : `No ${filter} ripples`}
           description={filter === "all" ? "Create your first ripple to begin tracking." : `No ripples in the ${filter} band.`}
         />
       )}
 
-      {!isLoading && filtered.length > 0 && (
-        <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {filtered.map((ripple: any) => (
-            <RippleCard
-              key={ripple.rippleId}
-              ripple={ripple}
-              onRealize={() => realizeRipple.mutate(ripple.rippleId)}
-              onDelete={() => { if (confirm("Delete this ripple?")) deleteRipple.mutate(ripple.rippleId); }}
-            />
-          ))}
-        </div>
-      )}
+      <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {filtered.map((ripple: any) => (
+          <RippleCard
+            key={ripple.rippleId}
+            ripple={ripple}
+            onRealize={() => realizeRipple.mutate(ripple.rippleId)}
+            onDelete={() => { if (confirm("Delete this ripple?")) deleteRipple.mutate(ripple.rippleId); }}
+          />
+        ))}
+      </div>
 
-      {/* ── Slide-in Panel ───────────────────────────────── */}
       {showPanel && (
         <NewRipplePanel
           onClose={() => setShowPanel(false)}
           onCreate={handleCreate}
         />
       )}
-    </div>
+    </AppPageFrame>
   );
 }

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -6,153 +6,162 @@ import Link from "next/link";
 import { useUser, useOrganization } from "@clerk/nextjs";
 import { GsapBridge } from "@/components/ui/gsap-bridge";
 import { GearIcon, AvatarIcon, Link1Icon, TargetIcon } from "@radix-ui/react-icons";
+import { AppPageFrame } from "@/components/layout/AppPageFrame";
+import { AppPageSection } from "@/components/layout/AppPageSection";
+import { AppLoadingState } from "@/components/layout/AppLoadingState";
+import { StatusPill } from "@/components/windows/StatusPill";
 
 export default function SettingsPage(): React.ReactElement {
   const { user, isLoaded: userLoaded } = useUser();
   const { organization, isLoaded: orgLoaded } = useOrganization();
 
+  if (!userLoaded || !orgLoaded) {
+    return (
+      <AppPageFrame eyebrow="System" title="Settings">
+        <AppLoadingState label="Loading workspace..." />
+      </AppPageFrame>
+    );
+  }
+
   return (
-    <div className="min-h-[calc(100vh-theme(spacing.16))] bg-[var(--background)] px-6 py-12 md:px-12 font-body">
-      <GsapBridge stagger={true} className="mx-auto max-w-[1200px] flex flex-col md:flex-row gap-12">
-        <aside className="gsap-reveal w-full md:w-64 shrink-0">
-          <h1 className="font-[family-name:var(--font-display)] text-5xl mb-8">Settings</h1>
-          <nav className="flex flex-col space-y-2 font-mono text-xs uppercase tracking-widest">
-            <Link href={"/settings" as Route} className="flex items-center gap-3 bg-[var(--primary)] text-[var(--primary-foreground)] px-4 py-3">
+    <AppPageFrame
+      eyebrow="System"
+      title="Settings"
+      description="Workspace configuration and account management."
+      maxWidth="wide"
+    >
+      <GsapBridge stagger={true} className="flex flex-col lg:flex-row gap-8">
+        {/* Settings nav rail */}
+        <aside className="gsap-reveal w-full lg:w-56 shrink-0">
+          <nav className="flex flex-col space-y-1 font-mono text-xs uppercase tracking-widest">
+            <Link
+              href={"/settings" as Route}
+              className="flex items-center gap-3 bg-[var(--primary)] text-[var(--primary-foreground)] px-4 py-3 rounded-[var(--radius)]"
+            >
               <GearIcon className="h-4 w-4" /> Workspace
             </Link>
-            <Link href={"/foundation" as Route} className="flex items-center gap-3 hover:bg-[var(--accent)] text-[var(--foreground)] px-4 py-3 transition-colors">
+            <Link
+              href={"/foundation" as Route}
+              className="flex items-center gap-3 hover:bg-[var(--paper-150)] text-[var(--foreground)] px-4 py-3 rounded-[var(--radius)] transition-colors"
+            >
               <TargetIcon className="h-4 w-4" /> Onboarding
             </Link>
-            <button className="flex items-center gap-3 hover:bg-[var(--accent)] text-[var(--foreground)] px-4 py-3 transition-colors text-left">
+            <button className="flex items-center gap-3 hover:bg-[var(--paper-150)] text-[var(--foreground)] px-4 py-3 rounded-[var(--radius)] transition-colors text-left opacity-50 cursor-not-allowed">
               <AvatarIcon className="h-4 w-4" /> Team Access
             </button>
-            <button className="flex items-center gap-3 hover:bg-[var(--accent)] text-[var(--foreground)] px-4 py-3 transition-colors text-left">
+            <button className="flex items-center gap-3 hover:bg-[var(--paper-150)] text-[var(--foreground)] px-4 py-3 rounded-[var(--radius)] transition-colors text-left opacity-50 cursor-not-allowed">
               <Link1Icon className="h-4 w-4" /> Integrations
             </button>
           </nav>
         </aside>
 
-        <div className="flex-1 space-y-16">
-          <section className="gsap-reveal border-t-2 border-[var(--foreground)] pt-6">
-            <h2 className="font-mono text-xs uppercase tracking-widest text-[var(--muted-foreground)] mb-8">Organization Profile</h2>
-
-            <div className="grid md:grid-cols-2 gap-12">
-              <div className="space-y-4">
-                <label className="font-mono text-[10px] uppercase tracking-widest block text-[var(--muted-foreground)]">Workspace Name</label>
+        <div className="flex-1 space-y-8">
+          <AppPageSection title="Organization Profile">
+            <div className="grid md:grid-cols-2 gap-8">
+              <div className="space-y-3">
+                <label className="mono-label">Workspace Name</label>
                 <input
                   type="text"
                   defaultValue={organization?.name || "RaptorFlow Workspace"}
-                  className="w-full bg-transparent border-b border-[var(--border)] focus:border-[var(--primary)] outline-none py-2 font-[family-name:var(--font-display)] text-2xl transition-colors"
+                  className="w-full bg-transparent border-b border-[var(--border)] focus:border-[var(--primary)] outline-none py-2 font-display text-2xl transition-colors"
                 />
               </div>
-              <div className="space-y-4">
-                <label className="font-mono text-[10px] uppercase tracking-widest block text-[var(--muted-foreground)]">Workspace ID</label>
-                <div className="py-2 text-sm font-mono text-[var(--muted-foreground)]">{organization?.id || "org_pending"}</div>
+              <div className="space-y-3">
+                <label className="mono-label">Workspace ID</label>
+                <div className="py-2 text-sm font-mono text-[var(--ink-400)]">{organization?.id || "org_pending"}</div>
               </div>
             </div>
 
-            <div className="mt-8 flex items-center gap-4">
+            <div className="mt-6 flex items-center gap-4">
               <button
                 disabled
                 title="Workspace name changes are managed via the Clerk dashboard"
-                className="bg-[var(--primary)] text-[var(--primary-foreground)] px-8 h-12 font-mono text-xs uppercase tracking-widest opacity-40 cursor-not-allowed"
+                className="btn-primary opacity-40 cursor-not-allowed"
               >
                 Save Changes
               </button>
-              <p className="text-xs font-mono text-[var(--muted-foreground)]">
+              <p className="text-xs font-mono text-[var(--ink-400)]">
                 Org name is managed via{" "}
-                <a href="https://dashboard.clerk.com" target="_blank" rel="noreferrer" className="underline hover:text-[var(--foreground)] transition-colors">
+                <a href="https://dashboard.clerk.com" target="_blank" rel="noreferrer" className="underline hover:text-[var(--ink-900)] transition-colors">
                   Clerk Dashboard
                 </a>
               </p>
             </div>
-          </section>
+          </AppPageSection>
 
-          <section className="gsap-reveal border-t border-[var(--border)] pt-6">
-            <h2 className="font-mono text-xs uppercase tracking-widest text-[var(--muted-foreground)] mb-8">
-              Access Status
-            </h2>
-            <div className="border border-[var(--border)] bg-[var(--card)] p-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <AppPageSection title="Access Status">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div>
-                <p className="font-[family-name:var(--font-display)] text-2xl">
-                  {orgLoaded && organization ? organization.name : "Workspace access"}
+                <p className="font-display text-2xl">
+                  {organization ? organization.name : "Workspace access"}
                 </p>
-                <p className="text-sm text-[var(--muted-foreground)]">
+                <p className="text-sm text-[var(--ink-500)]">
                   {organization
                     ? "Access is granted after Clerk sign-in. No paywall or unlock step is required."
                     : "Loading workspace access status from Clerk."}
                 </p>
               </div>
-              <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-[var(--muted-foreground)]">
-                Status: active
-              </div>
+              <StatusPill status="Active" tone="success" />
             </div>
-          </section>
+          </AppPageSection>
 
-          <section className="gsap-reveal border-t border-[var(--border)] pt-6">
-            <h2 className="font-mono text-xs uppercase tracking-widest text-[var(--muted-foreground)] mb-8">
-              Onboarding
-            </h2>
-            <div className="border border-[var(--border)] bg-[var(--card)] p-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <AppPageSection title="Onboarding">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div>
-                <p className="font-[family-name:var(--font-display)] text-2xl">Foundation flow</p>
-                <p className="text-sm text-[var(--muted-foreground)]">
+                <p className="font-display text-2xl">Foundation flow</p>
+                <p className="text-sm text-[var(--ink-500)]">
                   Open the guided onboarding whenever you want. It is no longer forced on login.
                 </p>
               </div>
               <Link
                 href={"/foundation" as Route}
-                className="inline-flex items-center justify-center border border-[var(--border)] px-6 h-12 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-[var(--accent)]"
+                className="btn-secondary"
               >
                 Start onboarding
               </Link>
             </div>
-          </section>
+          </AppPageSection>
 
-          <section className="gsap-reveal border-t border-[var(--border)] pt-6">
-            <h2 className="font-mono text-xs uppercase tracking-widest text-[var(--muted-foreground)] mb-8">Personal Account</h2>
-
-            <div className="bg-[var(--card)] border border-[var(--border)] p-6 flex flex-col md:flex-row items-center gap-8">
-              {userLoaded && user ? (
+          <AppPageSection title="Personal Account">
+            <div className="flex flex-col md:flex-row items-center gap-6">
+              {user ? (
                 <>
                   {user.imageUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
-                    <img src={user.imageUrl} alt={user.fullName ?? "User"} className="h-20 w-20 grayscale border border-[var(--border)]" />
+                    <img src={user.imageUrl} alt={user.fullName ?? "User"} className="h-16 w-16 rounded-[var(--radius)] grayscale border border-[var(--border)]" />
                   ) : (
-                    <div className="h-20 w-20 bg-[var(--accent)] border border-[var(--border)] flex items-center justify-center font-[family-name:var(--font-display)] text-2xl text-[var(--muted-foreground)]">
+                    <div className="h-16 w-16 rounded-[var(--radius)] bg-[var(--paper-150)] border border-[var(--border)] flex items-center justify-center font-display text-2xl text-[var(--ink-400)]">
                       {user.fullName?.charAt(0) || "U"}
                     </div>
                   )}
                   <div className="flex-1 text-center md:text-left">
-                    <h3 className="font-[family-name:var(--font-display)] text-2xl mb-1">{user.fullName ?? "Unknown"}</h3>
-                    <p className="font-mono text-xs text-[var(--muted-foreground)]">{user.primaryEmailAddress?.emailAddress}</p>
+                    <h3 className="font-display text-xl mb-0.5">{user.fullName ?? "Unknown"}</h3>
+                    <p className="font-mono text-xs text-[var(--ink-400)]">{user.primaryEmailAddress?.emailAddress}</p>
                   </div>
                 </>
               ) : (
-                <div className="h-20 w-full animate-pulse bg-[var(--muted)]" />
+                <div className="h-16 w-full animate-pulse bg-[var(--paper-200)] rounded-[var(--radius)]" />
               )}
 
-              <button className="border border-[var(--border)] bg-transparent hover:bg-[var(--accent)] px-6 h-10 font-mono text-[10px] uppercase tracking-widest transition-colors">
+              <button className="btn-secondary">
                 Manage Auth
               </button>
             </div>
-          </section>
+          </AppPageSection>
 
-          <section className="gsap-reveal border-t border-[var(--border)] pt-6">
-            <h2 className="font-mono text-xs uppercase tracking-widest text-[var(--destructive)] mb-8">Danger Zone</h2>
-
-            <div className="border border-[var(--destructive)] bg-[var(--destructive)]/5 p-6 md:p-8">
-              <h3 className="font-[family-name:var(--font-display)] text-2xl mb-2 text-[var(--destructive)]">Erase Workspace</h3>
-              <p className="text-[var(--muted-foreground)] text-sm mb-6 max-w-xl">
+          <AppPageSection title="Danger Zone" variant="danger">
+            <div className="flex flex-col gap-4">
+              <h3 className="font-display text-2xl text-[var(--destructive)]">Erase Workspace</h3>
+              <p className="text-[var(--ink-500)] text-sm max-w-xl">
                 This will permanently destroy the foundation, council logs, active campaigns, and intelligence streams. This action cannot be undone.
               </p>
-              <button className="bg-[var(--destructive)] text-[var(--destructive-foreground)] px-8 h-12 font-mono text-[10px] uppercase tracking-widest hover:bg-[var(--destructive)]/90 transition-opacity">
+              <button className="btn-primary bg-[var(--destructive)] hover:bg-[var(--destructive)]/90 w-fit">
                 Acknowledge and Delete
               </button>
             </div>
-          </section>
+          </AppPageSection>
         </div>
       </GsapBridge>
-    </div>
+    </AppPageFrame>
   );
 }

--- a/apps/web/src/app/(app)/uploads/page.tsx
+++ b/apps/web/src/app/(app)/uploads/page.tsx
@@ -7,6 +7,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { GsapBridge } from "@/components/ui/gsap-bridge";
 import { useGenerateUploadUrl, uploadFile } from "@/hooks/use-uploads";
+import { AppPageFrame } from "@/components/layout/AppPageFrame";
+import { AppPageSection } from "@/components/layout/AppPageSection";
+import { AppEmptyState } from "@/components/layout/AppEmptyState";
 
 export default function UploadsPage(): React.ReactElement {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -47,83 +50,65 @@ export default function UploadsPage(): React.ReactElement {
   };
 
   return (
-    <div className="flex flex-col gap-6 py-2">
-      <GsapBridge stagger={true}>
-        <header className="gsap-reveal flex items-end justify-between border-b-2 border-[var(--foreground)] pb-8">
-          <div>
-            <p
-              style={{
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: 9,
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.2em",
-                color: "var(--muted-foreground)",
-                marginBottom: 8,
-              }}
-            >
-              Asset Repository // Live Uploads
-            </p>
-            <h1 style={{ fontFamily: "'DM Serif Display', serif", fontSize: 40, lineHeight: 1, margin: 0 }}>
-              Uploads
-            </h1>
+    <AppPageFrame
+      eyebrow="Asset Repository"
+      title="Uploads"
+      description="S3-backed file uploads through the live backend."
+    >
+      <GsapBridge stagger={true} className="space-y-6">
+        <AppPageSection>
+          <div
+            onDragOver={(event) => {
+              event.preventDefault();
+              setDropActive(true);
+            }}
+            onDragLeave={() => setDropActive(false)}
+            onDrop={handleDrop}
+            className={cn(
+              "border-2 border-dashed p-12 flex flex-col items-center justify-center gap-4 transition-all duration-300 rounded-[var(--radius-lg)]",
+              dropActive
+                ? "border-[var(--primary)] bg-[var(--amber-wash)]"
+                : "border-[var(--border)] bg-[var(--paper-50)] hover:border-[var(--paper-400)]",
+            )}
+          >
+            <div className={cn(
+              "w-12 h-12 rounded-full border flex items-center justify-center transition-colors",
+              dropActive ? "border-[var(--primary)] bg-[var(--amber-wash)]" : "border-[var(--border)] bg-[var(--paper-150)]",
+            )}>
+              <UploadIcon className={cn("w-6 h-6", dropActive ? "text-[var(--primary)]" : "text-[var(--ink-400)]")} />
+            </div>
+            <div className="text-center space-y-2">
+              <p className="text-[var(--ink-900)] font-medium text-sm uppercase tracking-tight">
+                Drop an asset here or choose a file
+              </p>
+              <p className="text-[var(--ink-400)] text-[10px] font-mono uppercase tracking-widest">
+                S3-backed upload through the live backend
+              </p>
+              <input
+                type="file"
+                className="mx-auto block text-xs"
+                onChange={(event) => handleFile(event.target.files?.[0] ?? null)}
+              />
+            </div>
           </div>
-        </header>
+        </AppPageSection>
 
-        <div
-          onDragOver={(event) => {
-            event.preventDefault();
-            setDropActive(true);
-          }}
-          onDragLeave={() => setDropActive(false)}
-          onDrop={handleDrop}
-          className={`gsap-reveal border-2 border-dashed p-12 flex flex-col items-center justify-center gap-4 transition-all duration-300 ${
-            dropActive ? "border-[#D97757] bg-[#FBE9DE]" : "border-[#E5DED4] bg-[#F5F0E8]/20 hover:border-[#D5CBC0]"
-          }`}
-        >
-          <div className="w-12 h-12 rounded-full border border-[#E5DED4] flex items-center justify-center bg-[#F5F0E8]">
-            <UploadIcon className={dropActive ? "w-6 h-6 text-[#D97757]" : "w-6 h-6 text-[#9A948C]"} />
-          </div>
-          <div className="text-center space-y-2">
-            <p className="text-[#2A2622] font-medium text-sm uppercase tracking-tight">
-              Drop an asset here or choose a file
-            </p>
-            <p className="text-[#9A948C] text-[10px] font-mono uppercase tracking-widest">
-              S3-backed upload through the live backend
-            </p>
-            <input
-              type="file"
-              className="mx-auto block text-xs"
-              onChange={(event) => handleFile(event.target.files?.[0] ?? null)}
-            />
-          </div>
-        </div>
-
-        <Card className="gsap-reveal">
-          <CardHeader>
-            <CardTitle className="text-base">Upload status</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-[var(--muted-foreground)]">
+        <AppPageSection title="Upload status">
+          <div className="space-y-3">
+            <p className="text-sm text-[var(--ink-500)]">
               {selectedFile ? `Selected: ${selectedFile.name}` : "No file selected yet."}
             </p>
             {status && <p className="text-sm">{status}</p>}
             <Button onClick={handleUpload} disabled={!selectedFile || uploading || generateUploadUrl.isPending}>
-              {uploading || generateUploadUrl.isPending ? "Uploading…" : "Upload file"}
+              {uploading || generateUploadUrl.isPending ? "Uploading..." : "Upload file"}
             </Button>
-          </CardContent>
-        </Card>
-
-        <Card className="gsap-reveal border-amber-200 bg-amber-50/50">
-          <CardHeader>
-            <CardTitle className="text-base">What this page does now</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm text-amber-800">
-            <p>This page now generates a presigned S3 upload URL and sends the file directly to storage.</p>
-            <p>Asset listing remains backend-driven; do not reintroduce local mock ledgers here.</p>
-          </CardContent>
-        </Card>
+          </div>
+        </AppPageSection>
       </GsapBridge>
-    </div>
+    </AppPageFrame>
   );
+}
+
+function cn(...classes: (string | false | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
 }

--- a/apps/web/src/brand/README.md
+++ b/apps/web/src/brand/README.md
@@ -116,6 +116,62 @@ Respect `prefers-reduced-motion`. Do not add heavy animation libraries.
 - `RfWindowGrid` stacks gracefully: 1 col mobile, expands at `sm`/`lg` breakpoints.
 - Sidebar is fixed on desktop, slide-over on mobile.
 
+## App Shell Usage
+
+### AppPageFrame
+
+Standard page wrapper. Use on every page.
+
+```tsx
+import { AppPageFrame } from "@/components/layout";
+
+<AppPageFrame
+  eyebrow="Section"
+  title="Page Title"
+  description="Optional description."
+  actions={<button className="btn-primary">Action</button>}
+  maxWidth="wide"
+>
+  Content here
+</AppPageFrame>;
+```
+
+### AppPageSection
+
+Use for content sections within a page.
+
+```tsx
+import { AppPageSection } from "@/components/layout";
+
+<AppPageSection title="Section" variant="quiet">
+  Section content
+</AppPageSection>;
+```
+
+### Loading / Empty / Error States
+
+```tsx
+import { AppLoadingState, AppEmptyState, AppErrorState } from "@/components/layout";
+
+// While loading
+<AppLoadingState label="Loading..." />
+
+// When empty
+<AppEmptyState
+  icon={<FileText className="w-6 h-6" />}
+  title="Nothing here"
+  description="Get started by creating something."
+  action={<button className="btn-primary">Create</button>}
+/>
+
+// On error
+<AppErrorState
+  title="Failed to load"
+  description={error.message}
+  action={<button onClick={refetch}>Retry</button>}
+/>
+```
+
 ## What NOT to Do
 
 - Do NOT use dark glass as the default product UI.

--- a/apps/web/src/brand/README.md
+++ b/apps/web/src/brand/README.md
@@ -1,0 +1,128 @@
+# RaptorFlow Brand System
+
+## Visual Identity
+
+RaptorFlow uses a **Paper / Amber / Editorial SaaS** identity.
+
+The product should feel like:
+
+- Premium founder operating desk
+- Paper ledger
+- Strategic command journal
+- Warm B2B SaaS
+- Sharp, editorial, senior, operational
+- Calm but powerful
+
+## Asset Drop Locations
+
+Place final assets here:
+
+| Asset                  | Path                                         | Status      |
+| ---------------------- | -------------------------------------------- | ----------- |
+| Full logo              | `public/brand/logo-full.svg`                 | Placeholder |
+| Logo mark              | `public/brand/logo-mark.svg`                 | Placeholder |
+| Favicon                | `public/brand/favicon.svg`                   | Placeholder |
+| Apple touch icon       | `public/brand/apple-touch-icon.png`          | TBD         |
+| OG image               | `public/brand/og-image.png`                  | TBD         |
+| Paper grain (standard) | `public/brand/textures/paper-grain.svg`      | TBD         |
+| Paper grain (soft)     | `public/brand/textures/paper-grain-soft.svg` | TBD         |
+
+## How to Use `RaptorFlowLogo`
+
+```tsx
+import { RaptorFlowLogo } from "@/components/brand";
+
+// Full logo with asset fallback
+<RaptorFlowLogo size="md" variant="full" />
+
+// Mark only
+<RaptorFlowLogo size="sm" variant="mark" />
+
+// Wordmark only
+<RaptorFlowLogo size="lg" variant="wordmark" />
+```
+
+- `size`: `"sm" | "md" | "lg"`
+- `variant`: `"full" | "mark" | "wordmark"`
+- Falls back gracefully if `public/brand/logo-full.svg` is missing.
+
+## How to Use `RfWindow`
+
+```tsx
+import { RfWindow, RfWindowGrid } from "@/components/windows";
+
+<RfWindow
+  eyebrow="Section"
+  title="Window Title"
+  description="Optional description."
+  variant="default"
+  density="comfortable"
+>
+  Content here
+</RfWindow>;
+```
+
+Variants: `default` | `highlight` | `quiet` | `danger`
+Density: `comfortable` | `compact`
+
+Grid wrapper:
+
+```tsx
+<RfWindowGrid columns={3}>
+  <RfWindow>...</RfWindow>
+  <RfWindow>...</RfWindow>
+</RfWindowGrid>
+```
+
+## Color Usage Rules
+
+| Color                     | Usage                                     |
+| ------------------------- | ----------------------------------------- |
+| **Amber**                 | Strategic action, highlight, primary CTAs |
+| **Ink**                   | Primary text, headings, body              |
+| **Paper**                 | Surfaces, backgrounds, cards              |
+| **Crimson / Destructive** | Errors, risk, deletion, danger ONLY       |
+| **Leaf**                  | Success, confirmed, completed             |
+| **Indigo**                | Reserved for Muse                         |
+
+## Typography Rules
+
+| Token                  | Use                                       |
+| ---------------------- | ----------------------------------------- |
+| `font-display` (Serif) | Headlines, display text, hero lines       |
+| `font-sans`            | UI text, body, labels                     |
+| `font-mono`            | Metadata, status, system labels, eyebrows |
+
+## Motion Rules
+
+| Duration | Use                              |
+| -------- | -------------------------------- |
+| 150ms    | Hover states, micro-interactions |
+| 240ms    | Card lifts, transitions          |
+| 700ms    | Page enters, reveals             |
+
+Respect `prefers-reduced-motion`. Do not add heavy animation libraries.
+
+## Accessibility Rules
+
+- All interactive elements have visible focus rings (`outline-color: var(--ring)`).
+- Images have alt text.
+- SignalDot accepts an optional `label` for screen readers.
+- Color is never the sole indicator of state (pair with text/icons).
+
+## Responsive Design Rules
+
+- Mobile-first.
+- `RfWindowGrid` stacks gracefully: 1 col mobile, expands at `sm`/`lg` breakpoints.
+- Sidebar is fixed on desktop, slide-over on mobile.
+
+## What NOT to Do
+
+- Do NOT use dark glass as the default product UI.
+- Do NOT use neon overload.
+- Do NOT use fake hologram vibes.
+- Do NOT use random gradients everywhere.
+- Do NOT use random inline colours.
+- Do NOT use one-off page-specific styling.
+- Do NOT scatter logo usage — use `RaptorFlowLogo` everywhere.
+- Do NOT use a literal bird, mascot, or claw scratches in the mark.

--- a/apps/web/src/brand/copy.ts
+++ b/apps/web/src/brand/copy.ts
@@ -1,0 +1,32 @@
+/**
+ * RaptorFlow Canonical Product Copy
+ *
+ * Single source of truth for product names, taglines, and positioning.
+ * Keep copy tight. No hype paragraphs.
+ */
+
+export const copy = {
+  productName: "RaptorFlow",
+
+  // Section titles
+  officeTitle: "The Office",
+  officeTagline: "Where campaigns become moves.",
+  councilTitle: "Council War Room",
+  campaignsTitle: "Campaigns",
+  contentTitle: "Content Ledger",
+  foundationTitle: "Foundation",
+  museTitle: "Muse",
+  ripplesTitle: "Ripples",
+
+  // Hero / positioning
+  primaryHeroLine: "The office where campaigns become moves.",
+  shortPositioning:
+    "AI-native marketing operating system for founders who need strategy turned into execution.",
+
+  // System labels
+  dailyWinsTitle: "Daily Wins",
+  intelTitle: "Intel",
+  nudgesTitle: "Nudges",
+  uploadsTitle: "Uploads",
+  settingsTitle: "Settings",
+} as const;

--- a/apps/web/src/brand/index.ts
+++ b/apps/web/src/brand/index.ts
@@ -1,0 +1,10 @@
+/**
+ * RaptorFlow Brand System — Barrel Export
+ *
+ * Import from `@/brand` to access canonical tokens, copy, motion, and routes.
+ */
+
+export * from "./tokens";
+export * from "./copy";
+export * from "./motion";
+export * from "./routes";

--- a/apps/web/src/brand/motion.ts
+++ b/apps/web/src/brand/motion.ts
@@ -1,0 +1,48 @@
+/**
+ * RaptorFlow Motion Constants
+ *
+ * Standard motion values aligned with globals.css.
+ * Do not add heavy animation libraries in this phase.
+ * Use existing CSS / Tailwind motion utilities.
+ */
+
+export const motion = {
+  // Durations (ms)
+  fast: 150,
+  medium: 240,
+  slow: 700,
+
+  // Easing curves
+  easeOut: "cubic-bezier(0.16, 1, 0.3, 1)",
+  easeSoft: "cubic-bezier(0.4, 0, 0.2, 1)",
+  easeInOut: "cubic-bezier(0.65, 0, 0.35, 1)",
+
+  // CSS class names for common transitions
+  hoverLift: {
+    transition:
+      "transform 240ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 240ms cubic-bezier(0.4, 0, 0.2, 1)",
+    hoverTransform: "translateY(-2px)",
+  },
+
+  windowEnter: {
+    transition:
+      "opacity 700ms cubic-bezier(0.16, 1, 0.3, 1), transform 700ms cubic-bezier(0.16, 1, 0.3, 1)",
+    initial: { opacity: 0, transform: "translateY(16px)" },
+    final: { opacity: 1, transform: "translateY(0)" },
+  },
+
+  amberPulse: {
+    animation: "amberPulse 2.4s cubic-bezier(0.4, 0, 0.2, 1) infinite",
+  },
+} as const;
+
+/**
+ * Reduced-motion helper.
+ * Returns the given style object only when motion is not reduced.
+ * In component usage, prefer CSS `@media (prefers-reduced-motion: reduce)`.
+ */
+export function withMotion<T extends object>(style: T, reduced?: T): T {
+  if (typeof window === "undefined") return style;
+  const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  return prefersReduced ? (reduced ?? ({} as T)) : style;
+}

--- a/apps/web/src/brand/routes.ts
+++ b/apps/web/src/brand/routes.ts
@@ -1,0 +1,125 @@
+/**
+ * RaptorFlow Canonical Route Metadata
+ *
+ * Single source of truth for app route labels, grouping, and descriptions.
+ * Do not alter Next.js routing behavior here. This is metadata only.
+ */
+
+export interface RouteMeta {
+  href: string;
+  label: string;
+  shortLabel: string;
+  group: "workspace" | "intelligence" | "strategy" | "system";
+  description: string;
+}
+
+export const routes: Record<string, RouteMeta> = {
+  dashboard: {
+    href: "/app/dashboard",
+    label: "Dashboard",
+    shortLabel: "Dash",
+    group: "workspace",
+    description: "Your daily briefing and operational overview.",
+  },
+  office: {
+    href: "/office",
+    label: "The Office",
+    shortLabel: "Office",
+    group: "workspace",
+    description: "Where campaigns become moves.",
+  },
+  campaigns: {
+    href: "/campaigns",
+    label: "Campaigns",
+    shortLabel: "Campaigns",
+    group: "strategy",
+    description: "Active marketing campaigns and moves.",
+  },
+  council: {
+    href: "/council",
+    label: "Council",
+    shortLabel: "Council",
+    group: "strategy",
+    description: "Strategic council war room sessions.",
+  },
+  muse: {
+    href: "/muse",
+    label: "Muse",
+    shortLabel: "Muse",
+    group: "strategy",
+    description: "AI creative partner and ideation.",
+  },
+  content: {
+    href: "/content",
+    label: "Content",
+    shortLabel: "Content",
+    group: "strategy",
+    description: "Content ledger and editorial pipeline.",
+  },
+  foundation: {
+    href: "/foundation",
+    label: "Foundation",
+    shortLabel: "Foundation",
+    group: "system",
+    description: "Brand positioning and foundation data.",
+  },
+  intel: {
+    href: "/intel",
+    label: "Intel",
+    shortLabel: "Intel",
+    group: "intelligence",
+    description: "Market signals and intelligence feed.",
+  },
+  nudges: {
+    href: "/nudges",
+    label: "Nudges",
+    shortLabel: "Nudges",
+    group: "intelligence",
+    description: "Actionable nudges and alerts.",
+  },
+  ripples: {
+    href: "/ripples",
+    label: "Ripples",
+    shortLabel: "Ripples",
+    group: "intelligence",
+    description: "Impact tracking and ripple effects.",
+  },
+  uploads: {
+    href: "/uploads",
+    label: "Uploads",
+    shortLabel: "Uploads",
+    group: "workspace",
+    description: "File uploads and asset management.",
+  },
+  settings: {
+    href: "/settings",
+    label: "Settings",
+    shortLabel: "Settings",
+    group: "system",
+    description: "Account and workspace settings.",
+  },
+} as const;
+
+/** Ordered groups for navigation rendering. */
+export const routeGroups = [
+  {
+    key: "workspace" as const,
+    label: "Workspace",
+    routes: [routes.dashboard, routes.office, routes.uploads],
+  },
+  {
+    key: "intelligence" as const,
+    label: "Intelligence",
+    routes: [routes.intel, routes.nudges, routes.ripples],
+  },
+  {
+    key: "strategy" as const,
+    label: "Strategy",
+    routes: [routes.campaigns, routes.council, routes.muse, routes.content],
+  },
+  {
+    key: "system" as const,
+    label: "System",
+    routes: [routes.foundation, routes.settings],
+  },
+];

--- a/apps/web/src/brand/tokens.ts
+++ b/apps/web/src/brand/tokens.ts
@@ -1,0 +1,131 @@
+/**
+ * RaptorFlow Brand Tokens
+ *
+ * TypeScript mirrors of the CSS design system defined in globals.css.
+ * Do not create a parallel theme that fights the CSS. These are canonical
+ * references for use in components when JS-level access is needed.
+ */
+
+export const colors = {
+  // Paper surfaces
+  paper50: "#faf7f1",
+  paper100: "#fbf8f2",
+  paper150: "#f5f1e8",
+  paper200: "#efe9dc",
+  paper300: "#e6dfce",
+  paper400: "#c9c0ab",
+
+  // Ink scale
+  ink900: "#2a2622",
+  ink700: "#4a433c",
+  ink500: "#7a7268",
+  ink400: "#9c9384",
+  ink300: "#bab0a0",
+
+  // Amber primary
+  amber: "#d97757",
+  amberHover: "#c26645",
+  amberWash: "#fbe9de",
+  amberStroke: "#e89878",
+
+  // Semantic
+  leaf: "#5c8a5a",
+  leafWash: "#e8f0e5",
+  indigoMuse: "#5b5fb8",
+  indigoWash: "#e8e9f4",
+  destructive: "#c44a3f",
+  destructiveWash: "#fbeae7",
+
+  // Pod colors
+  podCreative: "#8b6fc2",
+  podDigital: "#4f87b8",
+  podStrategy: "#b8556b",
+  podSupport: "#c26f4a",
+  podStrategist: "#4a433c",
+} as const;
+
+export const typography = {
+  display: '"Instrument Serif", "DM Serif Display", ui-serif, serif',
+  sans: '"DM Sans", "Inter", ui-sans-serif, system-ui, sans-serif',
+  mono: '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace',
+} as const;
+
+export const radii = {
+  xs: "4px",
+  sm: "6px",
+  md: "10px",
+  lg: "12px",
+  xl: "16px",
+  "2xl": "20px",
+  pill: "9999px",
+} as const;
+
+export const shadows = {
+  xs: "0 1px 2px rgba(42, 38, 34, 0.04)",
+  sm: "0 1px 2px rgba(42, 38, 34, 0.05), 0 1px 3px rgba(42, 38, 34, 0.04)",
+  md: "0 2px 4px rgba(42, 38, 34, 0.04), 0 4px 12px rgba(42, 38, 34, 0.06)",
+  lg: "0 4px 8px rgba(42, 38, 34, 0.04), 0 12px 32px rgba(42, 38, 34, 0.08)",
+  amber: "0 0 0 3px rgba(217, 119, 87, 0.15), 0 6px 18px -6px rgba(217, 119, 87, 0.3)",
+  inset: "inset 0 1px 0 rgba(255, 255, 255, 0.6)",
+} as const;
+
+export const spacing = {
+  px: "1px",
+  0.5: "0.125rem",
+  1: "0.25rem",
+  1.5: "0.375rem",
+  2: "0.5rem",
+  2.5: "0.625rem",
+  3: "0.75rem",
+  3.5: "0.875rem",
+  4: "1rem",
+  5: "1.25rem",
+  6: "1.5rem",
+  7: "1.75rem",
+  8: "2rem",
+  9: "2.25rem",
+  10: "2.5rem",
+  12: "3rem",
+  14: "3.5rem",
+  16: "4rem",
+  20: "5rem",
+  24: "6rem",
+  28: "7rem",
+  32: "8rem",
+} as const;
+
+export const zIndex = {
+  base: 0,
+  dropdown: 50,
+  sticky: 100,
+  fixed: 200,
+  overlay: 300,
+  modal: 400,
+  popover: 500,
+  toast: 600,
+  tooltip: 700,
+} as const;
+
+export const semantic = {
+  // Surfaces
+  background: colors.paper100,
+  card: "#ffffff",
+  sidebar: colors.paper50,
+  muted: colors.paper150,
+
+  // Text
+  foreground: colors.ink900,
+  primaryText: colors.ink900,
+  secondaryText: colors.ink700,
+  mutedText: colors.ink500,
+  hintText: colors.ink400,
+
+  // Action
+  primary: colors.amber,
+  primaryHover: colors.amberHover,
+  ring: colors.amber,
+
+  // Borders
+  border: colors.paper300,
+  borderStrong: colors.paper400,
+} as const;

--- a/apps/web/src/components/brand/BrandHeader.tsx
+++ b/apps/web/src/components/brand/BrandHeader.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface BrandHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  status?: React.ReactNode;
+  actions?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export function BrandHeader({
+  eyebrow,
+  title,
+  description,
+  status,
+  actions,
+  children,
+  className,
+}: BrandHeaderProps) {
+  return (
+    <div className={cn("mb-8", className)}>
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          {eyebrow && (
+            <div className="flex items-center gap-3 mb-3">
+              <span className="eyebrow">{eyebrow}</span>
+              <span className="h-px flex-1 bg-[var(--border)]" />
+            </div>
+          )}
+          <h1 className="h1">{title}</h1>
+          {description && <p className="body-muted mt-2 max-w-xl">{description}</p>}
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {status && <div>{status}</div>}
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </div>
+      </div>
+      {children && <div className="mt-6">{children}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/brand/BrandWordmark.tsx
+++ b/apps/web/src/components/brand/BrandWordmark.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface BrandWordmarkProps {
+  size?: number;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function BrandWordmark({
+  size = 120,
+  className,
+  "aria-label": ariaLabel = "RaptorFlow",
+}: BrandWordmarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size * 0.25}
+      viewBox="0 0 200 40"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("shrink-0", className)}
+      aria-label={ariaLabel}
+      role="img"
+    >
+      <text
+        x="0"
+        y="28"
+        fontFamily="'Instrument Serif', 'DM Serif Display', ui-serif, serif"
+        fontSize="28"
+        fill="currentColor"
+        letterSpacing="-0.02em"
+        className="text-[#2a2622]"
+      >
+        RaptorFlow
+      </text>
+      <circle cx="188" cy="20" r="5" fill="#d97757" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/brand/PaperTexture.tsx
+++ b/apps/web/src/components/brand/PaperTexture.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface PaperTextureProps {
+  children: React.ReactNode;
+  intensity?: "none" | "soft" | "standard";
+  className?: string;
+}
+
+export function PaperTexture({ children, intensity = "soft", className }: PaperTextureProps) {
+  const textureClass = intensity === "none" ? "" : intensity === "soft" ? "paper-soft" : "paper";
+
+  return <div className={cn(textureClass, className)}>{children}</div>;
+}

--- a/apps/web/src/components/brand/RaptorFlowLogo.tsx
+++ b/apps/web/src/components/brand/RaptorFlowLogo.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+import { cn } from "@/lib/cn";
+import { RaptorMark } from "./RaptorMark";
+import { BrandWordmark } from "./BrandWordmark";
+
+export type LogoSize = "sm" | "md" | "lg";
+export type LogoVariant = "full" | "mark" | "wordmark";
+
+interface RaptorFlowLogoProps {
+  size?: LogoSize;
+  variant?: LogoVariant;
+  className?: string;
+}
+
+const sizeMap: Record<LogoSize, { mark: number; wordmark: number }> = {
+  sm: { mark: 24, wordmark: 80 },
+  md: { mark: 32, wordmark: 120 },
+  lg: { mark: 40, wordmark: 160 },
+};
+
+export function RaptorFlowLogo({ size = "md", variant = "full", className }: RaptorFlowLogoProps) {
+  const { mark: markSize, wordmark: wordmarkSize } = sizeMap[size];
+
+  if (variant === "mark") {
+    return <RaptorMark size={markSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  if (variant === "wordmark") {
+    return <BrandWordmark size={wordmarkSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  // variant === "full": try SVG asset first, fallback to mark + wordmark
+  const [assetError, setAssetError] = React.useState(false);
+
+  if (!assetError) {
+    return (
+      <Image
+        src="/brand/logo-full.svg"
+        alt="RaptorFlow"
+        width={wordmarkSize + markSize + 8}
+        height={markSize}
+        className={cn("h-auto", className)}
+        onError={() => setAssetError(true)}
+        priority
+      />
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <RaptorMark size={markSize} />
+      <BrandWordmark size={wordmarkSize} />
+    </div>
+  );
+}

--- a/apps/web/src/components/brand/RaptorFlowLogo.tsx
+++ b/apps/web/src/components/brand/RaptorFlowLogo.tsx
@@ -21,18 +21,15 @@ const sizeMap: Record<LogoSize, { mark: number; wordmark: number }> = {
   lg: { mark: 40, wordmark: 160 },
 };
 
-export function RaptorFlowLogo({ size = "md", variant = "full", className }: RaptorFlowLogoProps) {
-  const { mark: markSize, wordmark: wordmarkSize } = sizeMap[size];
-
-  if (variant === "mark") {
-    return <RaptorMark size={markSize} className={className} aria-label="RaptorFlow" />;
-  }
-
-  if (variant === "wordmark") {
-    return <BrandWordmark size={wordmarkSize} className={className} aria-label="RaptorFlow" />;
-  }
-
-  // variant === "full": try SVG asset first, fallback to mark + wordmark
+function FullRaptorFlowLogo({
+  markSize,
+  wordmarkSize,
+  className,
+}: {
+  markSize: number;
+  wordmarkSize: number;
+  className?: string;
+}) {
   const [assetError, setAssetError] = React.useState(false);
 
   if (!assetError) {
@@ -54,5 +51,21 @@ export function RaptorFlowLogo({ size = "md", variant = "full", className }: Rap
       <RaptorMark size={markSize} />
       <BrandWordmark size={wordmarkSize} />
     </div>
+  );
+}
+
+export function RaptorFlowLogo({ size = "md", variant = "full", className }: RaptorFlowLogoProps) {
+  const { mark: markSize, wordmark: wordmarkSize } = sizeMap[size];
+
+  if (variant === "mark") {
+    return <RaptorMark size={markSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  if (variant === "wordmark") {
+    return <BrandWordmark size={wordmarkSize} className={className} aria-label="RaptorFlow" />;
+  }
+
+  return (
+    <FullRaptorFlowLogo markSize={markSize} wordmarkSize={wordmarkSize} className={className} />
   );
 }

--- a/apps/web/src/components/brand/RaptorMark.tsx
+++ b/apps/web/src/components/brand/RaptorMark.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RaptorMarkProps {
+  size?: number;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export function RaptorMark({
+  size = 32,
+  className,
+  "aria-label": ariaLabel = "RaptorFlow",
+}: RaptorMarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("shrink-0", className)}
+      aria-label={ariaLabel}
+      role="img"
+    >
+      <rect
+        x="2"
+        y="2"
+        width="28"
+        height="28"
+        rx="6"
+        fill="currentColor"
+        className="text-[#2a2622]"
+      />
+      <path d="M16 8L24 16L16 24L8 16Z" fill="#d97757" />
+      <circle cx="16" cy="16" r="3" fill="#fbf8f2" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/brand/index.ts
+++ b/apps/web/src/components/brand/index.ts
@@ -1,0 +1,5 @@
+export { RaptorFlowLogo } from "./RaptorFlowLogo";
+export { RaptorMark } from "./RaptorMark";
+export { BrandWordmark } from "./BrandWordmark";
+export { BrandHeader } from "./BrandHeader";
+export { PaperTexture } from "./PaperTexture";

--- a/apps/web/src/components/layout/AppEmptyState.tsx
+++ b/apps/web/src/components/layout/AppEmptyState.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { RfWindow } from "@/components/windows/RfWindow";
+
+interface AppEmptyStateProps {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export function AppEmptyState({ title, description, action, icon, className }: AppEmptyStateProps) {
+  return (
+    <RfWindow variant="quiet" className={cn("py-12", className)}>
+      <div className="flex flex-col items-center text-center">
+        {icon && (
+          <div className="w-12 h-12 rounded-[var(--radius-lg)] bg-[var(--paper-150)] flex items-center justify-center mb-4">
+            {icon}
+          </div>
+        )}
+        <h3 className="h3 mb-2">{title}</h3>
+        <p className="body-muted max-w-sm mb-6">{description}</p>
+        {action && <div>{action}</div>}
+      </div>
+    </RfWindow>
+  );
+}

--- a/apps/web/src/components/layout/AppErrorState.tsx
+++ b/apps/web/src/components/layout/AppErrorState.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { RfWindow } from "@/components/windows/RfWindow";
+
+interface AppErrorStateProps {
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function AppErrorState({
+  title = "Something went wrong",
+  description = "We couldn't load this section. Try again or contact support if the problem persists.",
+  action,
+  className,
+}: AppErrorStateProps) {
+  return (
+    <RfWindow variant="danger" className={cn("py-10", className)}>
+      <div className="flex flex-col items-center text-center">
+        <div className="w-10 h-10 rounded-full bg-[var(--destructive)]/10 flex items-center justify-center mb-4">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            className="text-[var(--destructive)]"
+          >
+            <path
+              d="M10 6v5M10 15.5h.01M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </div>
+        <h3 className="h3 mb-2 text-[var(--destructive)]">{title}</h3>
+        <p className="body-muted max-w-sm mb-6">{description}</p>
+        {action && <div>{action}</div>}
+      </div>
+    </RfWindow>
+  );
+}

--- a/apps/web/src/components/layout/AppLoadingState.tsx
+++ b/apps/web/src/components/layout/AppLoadingState.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface AppLoadingStateProps {
+  label?: string;
+  className?: string;
+}
+
+export function AppLoadingState({ label = "Loading...", className }: AppLoadingStateProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center py-16", className)}>
+      <div className="relative w-8 h-8 mb-4">
+        <span className="absolute inset-0 rounded-full bg-[var(--primary)] opacity-20 animate-ping" />
+        <span className="absolute inset-1.5 rounded-full bg-[var(--primary)] opacity-40" />
+        <span className="absolute inset-3 rounded-full bg-[var(--primary)]" />
+      </div>
+      <span className="mono-label">{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/AppPageFrame.tsx
+++ b/apps/web/src/components/layout/AppPageFrame.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { BrandHeader } from "@/components/brand/BrandHeader";
+import { PaperTexture } from "@/components/brand/PaperTexture";
+
+export type MaxWidth = "standard" | "wide" | "full";
+
+interface AppPageFrameProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  rail?: React.ReactNode;
+  className?: string;
+  maxWidth?: MaxWidth;
+  status?: React.ReactNode;
+}
+
+const maxWidthMap: Record<MaxWidth, string> = {
+  standard: "max-w-5xl",
+  wide: "max-w-7xl",
+  full: "max-w-none",
+};
+
+export function AppPageFrame({
+  eyebrow,
+  title,
+  description,
+  actions,
+  children,
+  rail,
+  className,
+  maxWidth = "wide",
+  status,
+}: AppPageFrameProps) {
+  return (
+    <PaperTexture
+      intensity="soft"
+      className={cn("min-h-[calc(100vh-theme(spacing.16))]", className)}
+    >
+      <div className={cn("mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8", maxWidthMap[maxWidth])}>
+        <BrandHeader
+          eyebrow={eyebrow}
+          title={title}
+          description={description}
+          status={status}
+          actions={actions}
+        />
+        <div className={cn("flex gap-6", rail ? "flex-col lg:flex-row" : "flex-col")}>
+          <div className="flex-1 min-w-0">{children}</div>
+          {rail && <div className="w-full lg:w-80 xl:w-96 shrink-0">{rail}</div>}
+        </div>
+      </div>
+    </PaperTexture>
+  );
+}

--- a/apps/web/src/components/layout/AppPageSection.tsx
+++ b/apps/web/src/components/layout/AppPageSection.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { RfWindow } from "@/components/windows/RfWindow";
+
+interface AppPageSectionProps {
+  title?: string;
+  eyebrow?: string;
+  description?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  variant?: "default" | "quiet" | "highlight" | "danger";
+}
+
+export function AppPageSection({
+  title,
+  eyebrow,
+  description,
+  actions,
+  children,
+  className,
+  variant = "default",
+}: AppPageSectionProps) {
+  return (
+    <RfWindow
+      title={title}
+      eyebrow={eyebrow}
+      description={description}
+      actions={actions}
+      variant={variant}
+      className={cn("mb-6", className)}
+    >
+      {children}
+    </RfWindow>
+  );
+}

--- a/apps/web/src/components/layout/AppPageToolbar.tsx
+++ b/apps/web/src/components/layout/AppPageToolbar.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface AppPageToolbarProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function AppPageToolbar({ children, className }: AppPageToolbarProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-3 mb-6 p-3 rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--card)]",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -1,0 +1,7 @@
+export { AppShell, ShellTitle } from "./app-shell";
+export { AppPageFrame } from "./AppPageFrame";
+export { AppPageSection } from "./AppPageSection";
+export { AppPageToolbar } from "./AppPageToolbar";
+export { AppEmptyState } from "./AppEmptyState";
+export { AppErrorState } from "./AppErrorState";
+export { AppLoadingState } from "./AppLoadingState";

--- a/apps/web/src/components/layout/shell-sidebar.tsx
+++ b/apps/web/src/components/layout/shell-sidebar.tsx
@@ -24,59 +24,27 @@ import {
 import { cn } from "@/lib/cn";
 import { RaptorMark } from "@/components/brand/RaptorMark";
 import { BrandWordmark } from "@/components/brand/BrandWordmark";
+import { routeGroups } from "@/brand/routes";
 import { OfficeMiniStrip } from "@/components/office/office-mini-strip";
 import { NotificationPanel } from "@/components/layout/notification-panel";
 import { useOfficeStore } from "@/state/office-store";
 import { Menu, X } from "lucide-react";
 
-type NavItem = {
-  href: Route;
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  badge?: string;
-  accent?: string;
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+  "/app/dashboard": DashboardIcon,
+  "/office": MagicWandIcon,
+  "/daily-wins": CalendarIcon,
+  "/uploads": UploadIcon,
+  "/intel": TargetIcon,
+  "/nudges": BellIcon,
+  "/ripples": MixerHorizontalIcon,
+  "/campaigns": BackpackIcon,
+  "/council": AvatarIcon,
+  "/muse": ChatBubbleIcon,
+  "/content": FileTextIcon,
+  "/foundation": HomeIcon,
+  "/settings": GearIcon,
 };
-
-type NavGroup = {
-  label: string;
-  items: NavItem[];
-};
-
-const NAV_GROUPS: NavGroup[] = [
-  {
-    label: "Workspace",
-    items: [
-      { href: "/app/dashboard" as Route, label: "Dashboard", icon: DashboardIcon },
-      { href: "/office" as Route, label: "The Office", icon: MagicWandIcon },
-      { href: "/daily-wins" as Route, label: "Daily Wins", icon: CalendarIcon },
-      { href: "/uploads" as Route, label: "Uploads", icon: UploadIcon },
-    ],
-  },
-  {
-    label: "Intelligence",
-    items: [
-      { href: "/intel" as Route, label: "Intel", icon: TargetIcon },
-      { href: "/nudges" as Route, label: "Nudges", icon: BellIcon },
-      { href: "/ripples" as Route, label: "Ripples", icon: MixerHorizontalIcon },
-    ],
-  },
-  {
-    label: "Strategy",
-    items: [
-      { href: "/campaigns" as Route, label: "Campaigns", icon: BackpackIcon },
-      { href: "/council" as Route, label: "Council", icon: AvatarIcon },
-      { href: "/muse" as Route, label: "Muse", icon: ChatBubbleIcon, accent: "#4f46e5" },
-      { href: "/content" as Route, label: "Content", icon: FileTextIcon },
-    ],
-  },
-  {
-    label: "System",
-    items: [
-      { href: "/foundation" as Route, label: "Foundation", icon: HomeIcon },
-      { href: "/settings" as Route, label: "Settings", icon: GearIcon },
-    ],
-  },
-];
 
 function SidebarBadge({ queryKey, countPath }: { queryKey: unknown[]; countPath: string }) {
   const { data } = useQuery({
@@ -168,52 +136,53 @@ export function ShellSidebar({ identity }: { identity: { userId: string; orgId: 
         </div>
 
         <nav className="flex-1 overflow-y-auto pt-6 space-y-8 scrollbar-thin">
-          {NAV_GROUPS.map((group, groupIndex) => (
-            <div key={group.label} className="px-3">
+          {routeGroups.map((group, groupIndex) => (
+            <div key={group.key} className="px-3">
               <h2 className="px-3 mb-3 text-[9px] font-bold text-[var(--ink-400)] uppercase tracking-[0.2em] font-mono">
                 {group.label}
               </h2>
               <div className="space-y-1">
-                {group.items.map((item, itemIndex) => {
-                  const isExact = pathname === item.href;
+                {group.routes.map((route, itemIndex) => {
+                  const href = route.href as Route;
+                  const isExact = pathname === route.href;
                   const isNested =
-                    item.href !== "/office" &&
-                    item.href !== "/app/dashboard" &&
-                    pathname.startsWith(item.href + "/");
+                    route.href !== "/office" &&
+                    route.href !== "/app/dashboard" &&
+                    pathname.startsWith(route.href + "/");
                   const isActive = isExact || isNested;
-                  const Icon = item.icon;
+                  const Icon = iconMap[route.href] ?? DashboardIcon;
 
                   return (
                     <Link
-                      key={item.href}
-                      href={item.href}
+                      key={route.href}
+                      href={href}
                       className={cn(
                         "flex items-center gap-3 px-3 py-2.5 text-[13px] transition-all duration-150 group relative rounded-[var(--radius)]",
                         isActive
-                          ? "text-white bg-[rgba(139,92,246,0.08)] shadow-sm"
-                          : "text-slate-400 hover:text-slate-300 hover:bg-white/[0.04]",
+                          ? "bg-[var(--amber-wash)] text-[var(--ink-900)] shadow-sm border border-[var(--amber-stroke)]/20"
+                          : "text-[var(--ink-500)] hover:text-[var(--ink-900)] hover:bg-[var(--paper-150)]",
                       )}
                       style={{
                         animationDelay: `${(groupIndex * 4 + itemIndex) * 50}ms`,
                       }}
                     >
                       {isActive && (
-                        <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-5 bg-[#8b5cf6] rounded-r-full" />
+                        <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-5 bg-[var(--primary)] rounded-r-full" />
                       )}
                       <Icon
                         className={cn(
                           "w-4 h-4 transition-colors duration-200",
                           isActive
-                            ? "text-violet-400"
-                            : "text-slate-500 group-hover:text-slate-400",
+                            ? "text-[var(--primary)]"
+                            : "text-[var(--ink-400)] group-hover:text-[var(--ink-700)]",
                         )}
                       />
-                      <span className="font-medium">{item.label}</span>
+                      <span className="font-medium">{route.label}</span>
                       {isActive && <span className="ml-auto status-dot-live" />}
-                      {item.href === "/intel" && (
+                      {route.href === "/intel" && (
                         <SidebarBadge queryKey={["intel"]} countPath="signals.length" />
                       )}
-                      {item.href === "/nudges" && (
+                      {route.href === "/nudges" && (
                         <SidebarBadge queryKey={["nudges"]} countPath="totalCount" />
                       )}
                     </Link>

--- a/apps/web/src/components/layout/shell-sidebar.tsx
+++ b/apps/web/src/components/layout/shell-sidebar.tsx
@@ -19,10 +19,11 @@ import {
   FileTextIcon,
   GearIcon,
   UploadIcon,
-  LightningBoltIcon,
   MixerHorizontalIcon,
 } from "@radix-ui/react-icons";
 import { cn } from "@/lib/cn";
+import { RaptorMark } from "@/components/brand/RaptorMark";
+import { BrandWordmark } from "@/components/brand/BrandWordmark";
 import { OfficeMiniStrip } from "@/components/office/office-mini-strip";
 import { NotificationPanel } from "@/components/layout/notification-panel";
 import { useOfficeStore } from "@/state/office-store";
@@ -134,15 +135,11 @@ export function ShellSidebar({ identity }: { identity: { userId: string; orgId: 
       >
         <div className="h-16 px-6 flex items-center justify-between border-b border-[var(--sidebar-border)] relative">
           <div className="flex items-center gap-3">
-            <div className="w-7 h-7 bg-[var(--primary)] flex items-center justify-center rounded-[var(--radius)] transition-transform duration-300 hover:scale-105">
-              <LightningBoltIcon className="w-4 h-4 text-white" />
-            </div>
+            <RaptorMark size={28} className="text-[var(--ink-900)]" />
             <div className="flex flex-col">
-              <span className="text-sm font-bold text-[var(--ink-900)] tracking-tight leading-none">
-                RaptorFlow
-              </span>
+              <BrandWordmark size={90} className="text-[var(--ink-900)]" />
               <span className="text-[9px] font-mono text-[var(--ink-400)] uppercase tracking-widest mt-0.5">
-                EST. 1989
+                AI-NATIVE MARKETING OS
               </span>
             </div>
           </div>

--- a/apps/web/src/components/windows/RfWindow.tsx
+++ b/apps/web/src/components/windows/RfWindow.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import { RfWindowHeader } from "./RfWindowHeader";
+import { RfWindowBody } from "./RfWindowBody";
+
+export type WindowVariant = "default" | "highlight" | "quiet" | "danger";
+export type WindowDensity = "comfortable" | "compact";
+
+interface RfWindowProps {
+  title?: string;
+  eyebrow?: string;
+  description?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  variant?: WindowVariant;
+  density?: WindowDensity;
+}
+
+const variantMap: Record<WindowVariant, string> = {
+  default: "paper-card",
+  highlight: "card-highlight",
+  quiet: "bg-[var(--paper-150)] border border-[var(--border)] rounded-[var(--radius-lg)]",
+  danger:
+    "bg-[var(--destructive-wash)] border border-[var(--destructive)]/20 rounded-[var(--radius-lg)]",
+};
+
+export function RfWindow({
+  title,
+  eyebrow,
+  description,
+  actions,
+  children,
+  className,
+  variant = "default",
+  density = "comfortable",
+}: RfWindowProps) {
+  const hasHeader = title || eyebrow || description || actions;
+
+  return (
+    <div
+      className={cn(
+        variantMap[variant],
+        "overflow-hidden transition-all duration-[240ms]",
+        className,
+      )}
+    >
+      {hasHeader && (
+        <RfWindowHeader
+          eyebrow={eyebrow}
+          title={title}
+          description={description}
+          actions={actions}
+        />
+      )}
+      <RfWindowBody density={density}>{children}</RfWindowBody>
+    </div>
+  );
+}

--- a/apps/web/src/components/windows/RfWindowBody.tsx
+++ b/apps/web/src/components/windows/RfWindowBody.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+import type { WindowDensity } from "./RfWindow";
+
+interface RfWindowBodyProps {
+  children: React.ReactNode;
+  className?: string;
+  density?: WindowDensity;
+}
+
+export function RfWindowBody({ children, className, density = "comfortable" }: RfWindowBodyProps) {
+  return <div className={cn(density === "comfortable" ? "p-6" : "p-4", className)}>{children}</div>;
+}

--- a/apps/web/src/components/windows/RfWindowGrid.tsx
+++ b/apps/web/src/components/windows/RfWindowGrid.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RfWindowGridProps {
+  children: React.ReactNode;
+  columns?: 1 | 2 | 3 | 4;
+  className?: string;
+}
+
+const colMap: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+  4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+};
+
+export function RfWindowGrid({ children, columns = 2, className }: RfWindowGridProps) {
+  return <div className={cn("grid gap-4", colMap[columns], className)}>{children}</div>;
+}

--- a/apps/web/src/components/windows/RfWindowHeader.tsx
+++ b/apps/web/src/components/windows/RfWindowHeader.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RfWindowHeaderProps {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function RfWindowHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: RfWindowHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "px-6 pt-5 pb-0 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3",
+        className,
+      )}
+    >
+      <div className="flex-1 min-w-0">
+        {eyebrow && <span className="eyebrow block mb-1.5">{eyebrow}</span>}
+        {title && <h3 className="h3">{title}</h3>}
+        {description && <p className="body-muted mt-1">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/windows/RfWindowRail.tsx
+++ b/apps/web/src/components/windows/RfWindowRail.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+interface RfWindowRailProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function RfWindowRail({ children, className }: RfWindowRailProps) {
+  return (
+    <aside className={cn("w-full lg:w-80 xl:w-96 shrink-0 paper-card p-5 h-fit", className)}>
+      {children}
+    </aside>
+  );
+}

--- a/apps/web/src/components/windows/SignalDot.tsx
+++ b/apps/web/src/components/windows/SignalDot.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type SignalTone = "amber" | "success" | "danger" | "neutral";
+
+interface SignalDotProps {
+  tone?: SignalTone;
+  pulse?: boolean;
+  label?: string;
+  className?: string;
+}
+
+const toneMap: Record<SignalTone, string> = {
+  amber: "bg-[var(--primary)] shadow-[0_0_0_3px_rgba(217,119,87,0.18)]",
+  success: "bg-[var(--leaf-confirm)] shadow-[0_0_0_3px_rgba(92,138,90,0.18)]",
+  danger: "bg-[var(--destructive)] shadow-[0_0_0_3px_rgba(196,74,63,0.18)]",
+  neutral: "bg-[var(--ink-400)] shadow-none",
+};
+
+export function SignalDot({ tone = "amber", pulse = false, label, className }: SignalDotProps) {
+  return (
+    <span className={cn("inline-flex items-center gap-2", className)}>
+      <span
+        className={cn(
+          "inline-block w-2 h-2 rounded-full",
+          toneMap[tone],
+          pulse && "animate-[amberPulse_2.4s_cubic-bezier(0.4,0,0.2,1)_infinite]",
+        )}
+        aria-hidden={!label}
+        aria-label={label}
+      />
+      {label && <span className="text-[11px] text-[var(--ink-500)]">{label}</span>}
+    </span>
+  );
+}

--- a/apps/web/src/components/windows/StatusPill.tsx
+++ b/apps/web/src/components/windows/StatusPill.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type StatusTone = "neutral" | "success" | "warning" | "danger" | "amber" | "muse";
+
+interface StatusPillProps {
+  status: string;
+  tone?: StatusTone;
+  className?: string;
+}
+
+const toneMap: Record<StatusTone, string> = {
+  neutral: "bg-[var(--paper-200)] text-[var(--ink-700)] border-[var(--paper-300)]",
+  success: "bg-[var(--leaf-wash)] text-[var(--leaf)] border-[var(--leaf)]/20",
+  warning: "bg-[var(--amber-wash)] text-[var(--primary)] border-[var(--amber-stroke)]/30",
+  danger: "bg-[var(--destructive-wash)] text-[var(--destructive)] border-[var(--destructive)]/20",
+  amber: "bg-[var(--amber-wash)] text-[var(--primary)] border-[var(--amber-stroke)]/30",
+  muse: "bg-[var(--indigo-wash)] text-[var(--indigo-muse)] border-[var(--indigo-muse)]/20",
+};
+
+export function StatusPill({ status, tone = "neutral", className }: StatusPillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium border",
+        toneMap[tone],
+        className,
+      )}
+    >
+      {status}
+    </span>
+  );
+}

--- a/apps/web/src/components/windows/index.ts
+++ b/apps/web/src/components/windows/index.ts
@@ -1,0 +1,7 @@
+export { RfWindow } from "./RfWindow";
+export { RfWindowHeader } from "./RfWindowHeader";
+export { RfWindowBody } from "./RfWindowBody";
+export { RfWindowGrid } from "./RfWindowGrid";
+export { RfWindowRail } from "./RfWindowRail";
+export { StatusPill } from "./StatusPill";
+export { SignalDot } from "./SignalDot";

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -23,5 +23,4 @@ raptorflow-config = { path = "../config" }
 raptorflow-contracts = { path = "../contracts" }
 raptorflow-eel = { path = "../eel" }
 raptorflow-prl = { path = "../prl" }
-<<<<<<< HEAD
 raptorflow-aws = { path = "../aws" }

--- a/docs/frontend-phase-1-brand-system.md
+++ b/docs/frontend-phase-1-brand-system.md
@@ -1,0 +1,90 @@
+# Frontend Phase 1 — RaptorFlow Brand System
+
+## Summary
+
+This phase creates the central Paper / Amber / Editorial SaaS brand system for RaptorFlow. It is the foundation for the entire frontend renaissance. No product features were added. No API behavior was changed.
+
+## Files Created
+
+### Brand Directory
+
+- `apps/web/src/brand/index.ts` — Barrel export
+- `apps/web/src/brand/tokens.ts` — Canonical colors, typography, radii, shadows, spacing, z-index, semantic states
+- `apps/web/src/brand/copy.ts` — Canonical product copy and positioning
+- `apps/web/src/brand/motion.ts` — Standard motion constants and reduced-motion helper
+- `apps/web/src/brand/routes.ts` — Canonical route metadata and grouped navigation structure
+- `apps/web/src/brand/README.md` — Brand system documentation
+
+### Public Asset Hub
+
+- `public/brand/.gitkeep`
+- `public/brand/textures/.gitkeep`
+- `public/brand/logo-full.svg` — Placeholder
+- `public/brand/logo-mark.svg` — Placeholder
+- `public/brand/favicon.svg` — Placeholder
+
+### Brand Components
+
+- `apps/web/src/components/brand/RaptorFlowLogo.tsx` — Unified logo component with asset fallback
+- `apps/web/src/components/brand/RaptorMark.tsx` — Abstract amber/ink geometric mark
+- `apps/web/src/components/brand/BrandWordmark.tsx` — Serif wordmark
+- `apps/web/src/components/brand/BrandHeader.tsx` — Reusable page header
+- `apps/web/src/components/brand/PaperTexture.tsx` — Paper texture wrapper
+- `apps/web/src/components/brand/index.ts` — Barrel export
+
+### Window Components
+
+- `apps/web/src/components/windows/RfWindow.tsx` — Paper card/window
+- `apps/web/src/components/windows/RfWindowHeader.tsx` — Window header
+- `apps/web/src/components/windows/RfWindowBody.tsx` — Window body
+- `apps/web/src/components/windows/RfWindowGrid.tsx` — Responsive grid
+- `apps/web/src/components/windows/RfWindowRail.tsx` — Right rail wrapper
+- `apps/web/src/components/windows/StatusPill.tsx` — Status badge
+- `apps/web/src/components/windows/SignalDot.tsx` — Signal indicator dot
+- `apps/web/src/components/windows/index.ts` — Barrel export
+
+### Modified Files
+
+- `apps/web/src/components/layout/shell-sidebar.tsx` — Replaced generic lightning logo with `RaptorMark` + `BrandWordmark`
+- `apps/web/src/app/(app)/dashboard/page.tsx` — Added `BrandHeader`, `RfWindowGrid`, `StatusPill` as proof of concept
+
+## How Later Phases Should Use This
+
+1. **Import from `@/brand`** for tokens, copy, motion, and route metadata.
+2. **Use `RaptorFlowLogo`** instead of inline logo fragments.
+3. **Wrap page content with `RfWindow`** and `RfWindowGrid` instead of ad-hoc card divs.
+4. **Use `BrandHeader`** for consistent page headers.
+5. **Reference `globals.css`** for the canonical CSS design system; use `tokens.ts` only when JS-level access is required.
+
+## Known Limitations
+
+- Logo SVGs are placeholders. Final brand assets should be dropped into `public/brand/`.
+- `RaptorFlowLogo` falls back to `RaptorMark` + `BrandWordmark` if `logo-full.svg` fails to load.
+- `RfWindow` does not yet support collapsible or draggable behavior.
+- `PaperTexture` is a thin wrapper around existing CSS classes.
+
+## Next Phase Recommendation
+
+**Phase 2: Page-by-Page Brand Application**
+
+Transform each major page (Office, Campaigns, Content, Billing, Landing) to use the brand system consistently. Replace ad-hoc card styles with `RfWindow`, standardize headers with `BrandHeader`, and eliminate one-off color usage.
+
+## Commands Run
+
+| Command                        | Result                                                                |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `pnpm typecheck`               | PASS                                                                  |
+| `pnpm lint`                    | PASS                                                                  |
+| `pnpm structural:check`        | PASS (pre-existing WARNs: documented Prisma gaps, unused Rust routes) |
+| `pnpm route-parity:check`      | PASS (pre-existing WARNs: unused Rust routes)                         |
+| `pnpm runtime-authority:check` | PASS (pre-existing WARNs: documented Prisma gaps)                     |
+| `cargo fmt --all --check`      | PASS                                                                  |
+| `cargo check --workspace`      | PASS                                                                  |
+
+## Confirmations
+
+- No product logic changed.
+- No fake data added.
+- No route behavior changed.
+- No force push used.
+- No stale PR merge.

--- a/docs/frontend-phase-2-app-shell.md
+++ b/docs/frontend-phase-2-app-shell.md
@@ -1,0 +1,128 @@
+# Frontend Phase 2 — App Shell, Navigation, and Page Frame Integration
+
+## Summary
+
+This phase uses the Phase 1 brand/window system to make the RaptorFlow app shell feel coherent and production-grade. It creates the unified frame that every future page will live inside.
+
+This is NOT the Office rebuild yet.
+This is NOT campaign contract repair.
+This is NOT billing/payments.
+
+## Files Created
+
+### App Page Frame Components
+
+- `apps/web/src/components/layout/AppPageFrame.tsx` — Standard page wrapper with BrandHeader, paper texture, optional rail, max-width control
+- `apps/web/src/components/layout/AppPageSection.tsx` — Section wrapper using RfWindow
+- `apps/web/src/components/layout/AppPageToolbar.tsx` — Toolbar for filters, search, quick actions
+- `apps/web/src/components/layout/AppEmptyState.tsx` — Quiet empty state with optional action
+- `apps/web/src/components/layout/AppErrorState.tsx` — Error state with destructive tone
+- `apps/web/src/components/layout/AppLoadingState.tsx` — Subtle amber pulse loading indicator
+- `apps/web/src/components/layout/index.ts` — Barrel export for layout components
+
+### Modified Files
+
+- `apps/web/src/components/layout/shell-sidebar.tsx` — Integrated route metadata from `@/brand/routes`, updated active state styling to amber/paper theme, kept brand components
+- `apps/web/src/app/(app)/content/page.tsx` — Wrapped with AppPageFrame, AppPageSection, AppEmptyState, AppLoadingState, AppErrorState
+- `apps/web/src/app/(app)/settings/page.tsx` — Wrapped with AppPageFrame, AppPageSection, AppLoadingState
+- `apps/web/src/app/(app)/uploads/page.tsx` — Wrapped with AppPageFrame, AppPageSection
+- `apps/web/src/app/(app)/ripples/page.tsx` — Wrapped with AppPageFrame, AppPageSection, AppEmptyState, AppLoadingState, AppErrorState, AppPageToolbar
+
+## How to Use AppPageFrame
+
+```tsx
+import { AppPageFrame } from "@/components/layout";
+
+<AppPageFrame
+  eyebrow="Section"
+  title="Page Title"
+  description="Optional description."
+  actions={<button className="btn-primary">Action</button>}
+  maxWidth="wide"
+>
+  Content here
+</AppPageFrame>;
+```
+
+## How to Use AppPageSection
+
+```tsx
+import { AppPageSection } from "@/components/layout";
+
+<AppPageSection
+  title="Section Title"
+  eyebrow="Subsection"
+  actions={<StatusPill status="Live" tone="success" />}
+  variant="default"
+>
+  Section content
+</AppPageSection>;
+```
+
+Variants: `default` | `quiet` | `highlight` | `danger`
+
+## When to Use Empty/Error/Loading States
+
+| State   | Component         | Use When                                    |
+| ------- | ----------------- | ------------------------------------------- |
+| Loading | `AppLoadingState` | Data is fetching, no content yet            |
+| Empty   | `AppEmptyState`   | Data loaded, array is empty                 |
+| Error   | `AppErrorState`   | Query failed, show retry or contact support |
+
+## Routes Aligned
+
+- `/app/dashboard` — Phase 1 proof of concept (BrandHeader, RfWindowGrid)
+- `/content` — AppPageFrame, AppPageSection, AppEmptyState, AppLoadingState, AppErrorState
+- `/settings` — AppPageFrame, AppPageSection, AppLoadingState
+- `/uploads` — AppPageFrame, AppPageSection
+- `/ripples` — AppPageFrame, AppPageSection, AppEmptyState, AppLoadingState, AppErrorState, AppPageToolbar
+
+## Routes Intentionally Untouched
+
+These need dedicated phases and were not modified:
+
+- `/office` — Needs Office rebuild (Phase 3)
+- `/campaigns` and campaign detail — Needs campaign contract repair
+- `/moves` — Complex product flow
+- `/billing` — Payment flow
+- `/landing` — Marketing page
+- `/foundation` — Complex form flow
+- `/council` — War room, complex real-time UI
+
+## Sidebar Changes
+
+- Uses `routeGroups` from `@/brand/routes` for navigation structure
+- Active state uses amber wash (`--amber-wash`) instead of violet
+- Icon colors use ink scale instead of slate
+- Preserved: notification bell, mobile behavior, OfficeMiniStrip, SidebarBadge for intel/nudges
+
+## Known Limitations
+
+- `AppPageFrame` does not yet support collapsible rails
+- `AppPageToolbar` is a simple flex wrapper; advanced filter patterns may need custom builds
+- Pages not in the "safe routes" list still use their original styling
+
+## Next Phase Recommendation
+
+**Phase 3: Office Rebuild**
+
+Transform the Office page (`/office`) into a premium founder operating desk experience using the full brand system. This is where the Paper/Amber identity should shine most.
+
+## Commands Run
+
+| Command                   | Result                    |
+| ------------------------- | ------------------------- |
+| `pnpm typecheck`          | PASS                      |
+| `pnpm lint`               | PASS                      |
+| `pnpm structural:check`   | PASS (pre-existing WARNs) |
+| `cargo fmt --all --check` | PASS                      |
+| `cargo check --workspace` | PASS                      |
+
+## Confirmations
+
+- [x] No product logic changed
+- [x] No fake data added
+- [x] No route behavior changed
+- [x] No Office rebuild yet
+- [x] No force push used
+- [x] No stale PR merge

--- a/public/brand/favicon.svg
+++ b/public/brand/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- PLACEHOLDER: Replace with final RaptorFlow favicon -->
+  <rect width="32" height="32" rx="6" fill="#faf7f1"/>
+  <path d="M16 6L26 16L16 26L6 16Z" fill="#d97757"/>
+  <circle cx="16" cy="16" r="2.5" fill="#2a2622"/>
+</svg>

--- a/public/brand/logo-full.svg
+++ b/public/brand/logo-full.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" fill="none">
+  <!-- PLACEHOLDER: Replace with final RaptorFlow wordmark -->
+  <text x="0" y="28" font-family="'Instrument Serif', 'DM Serif Display', ui-serif, serif" font-size="28" fill="#2a2622" letter-spacing="-0.02em">RaptorFlow</text>
+  <circle cx="188" cy="20" r="6" fill="#d97757"/>
+</svg>

--- a/public/brand/logo-mark.svg
+++ b/public/brand/logo-mark.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- PLACEHOLDER: Replace with final RaptorFlow mark -->
+  <!-- Abstract strategic mark: amber diamond with ink inner shape -->
+  <rect x="2" y="2" width="28" height="28" rx="6" fill="#2a2622"/>
+  <path d="M16 8L24 16L16 24L8 16Z" fill="#d97757"/>
+  <circle cx="16" cy="16" r="3" fill="#fbf8f2"/>
+</svg>


### PR DESCRIPTION
## Summary

This PR uses the Phase 1 brand/window system to make the RaptorFlow app shell feel coherent and production-grade. It creates the unified frame that every future page will live inside.

## AppPageFrame components created

- `AppPageFrame.tsx` — Standard page wrapper with BrandHeader, paper texture, optional rail, max-width control
- `AppPageSection.tsx` — Section wrapper using RfWindow
- `AppPageToolbar.tsx` — Toolbar for filters, search, quick actions
- `AppEmptyState.tsx` — Quiet empty state with optional action
- `AppErrorState.tsx` — Error state with destructive tone
- `AppLoadingState.tsx` — Subtle amber pulse loading indicator
- `components/layout/index.ts` — Barrel export

## Routes aligned

- `/content` — AppPageFrame, AppPageSection, AppEmptyState, AppLoadingState, AppErrorState
- `/settings` — AppPageFrame, AppPageSection, AppLoadingState
- `/uploads` — AppPageFrame, AppPageSection
- `/ripples` — AppPageFrame, AppPageSection, AppEmptyState, AppLoadingState, AppErrorState, AppPageToolbar

## Sidebar/route metadata changes

- Uses `routeGroups` from `@/brand/routes` for navigation structure
- Active state uses amber wash instead of violet
- Icon colors use ink scale instead of slate
- Preserved: notification bell, mobile behavior, OfficeMiniStrip, SidebarBadge

## Loading/empty/error states added

Replaced plain "Loading..." and ad-hoc error UI on safe routes with standardized components.

## Responsive checks

- AppPageFrame works with and without rails
- Actions stack on mobile
- Sidebar mobile behavior preserved
- Page padding responsive at all breakpoints

## Commands run with pass/fail table

| Command                   | Result                    |
| ------------------------- | ------------------------- |
| `pnpm typecheck`          | PASS                      |
| `pnpm lint`               | PASS                      |
| `pnpm structural:check`   | PASS (pre-existing WARNs) |
| `cargo fmt --all --check` | PASS                      |
| `cargo check --workspace` | PASS                      |

## Known limitations

- AppPageFrame does not yet support collapsible rails
- AppPageToolbar is a simple flex wrapper
- Pages not in the safe routes list still use original styling

## Confirmations

- [x] No product logic changed
- [x] No fake data added
- [x] No route behavior changed
- [x] No Office rebuild yet
- [x] No force push used
- [x] No stale PR merge
