### PR TITLE
ci: align deploy reality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Check compilation
         run: cargo check --workspace --all-targets
 
+      - name: Compile Bedrock smoke test
+        run: cargo test -p raptorflow-aws --test bedrock_smoke --no-run
+
       - name: Clippy lint
         run: cargo clippy --workspace --all-targets
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -50,5 +50,18 @@ jobs:
             exit 1
           fi
           echo "Migration completed successfully"
-      - name: Trigger rolling update
-        run: aws ecs update-service --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" --task-definition "${{ steps.render-task-def.outputs.new-task-def-arn }}" --force-new-deployment
+      - name: Deploy and wait for service stability
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
+            --task-definition "${{ steps.render-task-def.outputs.new-task-def-arn }}" \
+            --force-new-deployment
+
+          echo "Waiting for $ECS_SERVICE in $ECS_CLUSTER to become stable..."
+          aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE"
+          aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].deployments[].{status:status,rolloutState:rolloutState,taskDefinition:taskDefinition,desired:desiredCount,running:runningCount,pending:pendingCount}' \
+            --output table

--- a/.github/workflows/runtime-reality.yml
+++ b/.github/workflows/runtime-reality.yml
@@ -87,6 +87,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ secrets.RAPTORFLOW_BEDROCK_REGION || secrets.AWS_REGION }}
+          RAPTORFLOW_BEDROCK_REGION: ${{ secrets.RAPTORFLOW_BEDROCK_REGION || secrets.AWS_REGION }}
+          RAPTORFLOW_BEDROCK_MODEL_FAST: ${{ secrets.RAPTORFLOW_BEDROCK_MODEL_FAST }}
           BEDROCK_SMOKE_TEST: "1"
         run: cargo test -p raptorflow-aws --test bedrock_smoke -- --nocapture --test-threads=1

