### PR TITLE
feat(db): enforce tenant rls coverage

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ ALB (TLS termination)
 
 ### Tenant isolation ✅
 
-Every database query includes `org_id` via PostgreSQL Row Level Security. The `app.current_org_id()` session variable is set from the JWT `org_id` claim before any query executes. S3 paths follow `{bucket}/{org_id}/`.
+Tenant-owned tables carry `org_id` and are covered by PostgreSQL Row Level Security policies against `app.current_org_id()`. New migrations are checked by a database validation test that fails when an `org_id` table is created without `ENABLE ROW LEVEL SECURITY`. Code paths that need database-enforced RLS should use a tenant transaction (`TenantDbPool::begin_for_tenant`) so `app.current_org_id` is scoped to the transaction. S3 paths follow `{bucket}/{org_id}/`.
 
 ### JWT authentication ✅
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -18,8 +18,9 @@
 //! ## RLS
 //!
 //! All tenant-scoped tables use Row Level Security via `app.current_org_id()`.
-//! The application must `SET LOCAL app.current_org_id = '{org_id}'` before
-//! executing queries on behalf of a tenant.
+//! Code that relies on database-enforced RLS should use
+//! [`TenantDbPool::begin_for_tenant`] so `app.current_org_id` is set with
+//! transaction-local scope.
 
 pub mod models;
 pub mod pool;

--- a/crates/db/src/pool.rs
+++ b/crates/db/src/pool.rs
@@ -1,3 +1,4 @@
+use sqlx::Transaction;
 use sqlx::postgres::{PgPool as SqlxPgPool, PgPoolOptions, Postgres};
 use std::time::Duration;
 use uuid::Uuid;
@@ -55,11 +56,23 @@ impl TenantDbPool {
         org_id: Uuid,
     ) -> Result<sqlx::pool::PoolConnection<Postgres>, sqlx::Error> {
         let mut conn = self.inner.acquire().await?;
-        sqlx::query("SET SESSION app.current_org_id = $1")
-            .bind(org_id)
+        sqlx::query("SELECT set_config('app.current_org_id', $1, false)")
+            .bind(org_id.to_string())
             .execute(&mut *conn)
             .await?;
         Ok(conn)
+    }
+
+    pub async fn begin_for_tenant(
+        &self,
+        org_id: Uuid,
+    ) -> Result<Transaction<'static, Postgres>, sqlx::Error> {
+        let mut tx = self.inner.begin().await?;
+        sqlx::query("SELECT set_config('app.current_org_id', $1, true)")
+            .bind(org_id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        Ok(tx)
     }
 
     pub fn pool(&self) -> &PgPool {

--- a/crates/db/src/validation.rs
+++ b/crates/db/src/validation.rs
@@ -23,3 +23,110 @@ pub fn validate_council_synthesis(body: &Value) -> Result<(), Vec<String>> {
         Err(errors) => Err(vec![errors.to_string()]),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn migrations_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../database/migrations")
+    }
+
+    fn normalize_table_name(raw: &str) -> String {
+        raw.trim()
+            .trim_end_matches('(')
+            .trim_matches('"')
+            .trim_end_matches(';')
+            .to_ascii_lowercase()
+    }
+
+    fn table_name_from_create(line: &str) -> Option<String> {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        let table_idx = tokens
+            .iter()
+            .position(|token| token.eq_ignore_ascii_case("TABLE"))?;
+        let mut name_idx = table_idx + 1;
+        if tokens
+            .get(name_idx)
+            .is_some_and(|token| token.eq_ignore_ascii_case("IF"))
+        {
+            name_idx += 3;
+        }
+        tokens.get(name_idx).map(|name| normalize_table_name(name))
+    }
+
+    fn table_name_from_alter(line: &str) -> Option<String> {
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        let table_idx = tokens
+            .iter()
+            .position(|token| token.eq_ignore_ascii_case("TABLE"))?;
+        tokens
+            .get(table_idx + 1)
+            .map(|name| normalize_table_name(name))
+    }
+
+    #[test]
+    fn org_scoped_tables_enable_rls_in_migrations() {
+        let mut org_tables = BTreeSet::new();
+        let mut rls_tables = BTreeSet::new();
+
+        for entry in fs::read_dir(migrations_dir()).expect("read database/migrations") {
+            let path = entry.expect("migration entry").path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("sql") {
+                continue;
+            }
+
+            let sql = fs::read_to_string(&path).expect("read migration");
+            let mut current_table: Option<String> = None;
+            let mut current_block = String::new();
+
+            for line in sql.lines() {
+                if line.to_ascii_uppercase().contains("CREATE TABLE") {
+                    if let Some(table) = current_table.take() {
+                        if current_block.to_ascii_lowercase().contains("org_id") {
+                            org_tables.insert(table);
+                        }
+                    }
+                    current_table = table_name_from_create(line);
+                    current_block.clear();
+                }
+
+                if let Some(table) = &current_table {
+                    current_block.push_str(line);
+                    current_block.push('\n');
+
+                    if line.trim_end().ends_with(");") {
+                        if current_block.to_ascii_lowercase().contains("org_id") {
+                            org_tables.insert(table.clone());
+                        }
+                        current_table = None;
+                        current_block.clear();
+                    }
+                }
+
+                if line
+                    .to_ascii_uppercase()
+                    .contains("ENABLE ROW LEVEL SECURITY")
+                {
+                    if let Some(table) = table_name_from_alter(line) {
+                        rls_tables.insert(table);
+                    }
+                }
+            }
+
+            if let Some(table) = current_table {
+                if current_block.to_ascii_lowercase().contains("org_id") {
+                    org_tables.insert(table);
+                }
+            }
+        }
+
+        let missing: Vec<_> = org_tables.difference(&rls_tables).cloned().collect();
+        assert!(
+            missing.is_empty(),
+            "org-scoped tables missing ENABLE ROW LEVEL SECURITY: {missing:?}"
+        );
+    }
+}

