### PR TITLE
refactor(web): centralize frontend API env usage

### DIFF
--- a/apps/web/src/app/api/foundation/route.ts
+++ b/apps/web/src/app/api/foundation/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { ingestRipple } from "@/lib/prl/ingest";
 import { broadcast, channels } from "@/lib/pusher/server";
-
-const RUST_API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+import { getApiBaseUrl } from "@/lib/api";
 
 const ALL_SECTION_KEYS = [
   "company_url",
@@ -57,7 +56,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 async function rustFetch(path: string, token: string, options?: RequestInit): Promise<Response> {
-  return fetch(`${RUST_API}${path}`, {
+  return fetch(`${getApiBaseUrl()}${path}`, {
     ...options,
     headers: {
       Authorization: `Bearer ${token}`,

--- a/apps/web/src/lib/harness/index.ts
+++ b/apps/web/src/lib/harness/index.ts
@@ -1,5 +1,6 @@
 import { cortexSearch, type CortexResult } from "@/lib/prl/cortex";
 import { enrichAvatarContext, type EELContextPack } from "@/lib/eel/enrich";
+import { apiFetch } from "@/lib/api";
 
 export type SessionMode = "council" | "strategist" | "muse" | "scan" | "evaluation";
 
@@ -32,18 +33,15 @@ export interface HarnessContextPack {
   };
 }
 
-const RUST_API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
-
 async function fetchFoundationSections(
   userId: string,
   token: string,
 ): Promise<Record<string, unknown> | null> {
   try {
-    const res = await fetch(`${RUST_API}/api/v1/foundation`, {
-      headers: { Authorization: `Bearer ${token}` },
+    const body = await apiFetch<{ sections?: Record<string, unknown> }>("/api/v1/foundation", {
+      auth: true,
+      token,
     });
-    if (!res.ok) return null;
-    const body = (await res.json()) as { sections?: Record<string, unknown> };
     return body.sections ?? null;
   } catch {
     return null;

--- a/apps/web/src/state/foundation-store.ts
+++ b/apps/web/src/state/foundation-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { useEffect, useCallback } from "react";
 import { useAuth } from "@clerk/nextjs";
+import { apiFetch } from "@/lib/api";
 
 /**
  * Valid Foundation Section IDs — 22 screens mapped to Rust model fields
@@ -287,22 +288,12 @@ export function useFoundationAutoSave(sectionId: FoundationSectionId, data: any)
       setIsAutoSaving(true);
       const token = await getToken();
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/foundation/section/${sectionId}`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ data }),
-        },
-      );
-
-      if (!response.ok) {
-        console.error(`[FoundationAutoSave] Failed to save section ${sectionId}`);
-        return;
-      }
+      await apiFetch<void>(`/api/v1/foundation/section/${sectionId}`, {
+        method: "PATCH",
+        body: { data },
+        auth: true,
+        token,
+      });
 
       // Mark current step as complete on successful save
       const stepForSection = FOUNDATION_STEPS.find((s) => s.section === sectionId)?.step;


### PR DESCRIPTION
## Summary
- remove direct NEXT_PUBLIC_API_BASE_URL reads from foundation autosave and harness context assembly
- route foundation proxy traffic through the shared API base helper
- keep API base and websocket derivation centralized in apps/web/src/lib/api.ts and env.ts

## Verification
- pnpm typecheck
- pnpm format
- pnpm route-parity:check
- pnpm contracts:check
- cargo fmt --all -- --check
- cargo check -p raptorflow-http
- rg direct NEXT_PUBLIC_API_BASE_URL scan: only apps/web/src/lib/env.ts reads process.env