--- a/infra/tofu/environments/prod/main.tf
+++ b/infra/tofu/environments/prod/main.tf
@@ -1,15 +1,81 @@
-module "stack" {
-  source = "../dev"
-
-  aws_region              = var.aws_region
-  name                    = var.name
-  allowed_cidr            = var.allowed_cidr
-  github_oidc_thumbprints  = var.github_oidc_thumbprints
-  certificate_arn         = var.certificate_arn
-  image_uri               = var.image_uri
-  qdrant_image_uri        = var.qdrant_image_uri
-  vector_node_ami_id        = var.vector_node_ami_id
-  execution_role_arn      = var.execution_role_arn
-  task_role_arn           = var.task_role_arn
+locals {
+  tags = {
+    project     = "raptorflow"
+    environment = "prod"
+    managed_by  = "tofu"
+  }
 }
 
+module "network" {
+  source                = "../../modules/network"
+  name                  = var.name
+  vpc_cidr              = "10.40.0.0/16"
+  availability_zones    = ["ap-south-1a", "ap-south-1b", "ap-south-1c"]
+  public_subnet_cidrs   = ["10.40.0.0/24", "10.40.1.0/24", "10.40.2.0/24"]
+  private_subnet_cidrs  = ["10.40.10.0/24", "10.40.11.0/24", "10.40.12.0/24"]
+  database_subnet_cidrs = ["10.40.20.0/24", "10.40.21.0/24", "10.40.22.0/24"]
+  tags                  = local.tags
+}
+
+module "security" {
+  source                  = "../../modules/security"
+  name                    = var.name
+  vpc_id                  = module.network.vpc_id
+  allowed_cidr            = var.allowed_cidr
+  github_org              = "RHUDHRESH"
+  github_repo             = "Raptorflow"
+  github_oidc_thumbprints = var.github_oidc_thumbprints
+  tags                    = local.tags
+}
+
+module "data" {
+  source                   = "../../modules/data"
+  name                     = var.name
+  private_subnet_ids       = module.network.private_subnet_ids
+  database_subnet_ids      = module.network.database_subnet_ids
+  db_security_group_id     = module.security.db_security_group_id
+  vector_security_group_id = module.security.vector_security_group_id
+  qdrant_security_group_id = module.security.qdrant_security_group_id
+  db_name                  = "raptorflow"
+  db_username              = "raptorflow"
+  vector_node_ami_id       = var.vector_node_ami_id
+  tags                     = local.tags
+}
+
+module "compute" {
+  source                     = "../../modules/compute"
+  name                       = var.name
+  aws_region                 = var.aws_region
+  public_subnet_ids          = module.network.public_subnet_ids
+  private_subnet_ids         = module.network.private_subnet_ids
+  alb_security_group_id      = module.security.alb_security_group_id
+  api_security_group_id      = module.security.api_security_group_id
+  qdrant_security_group_id   = module.security.qdrant_security_group_id
+  certificate_arn            = var.certificate_arn
+  image_uri                  = var.image_uri
+  qdrant_image_uri           = var.qdrant_image_uri
+  qdrant_efs_id              = module.data.qdrant_efs_id
+  database_app_secret_arn    = module.security.database_app_secret_arn
+  database_direct_secret_arn = module.security.database_direct_secret_arn
+  clerk_jwt_secret_arn       = module.security.clerk_jwt_secret_arn
+  bedrock_api_key_secret_arn = module.security.bedrock_api_key_secret_arn
+  razorpay_api_secret_arn    = module.security.razorpay_api_secret_arn
+  resend_api_key_secret_arn  = module.security.resend_api_key_secret_arn
+  execution_role_arn         = var.execution_role_arn
+  task_role_arn              = var.task_role_arn
+  tags                       = local.tags
+}
+
+module "observability" {
+  source                 = "../../modules/observability"
+  name                   = var.name
+  cluster_name           = module.compute.cluster_name
+  load_balancer_dns_name = module.compute.load_balancer_dns_name
+  tags                   = local.tags
+}
+
+module "vercel" {
+  source         = "../../modules/vercel"
+  project_name   = "raptorflow-web-prod"
+  root_directory = "apps/web"
+}

--- a/infra/tofu/environments/staging/main.tf
+++ b/infra/tofu/environments/staging/main.tf
@@ -1,15 +1,81 @@
-module "stack" {
-  source = "../dev"
-
-  aws_region              = var.aws_region
-  name                    = var.name
-  allowed_cidr            = var.allowed_cidr
-  github_oidc_thumbprints  = var.github_oidc_thumbprints
-  certificate_arn         = var.certificate_arn
-  image_uri               = var.image_uri
-  qdrant_image_uri        = var.qdrant_image_uri
-  vector_node_ami_id        = var.vector_node_ami_id
-  execution_role_arn      = var.execution_role_arn
-  task_role_arn           = var.task_role_arn
+locals {
+  tags = {
+    project     = "raptorflow"
+    environment = "staging"
+    managed_by  = "tofu"
+  }
 }
 
+module "network" {
+  source                = "../../modules/network"
+  name                  = var.name
+  vpc_cidr              = "10.30.0.0/16"
+  availability_zones    = ["ap-south-1a", "ap-south-1b", "ap-south-1c"]
+  public_subnet_cidrs   = ["10.30.0.0/24", "10.30.1.0/24", "10.30.2.0/24"]
+  private_subnet_cidrs  = ["10.30.10.0/24", "10.30.11.0/24", "10.30.12.0/24"]
+  database_subnet_cidrs = ["10.30.20.0/24", "10.30.21.0/24", "10.30.22.0/24"]
+  tags                  = local.tags
+}
+
+module "security" {
+  source                  = "../../modules/security"
+  name                    = var.name
+  vpc_id                  = module.network.vpc_id
+  allowed_cidr            = var.allowed_cidr
+  github_org              = "RHUDHRESH"
+  github_repo             = "Raptorflow"
+  github_oidc_thumbprints = var.github_oidc_thumbprints
+  tags                    = local.tags
+}
+
+module "data" {
+  source                   = "../../modules/data"
+  name                     = var.name
+  private_subnet_ids       = module.network.private_subnet_ids
+  database_subnet_ids      = module.network.database_subnet_ids
+  db_security_group_id     = module.security.db_security_group_id
+  vector_security_group_id = module.security.vector_security_group_id
+  qdrant_security_group_id = module.security.qdrant_security_group_id
+  db_name                  = "raptorflow"
+  db_username              = "raptorflow"
+  vector_node_ami_id       = var.vector_node_ami_id
+  tags                     = local.tags
+}
+
+module "compute" {
+  source                     = "../../modules/compute"
+  name                       = var.name
+  aws_region                 = var.aws_region
+  public_subnet_ids          = module.network.public_subnet_ids
+  private_subnet_ids         = module.network.private_subnet_ids
+  alb_security_group_id      = module.security.alb_security_group_id
+  api_security_group_id      = module.security.api_security_group_id
+  qdrant_security_group_id   = module.security.qdrant_security_group_id
+  certificate_arn            = var.certificate_arn
+  image_uri                  = var.image_uri
+  qdrant_image_uri           = var.qdrant_image_uri
+  qdrant_efs_id              = module.data.qdrant_efs_id
+  database_app_secret_arn    = module.security.database_app_secret_arn
+  database_direct_secret_arn = module.security.database_direct_secret_arn
+  clerk_jwt_secret_arn       = module.security.clerk_jwt_secret_arn
+  bedrock_api_key_secret_arn = module.security.bedrock_api_key_secret_arn
+  razorpay_api_secret_arn    = module.security.razorpay_api_secret_arn
+  resend_api_key_secret_arn  = module.security.resend_api_key_secret_arn
+  execution_role_arn         = var.execution_role_arn
+  task_role_arn              = var.task_role_arn
+  tags                       = local.tags
+}
+
+module "observability" {
+  source                 = "../../modules/observability"
+  name                   = var.name
+  cluster_name           = module.compute.cluster_name
+  load_balancer_dns_name = module.compute.load_balancer_dns_name
+  tags                   = local.tags
+}
+
+module "vercel" {
+  source         = "../../modules/vercel"
+  project_name   = "raptorflow-web-staging"
+  root_directory = "apps/web"
+}


### PR DESCRIPTION
## Summary
- compile the Bedrock smoke test explicitly in CI without running live AWS calls
- wire the manual Bedrock smoke workflow to the app-specific Bedrock region/model secrets
- wait for ECS service stability after backend deploy updates
- replace staging/prod Tofu references to ../dev with explicit environment stacks

## Checks
- pnpm format
- pnpm typecheck
- pnpm route-parity:check
- pnpm contracts:check
- pnpm structural:check
- cargo fmt --all -- --check
- cargo check --workspace
- cargo check -p raptorflow-aws --test bedrock_smoke

## Local notes
- cargo test -p raptorflow-aws --test bedrock_smoke --no-run was attempted locally, but Windows/MSVC linking failed inside aws-lc-sys native symbols. The new CI gate runs that no-run compile on Ubuntu, which avoids this local toolchain issue.
- tofu/terraform are not installed locally, so HCL native validate/fmt was not run.