--- a/database/migrations/0026_rls_enforcement.sql
+++ b/database/migrations/0026_rls_enforcement.sql
@@ -1,0 +1,153 @@
+-- Migration: 0026_rls_enforcement
+-- Add missing RLS coverage for org-scoped tables added after the base tenant model.
+
+BEGIN;
+
+ALTER TABLE org_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE org_members FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS org_members_tenant_isolation ON org_members;
+CREATE POLICY org_members_tenant_isolation ON org_members
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sessions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS sessions_tenant_isolation ON sessions;
+CREATE POLICY sessions_tenant_isolation ON sessions
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatars ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatars FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatars_tenant_isolation ON avatars;
+CREATE POLICY avatars_tenant_isolation ON avatars
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE harness_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE harness_runs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS harness_runs_tenant_isolation ON harness_runs;
+CREATE POLICY harness_runs_tenant_isolation ON harness_runs
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE harness_steps ENABLE ROW LEVEL SECURITY;
+ALTER TABLE harness_steps FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS harness_steps_tenant_isolation ON harness_steps;
+CREATE POLICY harness_steps_tenant_isolation ON harness_steps
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_capability_grants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_capability_grants FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_capability_grants_tenant_isolation ON avatar_capability_grants;
+CREATE POLICY avatar_capability_grants_tenant_isolation ON avatar_capability_grants
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE harness_context_packs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE harness_context_packs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS harness_context_packs_tenant_isolation ON harness_context_packs;
+CREATE POLICY harness_context_packs_tenant_isolation ON harness_context_packs
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE capability_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE capability_runs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS capability_runs_tenant_isolation ON capability_runs;
+CREATE POLICY capability_runs_tenant_isolation ON capability_runs
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE capability_artifacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE capability_artifacts FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS capability_artifacts_tenant_isolation ON capability_artifacts;
+CREATE POLICY capability_artifacts_tenant_isolation ON capability_artifacts
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE artifact_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE artifact_versions FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS artifact_versions_tenant_isolation ON artifact_versions;
+CREATE POLICY artifact_versions_tenant_isolation ON artifact_versions
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE artifact_ripple_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE artifact_ripple_links FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS artifact_ripple_links_tenant_isolation ON artifact_ripple_links;
+CREATE POLICY artifact_ripple_links_tenant_isolation ON artifact_ripple_links
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_souls ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_souls FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_souls_tenant_isolation ON avatar_souls;
+CREATE POLICY avatar_souls_tenant_isolation ON avatar_souls
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_memory_edges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_memory_edges FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_memory_edges_tenant_isolation ON avatar_memory_edges;
+CREATE POLICY avatar_memory_edges_tenant_isolation ON avatar_memory_edges
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_instinct_frames ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_instinct_frames FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_instinct_frames_tenant_isolation ON avatar_instinct_frames;
+CREATE POLICY avatar_instinct_frames_tenant_isolation ON avatar_instinct_frames
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_presence_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_presence_states FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_presence_states_tenant_isolation ON avatar_presence_states;
+CREATE POLICY avatar_presence_states_tenant_isolation ON avatar_presence_states
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_debate_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_debate_events FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_debate_events_tenant_isolation ON avatar_debate_events;
+CREATE POLICY avatar_debate_events_tenant_isolation ON avatar_debate_events
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_artifact_trails ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_artifact_trails FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_artifact_trails_tenant_isolation ON avatar_artifact_trails;
+CREATE POLICY avatar_artifact_trails_tenant_isolation ON avatar_artifact_trails
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE council_orchestration_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE council_orchestration_runs FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS council_orchestration_runs_tenant_isolation ON council_orchestration_runs;
+CREATE POLICY council_orchestration_runs_tenant_isolation ON council_orchestration_runs
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE council_avatar_turns ENABLE ROW LEVEL SECURITY;
+ALTER TABLE council_avatar_turns FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS council_avatar_turns_tenant_isolation ON council_avatar_turns;
+CREATE POLICY council_avatar_turns_tenant_isolation ON council_avatar_turns
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_identity_states ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_identity_states FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_identity_states_tenant_isolation ON avatar_identity_states;
+CREATE POLICY avatar_identity_states_tenant_isolation ON avatar_identity_states
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+ALTER TABLE avatar_experience_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE avatar_experience_log FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS avatar_experience_log_tenant_isolation ON avatar_experience_log;
+CREATE POLICY avatar_experience_log_tenant_isolation ON avatar_experience_log
+    USING (org_id = app.current_org_id())
+    WITH CHECK (org_id = app.current_org_id());
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add transaction-scoped tenant setup through TenantDbPool::begin_for_tenant
- enable and force RLS policies for remaining org-scoped tables
- add migration validation so future org_id tables must enable RLS
- update SECURITY.md tenant isolation guidance

## Checks
- pnpm format
- pnpm typecheck
- pnpm route-parity:check
- pnpm contracts:check
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test -p raptorflow-db --lib validation::tests::org_scoped_tables_enable_rls_in_migrations

## Notes
- Runtime DB smoke was not run locally; this branch relies on CI service-container coverage for database-backed checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented enhanced database-level security policies to improve data isolation and access controls.
  * Improved transaction-level security enforcement for consistent policy application throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->